### PR TITLE
de: Update whole translation to current version

### DIFF
--- a/de/kicad.po
+++ b/de/kicad.po
@@ -3,16 +3,17 @@ msgstr ""
 "Project-Id-Version: kicad\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2015-03-07 18:22+0100\n"
-"PO-Revision-Date: 2015-03-08 10:25+0100\n"
-"Last-Translator: \n"
-"Language-Team: Benno Achermann <bennoachermann@bluewin.ch>\n"
-"Language: de_CH\n"
+"PO-Revision-Date: 2015-12-13 20:50+0100\n"
+"Last-Translator: Carsten Schoenert <c.schoenert@t-online.de>\n"
+"Language-Team: \n"
+"Language: de_DE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Poedit-Basepath: /mnt/kicad\n"
 "X-Poedit-KeywordsList: _\n"
-"X-Generator: Poedit 1.5.4\n"
+"X-Generator: Poedit 1.8.6\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Poedit-SearchPath-0: 3d-viewer\n"
 "X-Poedit-SearchPath-1: common\n"
 "X-Poedit-SearchPath-2: cvpcb\n"
@@ -55,18 +56,17 @@ msgstr "Rückansicht"
 
 #: 3d-viewer/3d_canvas.cpp:384
 msgid "Move left <-"
-msgstr "Nach links bewegen"
+msgstr "Nach links bewegen <-"
 
 #: 3d-viewer/3d_canvas.cpp:388
 msgid "Move right ->"
-msgstr "Nach rechts bewegen"
+msgstr "Nach rechts bewegen ->"
 
 #: 3d-viewer/3d_canvas.cpp:392
 msgid "Move Up ^"
-msgstr "Nach oben bewegen"
+msgstr "Nach oben bewegen ^"
 
-#: 3d-viewer/3d_canvas.cpp:396
-#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:47
+#: 3d-viewer/3d_canvas.cpp:396 cvpcb/dialogs/dialog_config_equfiles_base.cpp:47
 #: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:151
 #: pcbnew/dialogs/dialog_fp_plugin_options_base.cpp:72
 msgid "Move Down"
@@ -96,28 +96,25 @@ msgstr "Kopiere 3D Grafik in die Zwischenablage"
 msgid "Set display options, and some layers visibility"
 msgstr "Stelle Anzeigeoptionen ein und die Sichtbarkeit einiger Lagen."
 
-#: 3d-viewer/3d_toolbar.cpp:72 common/zoom.cpp:231
-#: eeschema/tool_viewlib.cpp:75 pcbnew/footprint_wizard_frame.cpp:596
-#: pcbnew/tool_modedit.cpp:123 pcbnew/tool_modview.cpp:79
-#: gerbview/toolbars_gerber.cpp:77 eeschema/help_common_strings.h:43
-#: pcbnew/help_common_strings.h:19
+#: 3d-viewer/3d_toolbar.cpp:72 common/zoom.cpp:231 eeschema/tool_viewlib.cpp:75
+#: pcbnew/footprint_wizard_frame.cpp:596 pcbnew/tool_modedit.cpp:123
+#: pcbnew/tool_modview.cpp:79 gerbview/toolbars_gerber.cpp:77
+#: eeschema/help_common_strings.h:43 pcbnew/help_common_strings.h:19
 msgid "Zoom in"
-msgstr "Hineinzoomen "
+msgstr "Hinein zoomen"
 
-#: 3d-viewer/3d_toolbar.cpp:75 common/zoom.cpp:233
-#: eeschema/tool_viewlib.cpp:80 pcbnew/footprint_wizard_frame.cpp:601
-#: pcbnew/tool_modedit.cpp:126 pcbnew/tool_modview.cpp:84
-#: gerbview/toolbars_gerber.cpp:80 eeschema/help_common_strings.h:44
-#: pcbnew/help_common_strings.h:20
+#: 3d-viewer/3d_toolbar.cpp:75 common/zoom.cpp:233 eeschema/tool_viewlib.cpp:80
+#: pcbnew/footprint_wizard_frame.cpp:601 pcbnew/tool_modedit.cpp:126
+#: pcbnew/tool_modview.cpp:84 gerbview/toolbars_gerber.cpp:80
+#: eeschema/help_common_strings.h:44 pcbnew/help_common_strings.h:20
 msgid "Zoom out"
-msgstr "Herauszoomen "
+msgstr "Heraus zoomen"
 
-#: 3d-viewer/3d_toolbar.cpp:79 common/zoom.cpp:235
-#: eeschema/tool_viewlib.cpp:85 pcbnew/footprint_wizard_frame.cpp:606
-#: pcbnew/tool_modedit.cpp:129 pcbnew/tool_modview.cpp:89
-#: gerbview/toolbars_gerber.cpp:83
+#: 3d-viewer/3d_toolbar.cpp:79 common/zoom.cpp:235 eeschema/tool_viewlib.cpp:85
+#: pcbnew/footprint_wizard_frame.cpp:606 pcbnew/tool_modedit.cpp:129
+#: pcbnew/tool_modview.cpp:89 gerbview/toolbars_gerber.cpp:83
 msgid "Redraw view"
-msgstr "Aktualisieren"
+msgstr "Ansicht aktualisieren"
 
 #: 3d-viewer/3d_toolbar.cpp:82
 msgid "Fit in page"
@@ -213,6 +210,8 @@ msgid ""
 "Holes inside a copper layer copper zones are shown, but the calculation time "
 "is longer"
 msgstr ""
+"Bohrungen innerhalb einer Kupferlage, einer Kupferzone werden gezeigt, "
+"jedoch dauert die Kalkulation länger."
 
 #: 3d-viewer/3d_toolbar.cpp:174
 msgid "Render Textures"
@@ -221,10 +220,12 @@ msgstr "Render Texturen"
 #: 3d-viewer/3d_toolbar.cpp:175
 msgid "Apply a grid/cloud textures to Board, Solder Mask and Silkscreen"
 msgstr ""
+"Anwenden einer Raster-/Cloud Texture auf ein Board, Lötstop- und "
+"Siebdruckmaske"
 
 #: 3d-viewer/3d_toolbar.cpp:179
 msgid "Render Smooth Normals"
-msgstr ""
+msgstr "Render glatte Normals"
 
 #: 3d-viewer/3d_toolbar.cpp:183
 msgid "Render Material Properties"
@@ -300,11 +301,11 @@ msgstr "&Siebdrucklagen einblenden"
 
 #: 3d-viewer/3d_toolbar.cpp:251
 msgid "Show Solder &Mask Layers"
-msgstr "Lagen mit Lötstopp&maske einblenden"
+msgstr "Lagen mit Lötstop&maske einblenden"
 
 #: 3d-viewer/3d_toolbar.cpp:254
 msgid "Show Solder &Paste Layers"
-msgstr "Lagen mit Lötstopp&paste einblenden"
+msgstr "Lagen mit Lötstop&paste einblenden"
 
 #: 3d-viewer/3d_toolbar.cpp:257
 msgid "Show &Comments and Drawings Layer"
@@ -340,11 +341,11 @@ msgstr "Siebdrucklagen einblenden"
 
 #: 3d-viewer/dialogs/dialog_3D_view_option_base.cpp:54
 msgid "Show solder mask layers"
-msgstr "Lagen mit Lötstoppmaske einblenden"
+msgstr "Lagen mit Lötstopmaske einblenden"
 
 #: 3d-viewer/dialogs/dialog_3D_view_option_base.cpp:60
 msgid "Show solder paste layers"
-msgstr "Lagen mit Lötstopppaste einblenden"
+msgstr "Lagen mit Lötstoppaste einblenden"
 
 #: 3d-viewer/dialogs/dialog_3D_view_option_base.cpp:66
 msgid "Show adhesive layers"
@@ -366,6 +367,7 @@ msgstr "Alle Lagen einblenden"
 msgid "Show None"
 msgstr "Zeige nichts"
 
+# No translation needed
 #: common/eda_text.cpp:376 eeschema/libedit.cpp:498
 #: eeschema/onrightclick.cpp:380 eeschema/sch_text.cpp:761
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:92
@@ -384,7 +386,7 @@ msgstr "Zeige nichts"
 #: gerbview/class_GERBER.cpp:359 gerbview/class_GERBER.cpp:363
 #: gerbview/class_GERBER.cpp:366
 msgid "Normal"
-msgstr "Normal"
+msgstr ""
 
 #: common/eda_text.cpp:377 eeschema/sch_text.cpp:761
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:92
@@ -408,8 +410,7 @@ msgstr "Fett"
 msgid "Bold+Italic"
 msgstr "Fett+Kursiv"
 
-#: common/eda_doc.cpp:144
-#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:448
+#: common/eda_doc.cpp:144 eeschema/dialogs/dialog_edit_component_in_lib.cpp:448
 msgid "Doc Files"
 msgstr "Doc Dateien"
 
@@ -430,12 +431,12 @@ msgstr "Benutzerdef. Raster"
 #: common/base_screen.cpp:194
 #, c-format
 msgid "Grid: %.4f mm (%.2f mils)"
-msgstr ""
+msgstr "Raster: %.4f mm (%.2f mils)"
 
 #: common/base_screen.cpp:197
 #, c-format
 msgid "Grid: %.2f mils (%.4f mm)"
-msgstr ""
+msgstr "Raster: %.2f mils (%.4f mm)"
 
 #: common/footprint_info.cpp:315 common/footprint_info.cpp:336
 msgid "Errors were encountered loading footprints"
@@ -443,7 +444,7 @@ msgstr "Beim Laden der Footprints sind Fehler aufgetreten."
 
 #: common/footprint_info.cpp:334
 msgid "Load Error"
-msgstr "Fehler"
+msgstr "Fehler beim Laden"
 
 #: common/fpid.cpp:182 common/fpid.cpp:199
 msgid "Illegal character found in FPID string"
@@ -461,7 +462,7 @@ msgstr "Unzulässiges Zeichen in der Revision gefunden."
 #, c-format
 msgid "'%s' is a duplicate footprint library nickName"
 msgstr ""
-"<%s> ist ein doppelt vorkommender Nickname einer Footprint Bibliotheksdatei."
+"'%s' ist ein doppelt vorkommender Nickname einer Footprint Bibliotheksdatei."
 
 #: common/fp_lib_table.cpp:620
 #, c-format
@@ -475,35 +476,39 @@ msgstr ""
 "Der Pfad '%s' für die globale Bibliothekstabelle konnte nicht erstellen "
 "werden."
 
+# No translation needed
 #: common/class_marker_base.cpp:200
 msgid "Marker Info"
-msgstr "Marker Info"
+msgstr ""
 
+# No translation needed
 #: common/base_units.cpp:160
 msgid " mils"
-msgstr " mils"
+msgstr ""
 
+# No translation needed
 #: common/base_units.cpp:160
 msgid " in"
-msgstr " in"
+msgstr ""
 
+# No translation needed
 #: common/base_units.cpp:162 common/base_units.cpp:249
 msgid " mm"
-msgstr " mm"
+msgstr ""
 
+# No translation needed
 #: common/base_units.cpp:245
 msgid " \""
-msgstr " \""
+msgstr ""
 
 #: common/base_units.cpp:253
-#, fuzzy
 msgid " deg"
-msgstr "0.1 Grad"
+msgstr " Grad"
 
 #: common/richio.cpp:192
 #, c-format
 msgid "Unable to open filename '%s' for reading"
-msgstr "Konnte Datei <%s> nicht öffnen"
+msgstr "Konnte Datei '%s' nicht zum Lesen öffnen."
 
 #: common/richio.cpp:236 common/richio.cpp:333
 msgid "Maximum line length exceeded"
@@ -516,12 +521,12 @@ msgstr "Linienlänge überschritten"
 #: common/richio.cpp:554
 #, c-format
 msgid "cannot open or save file '%s'"
-msgstr "Konnte Datei <%s> nicht öffnen oder speichern"
+msgstr "Konnte Datei '%s' nicht öffnen oder speichern."
 
 #: common/richio.cpp:573 pcbnew/legacy_plugin.cpp:3229
 #, c-format
 msgid "error writing to file '%s'"
-msgstr "Ein Fehler ist beim Schreiben von Datei <%s> aufgetreten."
+msgstr "Ein Fehler ist beim Schreiben von Datei '%s' aufgetreten."
 
 #: common/richio.cpp:594
 msgid "OUTPUTSTREAM_OUTPUTFORMATTER write error"
@@ -530,21 +535,24 @@ msgstr "OUTPUTSTREAM_OUTPUTFORMATTER Schreibfehler"
 #: common/wxwineda.cpp:61
 #, c-format
 msgid "Size%s"
-msgstr "Grösse: %s"
+msgstr "Größe: %s"
 
+# No translation needed
 #: common/wxwineda.cpp:166 common/wxwineda.cpp:180
 msgid "Pos "
-msgstr "Pos "
+msgstr ""
 
+# No translation needed
 #: common/wxwineda.cpp:170
 #: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:90
 msgid "X"
-msgstr "X"
+msgstr ""
 
+# No translation needed
 #: common/wxwineda.cpp:183
 #: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:102
 msgid "Y"
-msgstr "Y"
+msgstr ""
 
 #: common/pgm_base.cpp:107
 #: pcbnew/dialogs/dialog_global_edit_tracks_and_vias.cpp:102
@@ -669,7 +677,7 @@ msgstr "KiCad Zeichensymboldateien (*.sym)|*.sym"
 
 #: common/wildcards_and_files_ext.cpp:69
 msgid "KiCad component library file (*.lib)|*.lib"
-msgstr "KiCad Bauteilebibliotheksdateien (*.lib)|*.lib"
+msgstr "KiCad Bauteilbibliotheksdatei (*.lib)|*.lib"
 
 #: common/wildcards_and_files_ext.cpp:70
 msgid "KiCad project files (*.pro)|*.pro"
@@ -704,9 +712,8 @@ msgid "KiCad s-expr printed circuit board files (*.kicad_pcb)|*.kicad_pcb"
 msgstr "KiCad s-expr Dateien gedruckter Schaltungen (*.kicad_pcb)|*.kicad_pcb"
 
 #: common/wildcards_and_files_ext.cpp:78
-#, fuzzy
 msgid "KiCad footprint s-expre file (*.kicad_mod)|*.kicad_mod"
-msgstr "KiCad Footprint S-Expre Bibliotheksdateien (*.kicad_mod)|*.kicad_mod"
+msgstr "KiCad Footprint S-Expre Dateien (*.kicad_mod)|*.kicad_mod"
 
 #: common/wildcards_and_files_ext.cpp:79
 msgid "KiCad footprint s-expre library path (*.pretty)|*.pretty"
@@ -754,7 +761,7 @@ msgstr "SVG Dateien (*.svg)|*.svg;*.SVG"
 
 #: common/wildcards_and_files_ext.cpp:95
 msgid "Portable document format files (*.pdf)|*.pdf"
-msgstr "Portable document format Dateien (*.pdf)|*.pdf"
+msgstr "Portables Dokumenten Format Dateien (*.pdf)|*.pdf"
 
 #: common/wildcards_and_files_ext.cpp:96
 msgid "PostScript files (.ps)|*.ps"
@@ -766,7 +773,7 @@ msgstr "Protokolldateien (*.rpt)|*.rpt"
 
 #: common/wildcards_and_files_ext.cpp:98
 msgid "Footprint place files (*.pos)|*.pos"
-msgstr "Footprintplatzierungsdateien (*.pos)|*.pos"
+msgstr "Footprint Platzierungsdateien (*.pos)|*.pos"
 
 #: common/wildcards_and_files_ext.cpp:99
 msgid "Vrml and x3d files (*.wrl *.x3d)|*.wrl;*.x3d"
@@ -785,20 +792,27 @@ msgid ""
 "The program cannot be closed\n"
 "A quasi-modal dialog window is currently open, please close it first."
 msgstr ""
+"Das Programm kann nicht geschlossen werden,\n"
+"ein quasi-modal Dialog Fenster ist noch geöffnet, bitte dieses zuerst "
+"schließen."
 
 #: common/basicframe.cpp:421
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "Html or pdf help file \n"
 "'%s'\n"
 " or\n"
 "'%s' could not be found."
-msgstr "Die Hilfedatei '%s' wurde nicht gefunden."
+msgstr ""
+"Die HTML oder PDF Hilfsdatei '\n"
+"'%s'\n"
+"oder\n"
+"'%s' wurde nicht gefunden."
 
 #: common/basicframe.cpp:438
 #, c-format
 msgid "Help file '%s' could not be found."
-msgstr "Die Hilfedatei '%s' wurde nicht gefunden."
+msgstr "Die Hilfsdatei '%s' wurde nicht gefunden."
 
 #: common/basicframe.cpp:459
 #, c-format
@@ -826,7 +840,7 @@ msgstr ""
 
 #: common/basicframe.cpp:565
 msgid "Clipboard Error"
-msgstr "Fehler bei Zugriff auf Zwischenablage"
+msgstr "Fehler beim Zugriff auf Zwischenablage"
 
 #: common/basicframe.cpp:642
 msgid "Version Information (copied to the clipboard)"
@@ -890,6 +904,7 @@ msgstr "Raster ausblenden"
 msgid "Show grid"
 msgstr "Raster einblenden"
 
+# No translation needed
 #: common/draw_frame.cpp:504 common/common.cpp:144 common/common.cpp:202
 #: common/dialogs/dialog_page_settings.cpp:458
 #: eeschema/dialogs/dialog_lib_edit_draw_item_base.cpp:45
@@ -904,7 +919,7 @@ msgstr "Raster einblenden"
 #: pcbnew/dialogs/dialog_create_array_base.cpp:191
 #: pcbnew/dialogs/dialog_create_array_base.cpp:202
 msgid "mm"
-msgstr "mm"
+msgstr ""
 
 #: common/draw_frame.cpp:508 pcbnew/footprint_wizard_frame.cpp:171
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:35
@@ -914,9 +929,10 @@ msgstr "mm"
 msgid "Units"
 msgstr "Einheit"
 
+# No translation needed
 #: common/common.cpp:140
 msgid "\""
-msgstr "\""
+msgstr ""
 
 #: common/common.cpp:171 common/dialogs/dialog_page_settings.cpp:458
 msgid "inches"
@@ -937,9 +953,10 @@ msgstr "Millimeter"
 msgid "units"
 msgstr "Einheiten"
 
+# No translation needed
 #: common/common.cpp:198
 msgid "in"
-msgstr "in"
+msgstr ""
 
 #: common/common.cpp:209 pcbnew/dialogs/dialog_pad_properties_base.cpp:141
 #: pcbnew/dialogs/dialog_move_exact_base.cpp:63
@@ -951,7 +968,7 @@ msgstr "Grad"
 #, c-format
 msgid "*** Error: cannot make path '%s' absolute with respect to '%s'! ***"
 msgstr ""
-"*** Fehler: Kann den Pfad '%s' nicht absolut erstellen unter "
+"*** Fehler: Kann den absoluten Pfad '%s' nicht erstellen unter "
 "Berücksichtigung von '%s'! ***"
 
 #: common/common.cpp:447
@@ -984,9 +1001,10 @@ msgstr "Autozoom "
 msgid "Zoom select"
 msgstr "Zoomauswahl"
 
+# No translation needed
 #: common/zoom.cpp:256
 msgid "Zoom: "
-msgstr "Zoom:  "
+msgstr ""
 
 #: common/zoom.cpp:267
 msgid "Grid Select"
@@ -1010,7 +1028,7 @@ msgstr "Rasterauswahl"
 #: pcbnew/dialogs/dialog_print_using_printer_base.cpp:141
 #: gerbview/dialogs/dialog_print_using_printer_base.cpp:109
 msgid "Close"
-msgstr "Schliessen"
+msgstr "Schließen"
 
 #: common/confirm.cpp:75 eeschema/symbedit.cpp:111
 msgid "Warning"
@@ -1043,9 +1061,8 @@ msgid "Block Drag"
 msgstr "Gruppe ziehen"
 
 #: common/block_commande.cpp:76
-#, fuzzy
 msgid "Drag item"
-msgstr "Elektr. Verbindung ziehen"
+msgstr "Element ziehen"
 
 #: common/block_commande.cpp:80
 msgid "Block Copy"
@@ -1144,8 +1161,8 @@ msgstr "Farben"
 #: pcbnew/modedit_onclick.cpp:272 pcbnew/muonde.cpp:803
 #: pcbnew/onrightclick.cpp:85 pcbnew/onrightclick.cpp:101
 #: pcbnew/dialogs/dialog_global_pads_edition_base.cpp:55
-#: pcbnew/dialogs/dialog_design_rules_base.cpp:382
-#: gerbview/onrightclick.cpp:59 gerbview/onrightclick.cpp:81
+#: pcbnew/dialogs/dialog_design_rules_base.cpp:382 gerbview/onrightclick.cpp:59
+#: gerbview/onrightclick.cpp:81
 #: gerbview/dialogs/dialog_select_one_pcb_layer.cpp:182
 msgid "Cancel"
 msgstr "Abbrechen"
@@ -1166,9 +1183,7 @@ msgstr "Kopieren\tCTRL+C"
 
 #: common/grid_tricks.cpp:114
 msgid "Copy selected cells to clipboard"
-msgstr ""
-"Den Inhalt selektierter Zellen in die Zwischenablage kopieren und Zellinhalt "
-"belassen"
+msgstr "Den Inhalt selektierter Zellen in die Zwischenablage kopieren"
 
 #: common/grid_tricks.cpp:115
 msgid "Paste\tCTRL+V"
@@ -1177,7 +1192,7 @@ msgstr "Einfügen\tCTRL+V"
 #: common/grid_tricks.cpp:115
 msgid "Paste clipboard cells to matrix at current cell"
 msgstr ""
-"Den Inhalt der Zwischenablage ab der aktuellen Zellen in die Tabelle einfügen"
+"Den Inhalt der Zwischenablage ab der aktuellen Zelle in die Tabelle einfügen"
 
 #: common/grid_tricks.cpp:116
 msgid "Select All\tCTRL+A"
@@ -1218,7 +1233,7 @@ msgstr "Getrennte Zeichenkette ist nicht abgeschlossen"
 #: common/dsnlexer.cpp:715
 msgid "String delimiter must be a single character of ', \", or $"
 msgstr ""
-"Das Zeichenkettentrennsymbol muss eines der folgenden Zeichen sein, ', \", "
+"Das Zeichenketten Trennsymbol muss eines der folgenden Zeichen sein, ', \", "
 "oder $"
 
 #: common/gestfich.cpp:227
@@ -1241,9 +1256,9 @@ msgid "Unable to find a PDF viewer for <%s>"
 msgstr "Konnte für <%s> keinen PDF-Betrachter finden."
 
 #: common/project.cpp:236
-#, fuzzy, c-format
+#, c-format
 msgid "Unable to find '%s' template config file."
-msgstr "Konnte die Templatekonfigurationsdatei '%s' nicht finden."
+msgstr "Konnte die Template Konfigurationsdatei '%s' nicht finden."
 
 #: common/dialogs/dialog_exit_base.cpp:34
 msgid "Save the changes before closing?"
@@ -1276,24 +1291,27 @@ msgid ""
 "<%s> is already assigned to \"%s\" in section \"%s\". Are you sure you want "
 "to change its assignment?"
 msgstr ""
+"<%s ist bereits zu \"%s\" in Sektion \"%s\" zugewiesen. Sind Sie sicher "
+"diese Zuweisung ändern zu wollen?"
 
 #: common/dialogs/dialog_hotkeys_editor.cpp:379
-#, fuzzy
 msgid "Confirm change"
-msgstr "Bestätigung"
+msgstr "Änderung bestätigungen"
 
+# No translation needed
 #: common/dialogs/dialog_get_component_base.cpp:22
 #: eeschema/dialogs/dialog_bom_base.cpp:44
 #: eeschema/dialogs/dialog_netlist_base.cpp:115
 #: eeschema/dialogs/dialog_sch_edit_sheet_pin_base.cpp:28
 #: pcbnew/librairi.cpp:624
 msgid "Name:"
-msgstr "Name:"
+msgstr ""
 
 #: common/dialogs/dialog_get_component_base.cpp:30
 msgid "History list:"
 msgstr "Historie:"
 
+# No translation needed
 #: common/dialogs/dialog_get_component_base.cpp:45
 #: common/dialogs/dialog_hotkeys_editor_base.cpp:30
 #: common/dialog_about/dialog_about_base.cpp:68
@@ -1304,7 +1322,7 @@ msgstr "Historie:"
 #: pcbnew/dialogs/dialog_orient_footprints_base.cpp:54
 #: gerbview/dialogs/dialog_select_one_pcb_layer.cpp:178
 msgid "OK"
-msgstr "OK"
+msgstr ""
 
 #: common/dialogs/dialog_get_component_base.cpp:49
 msgid "Search by Keyword"
@@ -1471,10 +1489,10 @@ msgid ""
 "%.1f - %.1f %s!\n"
 "Select another custom paper size?"
 msgstr ""
-"Benutzerdefinierte Seitengrösse befindet\n"
-"sich ausserhalb der zulässigen Grenzen\n"
+"Benutzerdefinierte Seitengröße befindet\n"
+"sich außerhalb der zulässigen Grenzen\n"
 "%.1f - %.1f %s!\n"
-"Möchten Sie eine andere Seitengrösse festlegen?"
+"Möchten Sie eine andere Seitengröße festlegen?"
 
 #: common/dialogs/dialog_page_settings.cpp:460
 msgid "Warning!"
@@ -1490,7 +1508,7 @@ msgid "Select Page Layout Descr File"
 msgstr "Dateiauswahl für Seitenlayoutbeschreibung"
 
 #: common/dialogs/dialog_page_settings.cpp:811
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "The page layout descr filename has changed.\n"
 "Do you want to use the relative path:\n"
@@ -1499,7 +1517,10 @@ msgid ""
 "'%s'"
 msgstr ""
 "Der Dateiname für die Seitenlayoutbeschreibung wurde geändert.\n"
-"Möchte Sie den folgenden relativen Pfad verwenden?%s"
+"Möchte Sie den folgenden relativen Pfad verwenden:\n"
+"'%s'\n"
+"statt\n"
+"'%s'"
 
 #: common/dialogs/dialog_page_settings_base.cpp:25
 msgid "Paper"
@@ -1507,7 +1528,7 @@ msgstr "Papier"
 
 #: common/dialogs/dialog_page_settings_base.cpp:32
 msgid "Size:"
-msgstr "Grösse:"
+msgstr "Größe:"
 
 #: common/dialogs/dialog_page_settings_base.cpp:36
 msgid "dummy text"
@@ -1521,7 +1542,7 @@ msgstr "Ausrichtung:"
 
 #: common/dialogs/dialog_page_settings_base.cpp:52
 msgid "Custom Size:"
-msgstr "Benutzerdefinierte Grösse:"
+msgstr "Benutzerdefinierte Größe:"
 
 #: common/dialogs/dialog_page_settings_base.cpp:62
 #: pcbnew/dialogs/dialog_global_modules_fields_edition_base.cpp:77
@@ -1580,9 +1601,10 @@ msgstr ""
 msgid "Export to other sheets"
 msgstr "In andere Schaltpläne exportieren"
 
+# No translation needed
 #: common/dialogs/dialog_page_settings_base.cpp:171
 msgid "Revision"
-msgstr "Revision"
+msgstr ""
 
 #: common/dialogs/dialog_page_settings_base.cpp:196
 msgid "Title"
@@ -1623,6 +1645,8 @@ msgstr "Durchsuchen"
 #: common/dialogs/dialog_hotkeys_editor_base.cpp:19
 msgid "Select a row and press a new key combination to alter the binding."
 msgstr ""
+"Wählen Sie eine Zeile aus, und drücken Sie eine neue Tastenkombination zum "
+"Ändern der Festlegung."
 
 #: common/dialogs/dialog_hotkeys_editor_base.cpp:36
 msgid "Undo"
@@ -1655,8 +1679,7 @@ msgid ""
 "electronic schematics and to design printed circuit boards."
 msgstr ""
 "Die KiCad EDA Suite besteht aus Open Source Anwendungen für das Erstellen "
-"von elektronischen Schaltungen und das Designen von  gedruckten "
-"Leiterplatten."
+"von elektronischen Schaltungen und das Designen von gedruckten Leiterplatten."
 
 #: common/dialog_about/AboutDialog_main.cpp:154
 msgid "KiCad on the web"
@@ -1680,7 +1703,7 @@ msgstr "Webseite mit zusätzlichen Bauteilebibliotheken"
 
 #: common/dialog_about/AboutDialog_main.cpp:176
 msgid "Contribute to KiCad"
-msgstr "Beteildige Dich an KiCad"
+msgstr "Beteilige Dich an KiCad"
 
 #: common/dialog_about/AboutDialog_main.cpp:182
 msgid "Report bugs if you found any"
@@ -1774,9 +1797,9 @@ msgid "Save Component Footprint Link File"
 msgstr "Speichern der Bauteile-Footprint Zuordnungsdatei"
 
 #: cvpcb/readwrite_dlgs.cpp:404
-#, fuzzy, c-format
+#, c-format
 msgid "Unable to create component footprint link file '%s'"
-msgstr "Konnte die Bauteile-Footprint Zuordnungsdatei (.cmp) nicht erstellen."
+msgstr "Konnte die Bauteile-Footprint Zuordnungsdatei '%s' nicht erstellen."
 
 #: cvpcb/readwrite_dlgs.cpp:409 eeschema/files-io.cpp:138
 #, c-format
@@ -1784,9 +1807,9 @@ msgid "File %s saved"
 msgstr "Datei %s gespeichert."
 
 #: cvpcb/cfg.cpp:79 cvpcb/dialogs/dialog_config_equfiles.cpp:52
-#, fuzzy, c-format
+#, c-format
 msgid "Project file: '%s'"
-msgstr "Projektdatei: <%s>"
+msgstr "Projektdatei: '%s'"
 
 #: cvpcb/cfg.cpp:84
 #, c-format
@@ -1794,9 +1817,8 @@ msgid "Project file '%s' is not writable"
 msgstr "Projektdatei '%s' ist nicht schreibbar."
 
 #: cvpcb/cvpcb.cpp:57
-#, fuzzy
 msgid "Component/footprint equ files (*.equ)|*.equ"
-msgstr "KiCad Footprintaliasdateien (*.equ)|*.equ"
+msgstr "Bauteil-/Footprintaliasdateien (*.equ)|*.equ"
 
 #: cvpcb/cvpcb.cpp:214 pcbnew/pcbnew.cpp:335
 #, c-format
@@ -1805,30 +1827,31 @@ msgid ""
 "\n"
 "%s"
 msgstr ""
-"Bei dem Versuch, die folgende globale Bibliothekstabelle für Footprints zu "
-"laden, ist ein Fehler aufgetreten.\n"
+"Bei dem Versuch die folgende globale Bibliothekstabelle für Footprints zu "
+"laden ist ein Fehler aufgetreten.\n"
 "\n"
 "%s"
 
 #: cvpcb/autosel.cpp:106
-#, fuzzy, c-format
+#, c-format
 msgid "Equ file '%s' could not be found in the default search paths."
 msgstr ""
 "Footprint Alias-Bibliotheksdatei '%s' konnte nicht in den voreingestellten "
 "Suchpfaden gefunden werden."
 
 #: cvpcb/autosel.cpp:127
-#, fuzzy, c-format
+#, c-format
 msgid "Error opening equ file '%s'."
-msgstr "Ein Fehler ist beim Schreiben von Datei <%s> aufgetreten."
+msgstr ""
+"Ein Fehler ist beim Öffnen der Footprint Alias-Bibliotheksdatei '%s' "
+"aufgetreten."
 
 #: cvpcb/autosel.cpp:179
-#, fuzzy
 msgid "Equ files Load Error"
-msgstr "Fehler beim Einlesen der Netzliste"
+msgstr "Fehler beim Einlesen der Footprint Alias-Bibliotheksdatei."
 
 #: cvpcb/autosel.cpp:187
-#, fuzzy, c-format
+#, c-format
 msgid "%d footprint/cmp equivalences found."
 msgstr "%d Footprint Alias gefunden."
 
@@ -1842,16 +1865,15 @@ msgstr ""
 "finden."
 
 #: cvpcb/autosel.cpp:287
-#, fuzzy
 msgid "CvPcb Warning"
-msgstr "Warnung"
+msgstr "CvPcb Warnung"
 
 #: cvpcb/cvframe.cpp:249
 msgid ""
 "Component to Footprint links modified.\n"
 "Save before exit ?"
 msgstr ""
-"Zuordnung von Footprints mit Bauteilen wurde verändert.\n"
+"Die Zuordnung von Footprints zu Bauteilen wurde verändert.\n"
 "Möchten Sie die Änderungen speichern?"
 
 #: cvpcb/cvframe.cpp:270
@@ -1880,7 +1902,7 @@ msgid ""
 "'%s'\n"
 "%s"
 msgstr ""
-"Bei dem Versuch, die globale Bibliothekstabelle für Footprints zu speichern, "
+"Bei dem Versuch die globale Bibliothekstabelle für Footprints zu speichern "
 "ist ein Fehler aufgetreten.\n"
 "'%s'\n"
 "%s"
@@ -1889,7 +1911,7 @@ msgstr ""
 #: pcbnew/moduleframe.cpp:894 pcbnew/pcbnew_config.cpp:136
 #: pcbnew/pcbnew_config.cpp:158
 msgid "File Save Error"
-msgstr "Fehler bei Dateischreibvorgang"
+msgstr "Fehler beim Dateischreibvorgang"
 
 #: cvpcb/cvframe.cpp:517
 #, c-format
@@ -1898,7 +1920,7 @@ msgid ""
 "'%s'\n"
 "%s"
 msgstr ""
-"Bei dem Versuch, die Projektbibliothek für Footprints zu speichern, ist ein "
+"Bei dem Versuch die Projektbibliothek für Footprints zu speichern ist ein "
 "Fehler aufgetreten.\n"
 "'%s'\n"
 "%s"
@@ -1937,15 +1959,15 @@ msgid "No filtering"
 msgstr "Ungefiltert"
 
 #: cvpcb/cvframe.cpp:715
-#, fuzzy, c-format
+#, c-format
 msgid "Filtered by %s"
-msgstr "Gefiltert nach "
+msgstr "Gefiltert nach %s"
 
 #: cvpcb/cvframe.cpp:731
 msgid ""
 "No PCB footprint libraries are listed in the current footprint library table."
 msgstr ""
-"Es sind keine PCB-Footprintbibliotheken in der gegewärtigen "
+"Es sind keine PCB-Footprintbibliotheken in der gegenwärtigen "
 "Footprintbibliothekstabelle aufgeführt."
 
 #: cvpcb/cvframe.cpp:732
@@ -1955,7 +1977,7 @@ msgstr "Konfigurationsfehler"
 #: cvpcb/cvframe.cpp:755
 #, c-format
 msgid "Project: '%s'  (netlist: '%s')"
-msgstr ""
+msgstr "Projekt: '%s' (Netzliste: '%s')"
 
 #: cvpcb/cvframe.cpp:761 eeschema/schframe.cpp:1225 eeschema/libedit.cpp:61
 #: kicad/prjconfig.cpp:277 pcbnew/pcbframe.cpp:955 pcbnew/moduleframe.cpp:780
@@ -1963,9 +1985,8 @@ msgid " [Read Only]"
 msgstr " [Nur lesbar]"
 
 #: cvpcb/cvframe.cpp:764
-#, fuzzy
 msgid "[no project]"
-msgstr "&Öffne Projekt"
+msgstr "[kein Projekt]"
 
 #: cvpcb/cvframe.cpp:821
 msgid "Unknown netlist format."
@@ -1983,7 +2004,7 @@ msgstr ""
 #: cvpcb/cvframe.cpp:826 pcbnew/netlist.cpp:93
 #: pcbnew/dialogs/dialog_netlist.cpp:433
 msgid "Netlist Load Error"
-msgstr "Fehler beim Einlesen der Netzliste"
+msgstr "Fehler beim Laden der Netzliste"
 
 #: cvpcb/menubar.cpp:72
 msgid "&Open Netlist"
@@ -1999,14 +2020,12 @@ msgid "Open recent netlist"
 msgstr "Zuletzt geöffnete Netzliste"
 
 #: cvpcb/menubar.cpp:98
-#, fuzzy
 msgid "&Save Cmp File\tCtrl+S"
-msgstr "&Speichern\tStrg+S"
+msgstr "&Speichern Bauteiledatei\tStrg+S"
 
 #: cvpcb/menubar.cpp:102
-#, fuzzy
 msgid "Save Cmp File &As...\tCtrl+Shift+S"
-msgstr "Speichern &unter...\tStrg+Shift+S"
+msgstr "Speichern Bauteiledatei &unter...\tStrg+Shift+S"
 
 #: cvpcb/menubar.cpp:109 eeschema/menubar_libedit.cpp:110
 #: eeschema/menubar.cpp:186 kicad/menubar.cpp:272
@@ -2028,15 +2047,16 @@ msgid "Setup footprint libraries"
 msgstr "Footprint Bibliothekseinstellungen"
 
 #: cvpcb/menubar.cpp:120
-#, fuzzy
 msgid "Edit &Equ Files List"
-msgstr "Plugindatei editieren"
+msgstr "Footprint Alias-Bibliotheksdatei &editieren"
 
 #: cvpcb/menubar.cpp:121
 msgid ""
 "Setup equ files list (.equ files)\n"
 "They are files which give the footprint name from the component value"
 msgstr ""
+"Footprint Alias-Bibliotheksdatei einrichten (.equ Dateien)\n"
+"Dies sind Dateien die den Footprint Namen aus dem Bauteilnamen bilden."
 
 #: cvpcb/menubar.cpp:130
 msgid "Keep Open On Save"
@@ -2056,11 +2076,11 @@ msgstr "Änderungen in Projektdatei speichern"
 
 #: cvpcb/menubar.cpp:150
 msgid "&CvPcb Manual"
-msgstr "Das &CvPcb-Benutzerhandbuch"
+msgstr "&CvPcb-Benutzerhandbuch"
 
 #: cvpcb/menubar.cpp:151
 msgid "Open CvPcb manual"
-msgstr "Das CvPcb-Benutzerhandbuch öffnen"
+msgstr "CvPcb-Benutzerhandbuch öffnen"
 
 #: cvpcb/menubar.cpp:156
 msgid "&About CvPcb"
@@ -2071,10 +2091,9 @@ msgid "About CvPcb footprint selector"
 msgstr "Über CvPcb Footprintselektor"
 
 #: cvpcb/menubar.cpp:163 eeschema/menubar_libedit.cpp:288
-#: eeschema/tool_viewlib.cpp:270 eeschema/menubar.cpp:513
-#: kicad/menubar.cpp:424 pcbnew/menubar_pcbframe.cpp:653
-#: pcbnew/tool_modview.cpp:211 pcbnew/menubar_modedit.cpp:330
-#: gerbview/menubar.cpp:239
+#: eeschema/tool_viewlib.cpp:270 eeschema/menubar.cpp:513 kicad/menubar.cpp:424
+#: pcbnew/menubar_pcbframe.cpp:653 pcbnew/tool_modview.cpp:211
+#: pcbnew/menubar_modedit.cpp:330 gerbview/menubar.cpp:239
 msgid "&Help"
 msgstr "&Hilfe"
 
@@ -2114,7 +2133,7 @@ msgstr "Texte durch Linien darstellen"
 
 #: cvpcb/class_DisplayFootprintsFrame.cpp:206
 msgid "Show outlines in line mode"
-msgstr "Silhouette durch Linien darstellen"
+msgstr "Konturen durch Linien darstellen"
 
 #: cvpcb/class_DisplayFootprintsFrame.cpp:221
 #: pcbnew/dialogs/dialog_display_options_base.h:72
@@ -2123,11 +2142,11 @@ msgstr "Anzeigeoptionen"
 
 #: cvpcb/class_DisplayFootprintsFrame.cpp:226
 msgid "Zoom in (F1)"
-msgstr "Hineinzoomen (F1)"
+msgstr "Hinein zoomen (F1)"
 
 #: cvpcb/class_DisplayFootprintsFrame.cpp:229
 msgid "Zoom out (F2)"
-msgstr "Herauszoomen (F2)"
+msgstr "Heraus zoomen (F2)"
 
 #: cvpcb/class_DisplayFootprintsFrame.cpp:232
 msgid "Redraw view (F3)"
@@ -2151,11 +2170,11 @@ msgstr "Texte als Umriss darstellen"
 
 #: cvpcb/class_DisplayFootprintsFrame.cpp:266
 msgid "Show outlines in filled mode"
-msgstr "Silhouette ausgefüllt darstellen"
+msgstr "Konturen ausgefüllt darstellen"
 
 #: cvpcb/class_DisplayFootprintsFrame.cpp:267
 msgid "Show outlines in sketch mode"
-msgstr "Silhouette als Umriss darstellen"
+msgstr "Konturen als Umriss darstellen"
 
 #: cvpcb/class_DisplayFootprintsFrame.cpp:397 pcbnew/pcbframe.cpp:648
 #: pcbnew/moduleframe.cpp:708
@@ -2178,9 +2197,8 @@ msgid "Lib: %s"
 msgstr "Bibliothek: %s"
 
 #: cvpcb/tool_cvpcb.cpp:65
-#, fuzzy
 msgid "Edit footprint library table"
-msgstr "Footprint Bibliotheksdateien"
+msgstr "Footprint Bibliotheksdatei editieren"
 
 #: cvpcb/tool_cvpcb.cpp:70
 msgid "View selected footprint"
@@ -2218,25 +2236,23 @@ msgstr "Die Footprintliste nach der Pinanzahl filtern"
 msgid "Filter footprint list by library"
 msgstr "Die Footprintliste nach Bibliothek filtern"
 
+# No translation needed
 #: cvpcb/dialogs/fp_conflict_assignment_selector.cpp:37
 #: pcbnew/dialogs/dialog_modedit_options_base.cpp:106
 msgid "Ref"
-msgstr "Ref"
+msgstr ""
 
 #: cvpcb/dialogs/fp_conflict_assignment_selector.cpp:38
-#, fuzzy
 msgid "Schematic assignment"
-msgstr "Schaltplangrösse"
+msgstr "Schaltplan Zuordnung"
 
 #: cvpcb/dialogs/fp_conflict_assignment_selector.cpp:41
-#, fuzzy
 msgid "Cmp file assignment"
-msgstr "Bauteil-Datei:"
+msgstr "Bauteildatei Zuordnung:"
 
 #: cvpcb/dialogs/dialog_config_equfiles_base.cpp:20
-#, fuzzy
 msgid "Footprint/Component equ files (.equ files)"
-msgstr "Bauteildateien (."
+msgstr "Footprint Alias-Bibliotheksdatei Dateien (.equ)"
 
 #: cvpcb/dialogs/dialog_config_equfiles_base.cpp:36
 #: eeschema/dialogs/dialog_eeschema_config_fbp.cpp:38
@@ -2270,14 +2286,14 @@ msgid "Move Up"
 msgstr "Nach oben bewegen"
 
 #: cvpcb/dialogs/dialog_config_equfiles_base.cpp:50
-#, fuzzy
 msgid "Edit Equ File"
-msgstr "Plugindatei editieren"
+msgstr "Footprint Alias-Bibliotheksdatei editieren"
 
 #: cvpcb/dialogs/dialog_config_equfiles_base.cpp:65
 msgid "Available environment variables for relative paths:"
-msgstr ""
+msgstr "Zur Verfügung stehende Umgebungsvariablen für relative Pfade:"
 
+# No translation needed
 #: cvpcb/dialogs/dialog_config_equfiles_base.cpp:82 eeschema/lib_pin.cpp:1928
 #: eeschema/libedit.cpp:477
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:231
@@ -2286,7 +2302,7 @@ msgstr ""
 #: pcbnew/dialogs/dialog_layers_setup.cpp:350
 #: pcbnew/dialogs/dialog_footprint_wizard_list_base.cpp:36
 msgid "Name"
-msgstr "Name"
+msgstr ""
 
 #: cvpcb/dialogs/dialog_config_equfiles_base.cpp:83 eeschema/lib_field.cpp:588
 #: eeschema/lib_field.cpp:766 eeschema/template_fieldnames.cpp:37
@@ -2305,35 +2321,30 @@ msgid "Value"
 msgstr "Wert"
 
 #: cvpcb/dialogs/dialog_config_equfiles_base.cpp:101
-#, fuzzy
 msgid "Absolute path"
-msgstr "Absolut"
+msgstr "Absoluter Pfad"
 
 #: cvpcb/dialogs/dialog_config_equfiles_base.cpp:101
-#, fuzzy
 msgid "Relative path"
-msgstr "Einen relativen Pfad verwenden?"
+msgstr "Relativen Pfad"
 
 #: cvpcb/dialogs/dialog_config_equfiles_base.cpp:103
-#, fuzzy
 msgid "Path option:"
-msgstr "Pad Optionen:"
+msgstr "Pfad Optionen:"
 
 #: cvpcb/dialogs/dialog_config_equfiles.cpp:99
-#, fuzzy
 msgid "No editor defined in Kicad. Please chose it"
 msgstr ""
 "Es wurde kein Texteditor für KiCAD ausgewählt. Bitte wählen Sie einen aus."
 
 #: cvpcb/dialogs/dialog_config_equfiles.cpp:259
-#, fuzzy
 msgid "Equ files:"
-msgstr "Equiv Dateien:"
+msgstr "Footprint Alias-Bibliotheksdatein:"
 
 #: cvpcb/dialogs/dialog_config_equfiles.cpp:304
-#, fuzzy, c-format
+#, c-format
 msgid "File '%s' already exists in list"
-msgstr "Bauteil %s existiert bereits in Bibliothek <%s>."
+msgstr "Bauteil '%s' existiert bereits in Bibliothek"
 
 #: cvpcb/dialogs/dialog_display_options_base.cpp:23
 msgid "Draw options"
@@ -2341,20 +2352,17 @@ msgstr "Zeichnungsoptionen"
 
 #: cvpcb/dialogs/dialog_display_options_base.cpp:25
 #: pcbnew/dialogs/dialog_display_options_base.cpp:98
-#, fuzzy
 msgid "Graphic items sketch mode"
-msgstr "DuKo's als Umrisse darstellen"
+msgstr "Darstellungsmodus für Grafische Elemente"
 
 #: cvpcb/dialogs/dialog_display_options_base.cpp:28
 #: pcbnew/dialogs/dialog_display_options_base.cpp:74
-#, fuzzy
 msgid "Texts sketch mode"
-msgstr "Texte als Umriss darstellen"
+msgstr "Darstellungsmodus für Texte"
 
 #: cvpcb/dialogs/dialog_display_options_base.cpp:31
-#, fuzzy
 msgid "Pad sketch mode"
-msgstr "Pads als Umrisse darstellen"
+msgstr "Darstellungsmodus für Pads"
 
 #: cvpcb/dialogs/dialog_display_options_base.cpp:34
 msgid "Show pad &number"
@@ -2522,9 +2530,10 @@ msgstr "Offener Emitter"
 msgid "Not connected"
 msgstr "Nicht angeschlossen"
 
+# No translation needed
 #: eeschema/lib_pin.cpp:215 eeschema/dialogs/dialog_color_config.cpp:75
 msgid "Pin"
-msgstr "Pin"
+msgstr ""
 
 #: eeschema/lib_pin.cpp:1935
 msgid "Number"
@@ -2583,10 +2592,11 @@ msgstr "Länge"
 msgid "Orientation"
 msgstr "Ausrichtung"
 
+# No translation needed
 #: eeschema/lib_pin.cpp:2220
 #, c-format
 msgid "Pin %s, %s, %s"
-msgstr "Pin %s, %s, %s"
+msgstr ""
 
 #: eeschema/edit_component_in_schematic.cpp:66
 #, c-format
@@ -2598,7 +2608,7 @@ msgstr ""
 "%s ist eine Komponente vom Typ Spannungsquelle deren Wert nicht modifiziert "
 "werden kann!\n"
 "\n"
-"Für einen neuen Wert muß eine neue Komponente vom Typ Spannungsquelle "
+"Für einen neuen Wert muss eine neue Komponente vom Typ Spannungsquelle "
 "erstellt werden."
 
 #: eeschema/edit_component_in_schematic.cpp:83
@@ -2636,15 +2646,15 @@ msgstr "Momentan aktive Bauteilebibliothek speichern"
 
 #: eeschema/menubar_libedit.cpp:83
 msgid "Save Current Library &As"
-msgstr "Aktuelle Bauteilebibliothek speichern &unter..."
+msgstr "Aktuelle Bauteilebibliothek speichern &unter ..."
 
 #: eeschema/menubar_libedit.cpp:84
 msgid "Save current active library as..."
-msgstr "Momentan aktive Bauteilebibliothek speichern unter..."
+msgstr "Momentan aktive Bauteilebibliothek speichern unter ..."
 
 #: eeschema/menubar_libedit.cpp:93
 msgid "Create &PNG File from Screen"
-msgstr "&PNG Datei erstellen"
+msgstr "&PNG Datei vom aktuellen Bildschirm erstellen"
 
 #: eeschema/menubar_libedit.cpp:94
 msgid "Create a PNG file from the component displayed on screen"
@@ -2690,19 +2700,19 @@ msgstr "&Entfernen"
 #: eeschema/menubar.cpp:245 pcbnew/menubar_pcbframe.cpp:329
 #: pcbnew/tool_modview.cpp:158 pcbnew/menubar_modedit.cpp:216
 msgid "Zoom &In"
-msgstr "Hin&einzoomen"
+msgstr "Hin&ein zoomen"
 
 #: eeschema/menubar_libedit.cpp:165 eeschema/tool_viewlib.cpp:229
 #: eeschema/menubar.cpp:249 pcbnew/menubar_pcbframe.cpp:333
 #: pcbnew/tool_modview.cpp:162 pcbnew/menubar_modedit.cpp:220
 msgid "Zoom &Out"
-msgstr "Her&auszoomen"
+msgstr "Her&aus zoomen"
 
 #: eeschema/menubar_libedit.cpp:169 eeschema/tool_viewlib.cpp:233
 #: eeschema/menubar.cpp:253 pcbnew/menubar_pcbframe.cpp:337
 #: pcbnew/tool_modview.cpp:166 pcbnew/menubar_modedit.cpp:224
 msgid "&Fit on Screen"
-msgstr "Auto&zoom"
+msgstr "An Bildschirm anpassen"
 
 #: eeschema/menubar_libedit.cpp:176 eeschema/tool_viewlib.cpp:238
 #: eeschema/menubar.cpp:265 pcbnew/menubar_pcbframe.cpp:342
@@ -2751,7 +2761,7 @@ msgstr "Einstellungen des Schaltplan&editors"
 
 #: eeschema/menubar_libedit.cpp:238
 msgid "Set Component Editor default values and options"
-msgstr ""
+msgstr "Standardwerte und Optionen für den Schaltplaneditor einstellen"
 
 #: eeschema/menubar_libedit.cpp:244 eeschema/menubar.cpp:388
 msgid "Set &Colors Scheme"
@@ -2869,26 +2879,26 @@ msgstr "Keine Element gefunden mit %s."
 
 #: eeschema/files-io.cpp:65
 msgid "Schematic Files"
-msgstr "Schaltplan speichern"
+msgstr "Schaltplan Dateien"
 
 #: eeschema/files-io.cpp:95
-#, fuzzy, c-format
+#, c-format
 msgid "Could not save backup of file '%s'"
-msgstr "Konnte Sicherungskopie der Datei <%s> nicht speichern."
+msgstr "Konnte Sicherungskopie der Datei '%s' nicht speichern."
 
 #: eeschema/files-io.cpp:109 eeschema/netform.cpp:389
-#, fuzzy, c-format
+#, c-format
 msgid "Failed to create file '%s'"
-msgstr "Konnte Datei <%s> nicht erstellen."
+msgstr "Konnte Datei '%s' nicht erstellen."
 
 #: eeschema/files-io.cpp:143
 msgid "File write operation failed."
 msgstr "Konnte Datei nicht schreiben."
 
 #: eeschema/files-io.cpp:197
-#, fuzzy, c-format
+#, c-format
 msgid "Schematic file '%s' is already open."
-msgstr "Diese Datei ist bereits geöffnet."
+msgstr "Schaltplan Datei '%s' ist bereits geöffnet."
 
 #: eeschema/files-io.cpp:210
 msgid ""
@@ -2906,15 +2916,12 @@ msgid "Load Without Saving"
 msgstr "Laden ohne zu Speichern"
 
 #: eeschema/files-io.cpp:243
-#, fuzzy, c-format
+#, c-format
 msgid "Schematic '%s' does not exist.  Do you wish to create it?"
-msgstr ""
-"Die Datei '%s' existiert bereits.\n"
-"\n"
-"Möchten Sie diese überschreiben?"
+msgstr "Der Schaltplan'%s' existiert nicht Möchten Sie diesen erstellen?"
 
 #: eeschema/files-io.cpp:265
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "Ready\n"
 "Project dir: '%s'\n"
@@ -2939,19 +2946,19 @@ msgstr ""
 "Möchten Sie das gegenwärtige Dokument speichern, bevor Sie fortfahren?"
 
 #: eeschema/files-io.cpp:425
-#, fuzzy, c-format
+#, c-format
 msgid "Directory '%s' is not writable"
-msgstr ""
-"Auf die Bibliothek '%s' kann nur lesend und nicht schreibend zugegriffen "
-"werden."
+msgstr "Das Verzeichnis '%s' ist nicht beschreibbar."
 
+# No translation needed
 #: eeschema/sch_line.cpp:474 pcbnew/dialogs/dialog_pad_properties_base.cpp:211
 msgid "Vert."
-msgstr "Vert."
+msgstr "Vert"
 
+# No translation needed
 #: eeschema/sch_line.cpp:476 pcbnew/dialogs/dialog_pad_properties_base.cpp:211
 msgid "Horiz."
-msgstr "Horiz."
+msgstr ""
 
 #: eeschema/sch_line.cpp:481
 #, c-format
@@ -3022,21 +3029,21 @@ msgstr "Breite"
 #: eeschema/lib_field.cpp:759 pcbnew/class_pcb_text.cpp:146
 #: pcbnew/class_text_mod.cpp:422 pcbnew/class_pad.cpp:643
 #: pcbnew/dialogs/dialog_edit_module_text_base.cpp:56
-#, fuzzy
 msgid "Height"
-msgstr "Höhe:"
+msgstr "Höhe"
 
+# No translation needed
 #: eeschema/plot_schematic_PS.cpp:122 eeschema/plot_schematic_HPGL.cpp:189
 #: eeschema/plot_schematic_DXF.cpp:92 pcbnew/dialogs/dialog_SVG_print.cpp:305
-#, fuzzy, c-format
+#, c-format
 msgid "Plot: '%s' OK\n"
-msgstr "Plot: %s OK\n"
+msgstr ""
 
 #: eeschema/plot_schematic_PS.cpp:127 eeschema/plot_schematic_PDF.cpp:100
 #: eeschema/plot_schematic_HPGL.cpp:191 eeschema/plot_schematic_DXF.cpp:96
-#, fuzzy, c-format
+#, c-format
 msgid "Unable to create '%s'\n"
-msgstr "Konnte <%s> nicht erstellen.\n"
+msgstr "Konnte '%s' nicht erstellen.\n"
 
 #: eeschema/controle.cpp:165 eeschema/libeditframe.cpp:1234
 msgid "Clarify Selection"
@@ -3055,7 +3062,7 @@ msgstr "Dateiname:"
 #: eeschema/libedit_plot_component.cpp:139
 #, c-format
 msgid "Can't save file <%s>"
-msgstr "Konnte Datei <%s> nicht erstellen."
+msgstr "Konnte Datei <%s> nicht speichern."
 
 #: eeschema/lib_polyline.cpp:53
 msgid "PolyLine"
@@ -3084,14 +3091,12 @@ msgstr "Die Y-Position von Punkt %d des Linienzugs ist nicht definiert."
 #: eeschema/lib_polyline.cpp:406 eeschema/lib_text.cpp:423
 #: eeschema/lib_bezier.cpp:416 eeschema/lib_arc.cpp:563
 #: eeschema/lib_circle.cpp:275 eeschema/lib_rectangle.cpp:255
-#, fuzzy
 msgid "Line Width"
 msgstr "Linienbreite"
 
 # Einen Bereich (gezeichnete Elemente) umgebendes Rechteck.
 #: eeschema/lib_polyline.cpp:411 eeschema/lib_bezier.cpp:421
 #: eeschema/lib_arc.cpp:568 eeschema/lib_circle.cpp:283
-#, fuzzy
 msgid "Bounding Box"
 msgstr "Darstellungsbereich"
 
@@ -3214,7 +3219,7 @@ msgstr "Linien Optionen editieren"
 
 #: eeschema/libedit_onrightclick.cpp:230
 msgid "Delete Line "
-msgstr "Linie entfernen"
+msgstr "Linie entfernen "
 
 #: eeschema/libedit_onrightclick.cpp:239 pcbnew/onrightclick.cpp:665
 msgid "Delete Segment"
@@ -3254,27 +3259,27 @@ msgstr "Global"
 
 #: eeschema/libedit_onrightclick.cpp:306
 msgid "Pin Size to selected pins"
-msgstr "Grösse des Pins den selektierten Pins zuweisen"
+msgstr "Größe des Pins den selektierten Pins zuweisen"
 
 #: eeschema/libedit_onrightclick.cpp:307
 msgid "Pin Size to Others"
-msgstr "Grösse des Pins allen anderen Pins zuweisen"
+msgstr "Größe des Pins allen anderen Pins zuweisen"
 
 #: eeschema/libedit_onrightclick.cpp:310
 msgid "Pin Name Size to selected pin"
-msgstr "Grösse des Pinnamens dem selektierten Pin zuweisen"
+msgstr "Größe des Pinnamens dem selektierten Pin zuweisen"
 
 #: eeschema/libedit_onrightclick.cpp:311
 msgid "Pin Name Size to Others"
-msgstr "Grösse des Pinnamens allen anderen Pins zuweisen"
+msgstr "Größe des Pinnamens allen anderen Pins zuweisen"
 
 #: eeschema/libedit_onrightclick.cpp:314
 msgid "Pin Num Size to selected pin"
-msgstr "Grösse der Pinnummer dem selektierten Pin zuweisen"
+msgstr "Größe der Pinnummer dem selektierten Pin zuweisen"
 
 #: eeschema/libedit_onrightclick.cpp:315
 msgid "Pin Num Size to Others"
-msgstr "Grösse der Pinnummer allen anderen Pins zuweisen"
+msgstr "Größe der Pinnummer allen anderen Pins zuweisen"
 
 #: eeschema/libedit_onrightclick.cpp:323 eeschema/onrightclick.cpp:805
 #: pcbnew/modedit_onclick.cpp:244 pcbnew/onrightclick.cpp:506
@@ -3311,7 +3316,7 @@ msgstr "Gruppe spiegeln --"
 
 #: eeschema/libedit_onrightclick.cpp:344
 msgid "Rotate Block ccw"
-msgstr "Gruppe rotieren"
+msgstr "Gruppe rotieren (entgegen Uhrzeigersinn)"
 
 #: eeschema/libedit_onrightclick.cpp:346 eeschema/onrightclick.cpp:826
 #: pcbnew/onrightclick.cpp:514
@@ -3328,15 +3333,16 @@ msgid "Choose Component (%d items loaded)"
 msgstr "Bauteilauswahl (%d Elemente geladen)"
 
 #: eeschema/getpart.cpp:196
-#, fuzzy, c-format
+#, c-format
 msgid "Failed to find part '%s' in library"
-msgstr "Konnte Bauteil <%s> nicht in der Bibliothek finden"
+msgstr "Konnte Bauteil '%s' nicht in der Bibliothek finden"
 
+# No translation needed
 #: eeschema/lib_text.cpp:51 eeschema/dialogs/dialog_lib_edit_text_base.cpp:28
 #: pcbnew/class_text_mod.cpp:383 pcbnew/class_text_mod.cpp:390
 #: pcbnew/dialogs/dialog_global_deletion_base.cpp:28
 msgid "Text"
-msgstr "Text"
+msgstr ""
 
 #: eeschema/lib_text.cpp:132
 #, c-format
@@ -3368,10 +3374,10 @@ msgstr ""
 "geladen werden."
 
 #: eeschema/class_library.cpp:256
-#, fuzzy, c-format
+#, c-format
 msgid "Cannot add duplicate alias '%s' to library '%s'."
 msgstr ""
-"Kann doppelten Alias <%s> der Bauteilebibliothek <%s> nicht hinzufügen."
+"Kann doppelten Alias '%s' der Bauteilebibliothek '%s' nicht hinzufügen."
 
 #: eeschema/class_library.cpp:423
 msgid "The component library file name is not set."
@@ -3398,47 +3404,49 @@ msgid "An error occurred attempting to read the header."
 msgstr "Bei dem Versuch den Header einzulesen ist ein Fehler aufgetreten."
 
 #: eeschema/class_library.cpp:543
-#, fuzzy, c-format
+#, c-format
 msgid "Library '%s' component load error %s."
-msgstr "Aus Bibliothek <%s> ein Bauteil einzulesen ist Fehler %s aufgetreten."
+msgstr ""
+"Beim Versuch aus der Bibliothek '%s' ein Bauteil einzulesen ist ein Fehler "
+"%s aufgetreten."
 
 #: eeschema/class_library.cpp:616
-#, fuzzy, c-format
+#, c-format
 msgid "Could not open component document library file '%s'."
-msgstr "Konnte Bauteiledokumentationsbibliothek <%s> nicht öffnen."
+msgstr "Konnte Bauteile Dokumentationsbibliothek '%s' nicht öffnen."
 
 #: eeschema/class_library.cpp:623
-#, fuzzy, c-format
+#, c-format
 msgid "Part document library file '%s' is empty."
-msgstr "Bauteiledokumentationsbibliothek <%s> ist leer."
+msgstr "Bauteile Dokumentationsbibliothek '%s' ist leer."
 
 #: eeschema/class_library.cpp:631
-#, fuzzy, c-format
+#, c-format
 msgid "File '%s' is not a valid component library document file."
-msgstr "Datei <%s> ist keine gültige Bauteiledokumentationsbibliothek."
+msgstr "Datei '%s' ist keine gültige Bauteile Dokumentationsbibliothek."
 
 #: eeschema/class_library.cpp:1019
-#, fuzzy, c-format
+#, c-format
 msgid "Unable to load project's '%s' file"
-msgstr "Konnte Datei für Netzliste nicht erstellen"
+msgstr "Konnte Projektdatei '%s' nicht laden."
 
 #: eeschema/class_library.cpp:1110
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "Part library '%s' failed to load. Error:\n"
 "%s"
 msgstr ""
-"Bauteilebibliothek '%s' wurde nicht geladen.\n"
-"Fehler: %s"
+"Bauteilebibliothek '%s' wurde nicht geladen. Fehler:\n"
+"%s"
 
 #: eeschema/class_library.cpp:1132
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "Part library '%s' failed to load.\n"
 "Error: %s"
 msgstr ""
-"Bauteilebibliothek '%s' wurde nicht geladen.\n"
-"Fehler: %s"
+"Bauteilebibliothek '%s' wurde nicht geladen. Fehler:\n"
+"%s"
 
 #: eeschema/schedit.cpp:258
 msgid "There are no undefined labels in this sheet to clean up."
@@ -3545,27 +3553,27 @@ msgid "Select Component"
 msgstr "Bauteil auswählen"
 
 #: eeschema/load_one_schematic_file.cpp:92
-#, fuzzy, c-format
+#, c-format
 msgid "Failed to open '%s'"
-msgstr "Es trat ein Fehler beim Öffnen von <%s> auf."
+msgstr "Es trat ein Fehler beim Öffnen von '%s' auf."
 
 #: eeschema/load_one_schematic_file.cpp:100
-#, fuzzy, c-format
+#, c-format
 msgid "Loading '%s'"
-msgstr "Lade <%s>"
+msgstr "Lade '%s'"
 
 #: eeschema/load_one_schematic_file.cpp:107
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' is NOT an Eeschema file!"
-msgstr "<%s> ist keine Eeschema Datei!"
+msgstr "'%s' ist keine Eeschema Datei!"
 
 #: eeschema/load_one_schematic_file.cpp:126
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "'%s' was created by a more recent version of Eeschema and may not load "
 "correctly. Please consider updating!"
 msgstr ""
-"<%s> wurde von einer älteren Version von Eeschema erstellt und wird "
+"'%s' wurde von einer älteren Version von Eeschema erstellt und wird "
 "möglicherweise nicht korrekt eingelesen.\n"
 "Bitte erwägen Sie ein Aktualisierung durchzuführen!"
 
@@ -3669,11 +3677,11 @@ msgstr "Das nächste Bauteil anzeigen"
 
 #: eeschema/tool_viewlib.cpp:98 eeschema/tool_lib.cpp:183
 msgid "Show as \"De Morgan\" normal part"
-msgstr "Bauteil in Normaldarstellung"
+msgstr "Bauteil in \"De Morgan\" Normaldarstellung"
 
 #: eeschema/tool_viewlib.cpp:103 eeschema/tool_lib.cpp:185
 msgid "Show as \"De Morgan\" convert part"
-msgstr "Bauteil in \"De Morgan\"-Darstellung"
+msgstr "Bauteil in \"De Morgan\" Darstellung konvertieren"
 
 #: eeschema/tool_viewlib.cpp:116
 msgid "View component documents"
@@ -3689,14 +3697,12 @@ msgid "Unit %c"
 msgstr "Einheit %c"
 
 #: eeschema/tool_viewlib.cpp:211 pcbnew/tool_modview.cpp:144
-#, fuzzy
 msgid "Set Current Library"
-msgstr "Aktuelle Bibliothek wählen:"
+msgstr "Aktuelle Bibliothek wählen"
 
 #: eeschema/tool_viewlib.cpp:212 pcbnew/tool_modview.cpp:145
-#, fuzzy
 msgid "Select library to be displayed"
-msgstr "Wähle Bibliothek "
+msgstr "Wähle Bibliothek zur Anzeige"
 
 #: eeschema/tool_viewlib.cpp:218 pcbnew/tool_modview.cpp:151
 #: pcbnew/menubar_modedit.cpp:150
@@ -3704,9 +3710,8 @@ msgid "Cl&ose"
 msgstr "&Beenden"
 
 #: eeschema/tool_viewlib.cpp:219
-#, fuzzy
 msgid "Close schematic component viewer"
-msgstr "Annotation im Schaltplan durchführen"
+msgstr "Bauteilbetrachter schließen"
 
 #: eeschema/tool_viewlib.cpp:250 eeschema/menubar.cpp:489
 msgid "Eesc&hema Manual"
@@ -3726,7 +3731,7 @@ msgid "Import Component"
 msgstr "Bauteil importieren"
 
 #: eeschema/lib_export.cpp:70
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "Unable to import library '%s'.  Error:\n"
 "%s"
@@ -3735,9 +3740,9 @@ msgstr ""
 "Fehler: %s"
 
 #: eeschema/lib_export.cpp:84
-#, fuzzy, c-format
+#, c-format
 msgid "Part library file '%s' is empty."
-msgstr "Bauteilebibliotheksdatei <%s> ist leer."
+msgstr "Bauteilebibliotheksdatei '%s' ist leer."
 
 #: eeschema/lib_export.cpp:111
 msgid "There is no component selected to save."
@@ -3752,9 +3757,9 @@ msgid "Export Component"
 msgstr "Bauteil exportieren"
 
 #: eeschema/lib_export.cpp:174
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' - OK"
-msgstr "<%s> - Erstellt"
+msgstr "'%s' - Erstellt"
 
 #: eeschema/lib_export.cpp:176
 msgid ""
@@ -3763,21 +3768,21 @@ msgid ""
 "Modify the Eeschema library configuration if you want to include it as part "
 "of this project."
 msgstr ""
-"Diese Bibliothek steht erst zur Verfügung, wenn sie von Eeschema geladen "
+"Diese Bibliothek steht erst zur Verfügung wenn sie von Eeschema geladen "
 "wurde.\n"
 "\n"
 "Ändern Sie bitte entsprechend die Eeschema Bibliothekseinstellungen, wenn "
 "die Bibliothek Bestandteil dieses Projektes sein soll."
 
 #: eeschema/lib_export.cpp:182
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' - Export OK"
-msgstr "<%s> - Exportiert"
+msgstr "'%s' - Exportiert"
 
 #: eeschema/lib_export.cpp:187
-#, fuzzy, c-format
+#, c-format
 msgid "Error creating '%s'"
-msgstr "Ein Fehler ist aufgetreten beim Erstellen von <%s>."
+msgstr "Ein Fehler ist aufgetreten beim Erstellen von '%s'."
 
 #: eeschema/viewlibs.cpp:141 eeschema/libedit.cpp:65
 #: pcbnew/modview_frame.cpp:740
@@ -3798,19 +3803,21 @@ msgstr "Keine"
 msgid "Part"
 msgstr "Bauteil"
 
+# No translatation needed
 #: eeschema/viewlibs.cpp:307 eeschema/libedit.cpp:488
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:202
 msgid "Alias"
-msgstr "Alias"
+msgstr ""
 
 #: eeschema/viewlibs.cpp:309 eeschema/libedit.cpp:509
 msgid "Key words"
 msgstr "Schlüsselwörter"
 
+# No translation needed.
 #: eeschema/sch_component.cpp:235
 #: eeschema/dialogs/dialog_lib_new_component_base.cpp:48
 msgid "U"
-msgstr "U"
+msgstr ""
 
 #: eeschema/sch_component.cpp:1502
 msgid "Power symbol"
@@ -3835,7 +3842,6 @@ msgid "<Unknown>"
 msgstr "<unbekannt>"
 
 #: eeschema/sch_component.cpp:1524
-#, fuzzy
 msgid "Key Words"
 msgstr "Schlüsselwörter"
 
@@ -3916,7 +3922,6 @@ msgid "Field %s"
 msgstr "Feld %s"
 
 #: eeschema/sch_marker.cpp:162
-#, fuzzy
 msgid "Electronics Rule Check Error"
 msgstr "Electronic Rule Check Fehler"
 
@@ -3929,43 +3934,36 @@ msgstr "keine"
 msgid ""
 "An attempt was made to remove the %s field from component %s in library %s."
 msgstr ""
-"Es wurde versucht das Feld <%s> von Bauteil <%s> in Bibliothek <%s> zu "
-"entfernen."
+"Es wurde versucht das Feld %s von Bauteil %s in Bibliothek %s zu entfernen."
 
 #: eeschema/backanno.cpp:225
-#, fuzzy
 msgid "Load Component Footprint Link File"
 msgstr "Laden einer Bauteile-Footprint Zuordnungsdatei"
 
 #: eeschema/backanno.cpp:239
-#, fuzzy
 msgid "Keep existing footprint field visibility"
 msgstr "Möchten Sie die Sichtbarkeit aller Footprintfelder erzwingen?"
 
 #: eeschema/backanno.cpp:240
-#, fuzzy
 msgid "Show all footprint fields"
-msgstr "Keine Footprintdatei"
+msgstr "Zeige alle Felder der Footprintdatei"
 
 #: eeschema/backanno.cpp:241
-#, fuzzy
 msgid "Hide all footprint fields"
-msgstr "Keine Footprintdatei"
+msgstr "Verberge alle Felder der Footprintdatei"
 
 #: eeschema/backanno.cpp:243
-#, fuzzy
 msgid "Select the footprint field visibility setting."
-msgstr "Möchten Sie die Sichtbarkeit aller Footprintfelder erzwingen?"
+msgstr "Auswahl Sichtbarkeit der Felder der Footprintdatei."
 
 #: eeschema/backanno.cpp:244
-#, fuzzy
 msgid "Change Visibility"
-msgstr "Darstellung"
+msgstr "Sichtbarkeit umstellen"
 
 #: eeschema/backanno.cpp:255
-#, fuzzy, c-format
+#, c-format
 msgid "Failed to open component-footprint link file '%s'"
-msgstr "Konnte Bauteile-Footprint Zuordnungsdatei <%s> nicht öffnen."
+msgstr "Konnte Bauteile-Footprint Zuordnungsdatei '%s' nicht öffnen."
 
 #: eeschema/pinedit.cpp:249
 msgid "This position is already occupied by another pin. Continue?"
@@ -3997,22 +3995,22 @@ msgstr " in Bauteil %c"
 
 #: eeschema/pinedit.cpp:700 eeschema/pinedit.cpp:742
 msgid "  of converted"
-msgstr "  in \"De Morgan\"-Darstellung"
+msgstr "  in konvertierter Darstellung"
 
 #: eeschema/pinedit.cpp:702 eeschema/pinedit.cpp:744
 msgid "  of normal"
-msgstr "  in Normal-Darstellung"
+msgstr "  in normaler Darstellung"
 
 #: eeschema/pinedit.cpp:727
 #, c-format
 msgid "<b>Off grid pin %s</b> \"%s\" at location <b>(%.3f, %.3f)</b>"
 msgstr ""
-"<b>Pin %s ausserhalb des Rasters</b> \"%s\" an Position <b>(%.3f, %.3f)</b>"
+"<b>Pin %s außerhalb des Rasters</b> \"%s\" an Position <b>(%.3f, %.3f)</b>"
 
 #: eeschema/pinedit.cpp:753
 msgid "No off grid or duplicate pins were found."
 msgstr ""
-"Es wurden keine Pins ausserhalb des Rasters und keine Pin-Duplikate gefunden."
+"Es wurden keine Pins außerhalb des Rasters und keine Pin-Duplikate gefunden."
 
 #: eeschema/tool_sch.cpp:55
 msgid "New schematic project"
@@ -4055,7 +4053,6 @@ msgid "Navigate schematic hierarchy"
 msgstr "Navigation in der Schaltplanhierarchie"
 
 #: eeschema/tool_sch.cpp:149 eeschema/menubar.cpp:450
-#, fuzzy
 msgid "Perform electrical rules check"
 msgstr "Electrical Rules Check ausführen"
 
@@ -4107,12 +4104,10 @@ msgid "HV orientation for wires and bus"
 msgstr "H-V-Ausrichtung für elektr. Verbindungen und Busse"
 
 #: eeschema/sch_sheet.cpp:828
-#, fuzzy
 msgid "Sheet Name"
 msgstr "Schaltplanname"
 
 #: eeschema/sch_sheet.cpp:829
-#, fuzzy
 msgid "File Name"
 msgstr "Dateiname"
 
@@ -4175,7 +4170,7 @@ msgstr "Bauteil exportieren"
 
 #: eeschema/tool_lib.cpp:147
 msgid "Save current component to new library"
-msgstr "Gegenwärtiges Bauteil in einer neue Bibliothek speichern"
+msgstr "Gegenwärtiges Bauteil in einer neuen Bibliothek speichern"
 
 #: eeschema/tool_lib.cpp:150 eeschema/help_common_strings.h:40
 msgid "Undo last command"
@@ -4195,7 +4190,7 @@ msgstr "Hinzufügen, entfernen von Feldern und editieren ihrer Eigenschaften"
 
 #: eeschema/tool_lib.cpp:166
 msgid "Test for duplicate and off grid pins"
-msgstr "Auf Pin-Duplikate und Pins ausserhalb des Rasters prüfen"
+msgstr "Auf Pin-Duplikate und Pins außerhalb des Rasters prüfen"
 
 #: eeschema/tool_lib.cpp:189
 msgid "Edit document file"
@@ -4287,9 +4282,8 @@ msgid "Pa&ge Settings"
 msgstr "Seite ein&richten..."
 
 #: eeschema/menubar.cpp:138
-#, fuzzy
 msgid "Setting for sheet size and frame references"
-msgstr "Seitengrösse einrichten und Informationen setzen"
+msgstr "Seitengröße einrichten und Informationen setzen"
 
 #: eeschema/menubar.cpp:143
 msgid "Pri&nt"
@@ -4323,8 +4317,7 @@ msgstr "Schaltplan im HPGL, Postscript oder Gerber Format plotten"
 msgid "Quit Eeschema"
 msgstr "Eeschema beenden"
 
-#: eeschema/menubar.cpp:211
-#: eeschema/dialogs/dialog_schematic_find_base.cpp:111
+#: eeschema/menubar.cpp:211 eeschema/dialogs/dialog_schematic_find_base.cpp:111
 #: pcbnew/menubar_pcbframe.cpp:290
 msgid "&Find"
 msgstr "&Suchen"
@@ -4357,9 +4350,10 @@ msgstr "S&pannungsquelle"
 msgid "&Wire"
 msgstr "Elektr. &Verbindung"
 
+# No translation needed
 #: eeschema/menubar.cpp:289
 msgid "&Bus"
-msgstr "&Bus"
+msgstr ""
 
 #: eeschema/menubar.cpp:295
 msgid "Wire to Bus &Entry"
@@ -4434,7 +4428,6 @@ msgid "Load Prefe&rences"
 msgstr "Einstellungen &laden"
 
 #: eeschema/menubar.cpp:423 pcbnew/menubar_pcbframe.cpp:582
-#, fuzzy
 msgid "Load application preferences"
 msgstr "Applikationseinstellungen laden"
 
@@ -4450,10 +4443,10 @@ msgstr "Bibliotheks&browser"
 msgid "&Annotate Schematic"
 msgstr "&Annotation des Schaltplans"
 
+# No translation needed
 #: eeschema/menubar.cpp:449
-#, fuzzy
 msgid "Electrical Rules &Checker"
-msgstr "Electric Rules &Checker"
+msgstr ""
 
 #: eeschema/menubar.cpp:455
 msgid "Generate &Netlist File"
@@ -4497,19 +4490,19 @@ msgid "Not Found"
 msgstr "Nicht gefunden"
 
 #: eeschema/schframe.cpp:172
-#, fuzzy
 msgid "The following libraries were not found:"
 msgstr "Die folgenden Bibliotheken konnten nicht gefunden werden:"
 
 #: eeschema/schframe.cpp:596 pcbnew/pcbframe.cpp:577
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "Save the changes in\n"
 "'%s'\n"
 "before closing?"
 msgstr ""
-"Änderungen vor dem Beenden speichern in\n"
-"<%s>?"
+"Änderungen in\n"
+"'%s'\n"
+"vor dem Beenden speichern?"
 
 #: eeschema/schframe.cpp:744
 msgid "Draw wires and buses in any direction"
@@ -4532,12 +4525,10 @@ msgid "New Schematic"
 msgstr "Neuer Schaltplan"
 
 #: eeschema/schframe.cpp:891
-#, fuzzy, c-format
+#, c-format
 msgid "Schematic file '%s' already exists, use Open instead"
 msgstr ""
-"Die Datei '%s' existiert bereits.\n"
-"\n"
-"Möchten Sie diese überschreiben?"
+"Die Schaltplan Datei '%s' existiert bereits, statt dessen \"Öffnen\" benutzen"
 
 #: eeschema/schframe.cpp:911
 msgid "Open Schematic"
@@ -4556,18 +4547,18 @@ msgid "Import Symbol Drawings"
 msgstr "Symbole importieren"
 
 #: eeschema/symbedit.cpp:87
-#, fuzzy, c-format
+#, c-format
 msgid "Error '%s' occurred loading part file '%s'."
 msgstr ""
 "Fehler '%s' ist aufgetreten beim Einlesen der Symbolbibliotheksdatei '%s'."
 
 #: eeschema/symbedit.cpp:98
-#, fuzzy, c-format
+#, c-format
 msgid "No parts found in part file '%s'."
 msgstr "Keine Bauteile in Symbolbibliothek '%s' gefunden."
 
 #: eeschema/symbedit.cpp:108
-#, fuzzy, c-format
+#, c-format
 msgid "More than one part in part file '%s'."
 msgstr "Symboldatei '%s' enthält mehr als ein Element."
 
@@ -4737,9 +4728,8 @@ msgstr ""
 " >> ERC Fehler: %d\n"
 
 #: eeschema/libedit.cpp:53
-#, fuzzy
 msgid "Part Library Editor: "
-msgstr "Bauteilebibliothekseditor beenden"
+msgstr "Bauteilebibliothekseditor beenden: "
 
 #: eeschema/libedit.cpp:89 eeschema/libedit.cpp:120
 msgid ""
@@ -4752,7 +4742,6 @@ msgstr ""
 "Möchten Sie die Änderungen verwerfen?"
 
 #: eeschema/libedit.cpp:166
-#, fuzzy
 msgid "The selected component is not in the active library."
 msgstr "Das ausgewählte Bauteil befindet sich nicht in der aktiven Bibliothek"
 
@@ -4761,7 +4750,7 @@ msgid "Do you want to change the active library?"
 msgstr "Möchten Sie die aktive Bibliothek wechseln?"
 
 #: eeschema/libedit.cpp:178
-#, fuzzy, c-format
+#, c-format
 msgid "Part name '%s' not found in library '%s'"
 msgstr "Footprint '%s' konnte nicht in der Bibliothek '%s' gefunden werden."
 
@@ -4774,28 +4763,27 @@ msgid "Include last component changes?"
 msgstr "Möchten Sie die Bauteiländerungen übernehmen?"
 
 #: eeschema/libedit.cpp:336
-#, fuzzy
 msgid "Part Library Name:"
 msgstr "Bauteilebibliotheksname:"
 
 #: eeschema/libedit.cpp:356
-#, fuzzy, c-format
+#, c-format
 msgid "Modify library file '%s' ?"
-msgstr "Möchten Sie die existierende Bibliotheksdatei <%s> überschreiben?"
+msgstr "Möchten Sie die existierende Bibliotheksdatei '%s' überschreiben?"
 
 #: eeschema/libedit.cpp:396
-#, fuzzy, c-format
+#, c-format
 msgid "Error occurred while saving library file '%s'"
-msgstr "Ein Fehler ist aufgetreten beim Speichern der Bibliotheksdatei <%s>."
+msgstr "Ein Fehler ist aufgetreten beim Speichern der Bibliotheksdatei '%s'."
 
 #: eeschema/libedit.cpp:398 eeschema/libedit.cpp:440
 msgid "*** ERROR: ***"
 msgstr "*** FEHLER: ***"
 
 #: eeschema/libedit.cpp:406 eeschema/libarch.cpp:111
-#, fuzzy, c-format
+#, c-format
 msgid "Failed to create component library file '%s'"
-msgstr "Konnte die Bauteilebibliothek <%s> nicht erstellen."
+msgstr "Konnte die Bauteilebibliothek '%s' nicht erstellen."
 
 #: eeschema/libedit.cpp:438
 #, c-format
@@ -4810,14 +4798,14 @@ msgid "Failed to create component document library file <%s>"
 msgstr "Konnte Bauteiledokumentationsbibliothek <%s> nicht erstellen."
 
 #: eeschema/libedit.cpp:454
-#, fuzzy, c-format
+#, c-format
 msgid "Library file '%s' OK"
-msgstr "Bibliotheksdatei <%s> erstellt."
+msgstr "Bibliotheksdatei '%s' erstellt."
 
 #: eeschema/libedit.cpp:457
-#, fuzzy, c-format
+#, c-format
 msgid "Documentation file '%s' OK"
-msgstr "Dokumentationsdatei <%s> erstellt."
+msgstr "Dokumentationsdatei '%s' erstellt."
 
 #: eeschema/libedit.cpp:496 eeschema/onrightclick.cpp:439
 #: eeschema/lib_draw_item.cpp:83
@@ -4837,37 +4825,36 @@ msgid "Please select a component library."
 msgstr "Wähle bitte eine Bauteilebibliothek."
 
 #: eeschema/libedit.cpp:544
-#, fuzzy, c-format
+#, c-format
 msgid "Part library '%s' is empty."
-msgstr "Bauteilebibliothek <%s> ist leer."
+msgstr "Bauteilebibliothek '%s' ist leer."
 
 #: eeschema/libedit.cpp:545
 msgid "Delete Entry Error"
 msgstr "Entferne fehlerhaften Eintrag"
 
 #: eeschema/libedit.cpp:549
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "Select 1 of %d components to delete\n"
 "from library '%s'."
 msgstr ""
 "Wähle 1 von %d Bauteilen zum Entfernen\n"
-"aus Bibliothek <%s>."
+"aus Bibliothek '%s'."
 
 #: eeschema/libedit.cpp:553
-#, fuzzy
 msgid "Delete Part"
-msgstr "Pad entfernen"
+msgstr "Footprint entfernen"
 
 #: eeschema/libedit.cpp:562
-#, fuzzy, c-format
+#, c-format
 msgid "Entry '%s' not found in library '%s'."
-msgstr "Eintrag <%s> konnte nicht in Bauteilebibliothek <%s> gefunden werden."
+msgstr "Eintrag '%s' konnte nicht in Bauteilebibliothek '%s' gefunden werden."
 
 #: eeschema/libedit.cpp:569
-#, fuzzy, c-format
+#, c-format
 msgid "Delete component '%s' from library '%s' ?"
-msgstr "Möchten Sie das Bauteil %s aus Bibliothek %s entfernen?"
+msgstr "Möchten Sie das Bauteil '%s' aus Bibliothek '%s' entfernen?"
 
 #: eeschema/libedit.cpp:588
 msgid ""
@@ -4895,19 +4882,19 @@ msgstr ""
 "Abbruch"
 
 #: eeschema/libedit.cpp:649
-#, fuzzy, c-format
+#, c-format
 msgid "Part '%s' already exists in library '%s'"
 msgstr "Footprint '%s' existiert bereits in der Bibliothek '%s'."
 
 #: eeschema/libedit.cpp:721
-#, fuzzy, c-format
+#, c-format
 msgid "Part '%s' already exists. Change it?"
-msgstr "Soll das existierende Bauteil %s geändert werden?"
+msgstr "Soll das existierende Bauteil '%s' geändert werden?"
 
 #: eeschema/libedit.cpp:735
-#, fuzzy, c-format
+#, c-format
 msgid "Part '%s' saved in library '%s'"
-msgstr "Kein '%s' Package in Bibliothek '%s'"
+msgstr "Footprint '%s' in Bibliothek '%s' gespeichert."
 
 #: eeschema/libeditframe.cpp:180
 msgid "Library Editor"
@@ -4919,12 +4906,12 @@ msgstr ""
 "Möchten Sie die Änderungen an der Bibliothek vor dem Beenden speichern?"
 
 #: eeschema/libeditframe.cpp:322
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "Library '%s' was modified!\n"
 "Discard changes?"
 msgstr ""
-"Bibliothek %s wurde modifiziert!\n"
+"Bibliothek '%s' wurde modifiziert!\n"
 "Möchten Sie die Änderungen verwerfen?"
 
 #: eeschema/libeditframe.cpp:428
@@ -4933,7 +4920,6 @@ msgid "Unit %s"
 msgstr "Einheit %s"
 
 #: eeschema/libeditframe.cpp:691
-#, fuzzy
 msgid "No part to save."
 msgstr "Kein Bauteil zum Speichern vorhanden"
 
@@ -5000,14 +4986,14 @@ msgid "Bus to Bus Entry"
 msgstr "Bus zu Buseingang"
 
 #: eeschema/plot_schematic_SVG.cpp:93
-#, fuzzy, c-format
+#, c-format
 msgid "Error creating file '%s'\n"
-msgstr "Beim Erstellen von <%s> ist ein Fehler aufgetreten.\n"
+msgstr "Beim Erstellen von '%s' ist ein Fehler aufgetreten.\n"
 
 #: eeschema/plot_schematic_SVG.cpp:98
-#, fuzzy, c-format
+#, c-format
 msgid "File '%s' OK\n"
-msgstr "Datei <%s> erstellt\n"
+msgstr "Datei '%s' erstellt\n"
 
 #: eeschema/plot_schematic_SVG.cpp:141
 #, c-format
@@ -5045,15 +5031,15 @@ msgstr ""
 "Unzulässige Referenz. Eine Referenz muss mit einem Buchstaben beginnen."
 
 #: eeschema/libfield.cpp:108
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "The name '%s' conflicts with an existing entry in the component library "
 "'%s'.\n"
 "\n"
 "Do you wish to replace the current component in library with this one?"
 msgstr ""
-"Der Name <%s> steht in Konflikt mit einem existierenden Eintrag in der "
-"Bauteilebibliothek <%s>.\n"
+"Der Name '%s' steht in Konflikt mit einem existierenden Eintrag in der "
+"Bauteilebibliothek '%s'.\n"
 "\n"
 "Möchten Sie das gegenwärtige Bauteil in der Bibliothek mit diesem ersetzen?"
 
@@ -5063,18 +5049,18 @@ msgid "Confirm"
 msgstr "Bestätigung"
 
 #: eeschema/libfield.cpp:125
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "The current component already has an alias named '%s'.\n"
 "\n"
 "Do you wish to remove this alias from the component?"
 msgstr ""
-"Das gegenwärtige Bauteil besitzt bereits einen Alias <%s>.\n"
+"Das gegenwärtige Bauteil besitzt bereits einen Alias '%s'.\n"
 "\n"
 "Möchten Sie diesen Alias entfernen?"
 
 #: eeschema/libfield.cpp:144
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "The new component contains alias names that conflict with entries in the "
 "component library '%s'.\n"
@@ -5082,7 +5068,7 @@ msgid ""
 "Do you wish to remove all of the conflicting aliases from this component?"
 msgstr ""
 "Das neue Bauteil besitzt Aliasnamen, welche mit Einträgen der "
-"Bauteilebibliothek <%s> in Konflikt stehen.\n"
+"Bauteilebibliothek %s in Konflikt stehen.\n"
 "\n"
 "Möchten Sie alle in Konflikt stehenden Aliasnamen dieses Bauteils entfernen?"
 
@@ -5504,16 +5490,16 @@ msgid "A sheet named \"%s\" already exists."
 msgstr "Eine Schaltplan mit dem Namen \"%s\" existiert bereits."
 
 #: eeschema/sheet.cpp:130
-#, fuzzy, c-format
+#, c-format
 msgid "A file named '%s' already exists in the current schematic hierarchy."
 msgstr ""
-"Eine Datei namens <%s> existiert bereits in der gegenwärtigen "
+"Eine Datei namens '%s' existiert bereits in der gegenwärtigen "
 "Schaltplanhierarchie."
 
 #: eeschema/sheet.cpp:135
-#, fuzzy, c-format
+#, c-format
 msgid "A file named '%s' already exists."
-msgstr "Eine Datei namens <%s> existiert bereits."
+msgstr "Eine Datei namens '%s' existiert bereits."
 
 #: eeschema/sheet.cpp:139
 msgid ""
@@ -5568,10 +5554,10 @@ msgstr ""
 "lassen?"
 
 #: eeschema/libarch.cpp:101
-#, fuzzy, c-format
+#, c-format
 msgid "An error occurred attempting to save component library '%s'."
 msgstr ""
-"Bei dem Versuch die Bauteilebibliothek <%s> zu speichern ist ein Fehler "
+"Bei dem Versuch die Bauteilebibliothek '%s' zu speichern ist ein Fehler "
 "aufgetreten."
 
 #: eeschema/hierarch.cpp:148
@@ -5638,19 +5624,18 @@ msgstr ""
 msgid "A no connect symbol is connected to more than 1 pin"
 msgstr "Ein 'Keine-Verbindung' Symbol ist mit mehr als einem Pin verbunden"
 
+# No translation needed
 #: eeschema/sch_text.cpp:715 eeschema/dialogs/dialog_color_config.cpp:64
 msgid "Label"
-msgstr "Label"
+msgstr ""
 
 #: eeschema/sch_text.cpp:719
-#, fuzzy
 msgid "Global Label"
-msgstr "&Globales Netzlabel"
+msgstr "Globales Netzlabel"
 
 #: eeschema/sch_text.cpp:723
-#, fuzzy
 msgid "Hierarchical Label"
-msgstr "&Hierarchisches Label"
+msgstr "Hierarchisches Label"
 
 #: eeschema/sch_text.cpp:727
 msgid "Hierarchical Sheet Pin"
@@ -5802,7 +5787,7 @@ msgstr "Suche mittels &einfacher Wildcards"
 
 #: eeschema/dialogs/dialog_schematic_find_base.cpp:84
 msgid "Wrap around &end of search list"
-msgstr "Bei erreichen des Suchendes von &vorne beginnen"
+msgstr "Beim Erreichen des Suchendes von &vorne beginnen"
 
 #: eeschema/dialogs/dialog_schematic_find_base.cpp:88
 msgid "Search all com&ponent fields"
@@ -5847,7 +5832,7 @@ msgstr "Drucke Schaltplan"
 
 #: eeschema/dialogs/dialog_print_using_printer.cpp:311
 msgid "An error occurred attempting to print the schematic."
-msgstr "Bei dem Versuch den Schaltplan zu drucken ist ein Fehler aufgetreten."
+msgstr "Beim Versuch den Schaltplan zu drucken ist ein Fehler aufgetreten."
 
 #: eeschema/dialogs/dialog_print_using_printer.cpp:312
 msgid "Printing"
@@ -5864,7 +5849,7 @@ msgstr "Globale Label Eigenschaften"
 
 #: eeschema/dialogs/dialog_edit_label.cpp:130
 msgid "Hierarchical Label Properties"
-msgstr "Eigenschaften eines hierarchischen Labels"
+msgstr "Hierarchische Label Eigenschaften"
 
 #: eeschema/dialogs/dialog_edit_label.cpp:134
 msgid "Label Properties"
@@ -5879,10 +5864,11 @@ msgstr "Eigenschaften eines hierarchischen Schaltplanpins"
 msgid "Text Properties"
 msgstr "Text Eigenschaften"
 
+# No translation needed
 #: eeschema/dialogs/dialog_edit_label.cpp:203
 #, c-format
 msgid "H%s x W%s"
-msgstr "H%s x W%s"
+msgstr ""
 
 #: eeschema/dialogs/dialog_edit_label.cpp:269
 msgid "Empty Text!"
@@ -5894,44 +5880,51 @@ msgstr "Leerer Text!"
 msgid "&Grid size:"
 msgstr "&Rastergröße:"
 
+# No translation needed
 #: eeschema/dialogs/dialog_libedit_dimensions_base.cpp:37
 #: eeschema/dialogs/dialog_libedit_dimensions_base.cpp:73
 #: eeschema/dialogs/dialog_libedit_dimensions_base.cpp:87
 msgid "50"
-msgstr "50"
+msgstr ""
 
+# No translation needed
 #: eeschema/dialogs/dialog_libedit_dimensions_base.cpp:37
 #: eeschema/dialogs/dialog_libedit_dimensions_base.cpp:73
 #: eeschema/dialogs/dialog_libedit_dimensions_base.cpp:87
 msgid "25"
-msgstr "25"
+msgstr ""
 
+# No translation needed
 #: eeschema/dialogs/dialog_libedit_dimensions_base.cpp:37
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:45
 msgid "10"
-msgstr "10"
+msgstr ""
 
+# No translation needed
 #: eeschema/dialogs/dialog_libedit_dimensions_base.cpp:37
 #: pcbnew/dialogs/dialog_create_array_base.cpp:33
 #: pcbnew/dialogs/dialog_create_array_base.cpp:40
 #: pcbnew/dialogs/dialog_create_array_base.cpp:47
 #: pcbnew/dialogs/dialog_create_array_base.cpp:58
 msgid "5"
-msgstr "5"
+msgstr ""
 
+# No translation needed
 #: eeschema/dialogs/dialog_libedit_dimensions_base.cpp:37
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:45
 msgid "2"
-msgstr "2"
+msgstr ""
 
+# No translation needed
 #: eeschema/dialogs/dialog_libedit_dimensions_base.cpp:37
 #: pcbnew/dialogs/dialog_create_array_base.cpp:91
 #: pcbnew/dialogs/dialog_create_array_base.cpp:158
 #: pcbnew/dialogs/dialog_create_array_base.cpp:161
 #: pcbnew/dialogs/dialog_create_array_base.cpp:272
 msgid "1"
-msgstr "1"
+msgstr ""
 
+# No translation needed
 #: eeschema/dialogs/dialog_libedit_dimensions_base.cpp:43
 #: eeschema/dialogs/dialog_libedit_dimensions_base.cpp:54
 #: eeschema/dialogs/dialog_libedit_dimensions_base.cpp:65
@@ -5952,7 +5945,7 @@ msgstr "1"
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:118
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:129
 msgid "mils"
-msgstr "mils"
+msgstr ""
 
 #: eeschema/dialogs/dialog_libedit_dimensions_base.cpp:47
 msgid "Current graphic &line width:"
@@ -6114,19 +6107,17 @@ msgstr "Feldname:"
 
 #: eeschema/dialogs/dialog_eeschema_options.cpp:51
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:238
-#, fuzzy
 msgid "Default Value"
 msgstr "Voreingestellter DuKo-Typ:"
 
 #: eeschema/dialogs/dialog_eeschema_options.cpp:192
-#, fuzzy
 msgid "Hidden"
 msgstr "Versteckter Text"
 
 #: eeschema/dialogs/dialog_bom.cpp:319
-#, fuzzy, c-format
+#, c-format
 msgid "Failed to open file '%s'"
-msgstr "Konnte Datei <%s> nicht öffnen."
+msgstr "Konnte Datei '%s' nicht öffnen."
 
 #: eeschema/dialogs/dialog_bom.cpp:381 eeschema/dialogs/dialog_netlist.cpp:536
 msgid "Save Netlist File"
@@ -6134,17 +6125,15 @@ msgstr "Netzliste speichern"
 
 #: eeschema/dialogs/dialog_bom.cpp:444
 msgid "Plugin name in plugin list"
-msgstr ""
+msgstr "Pluginname in Pluginliste"
 
 #: eeschema/dialogs/dialog_bom.cpp:445
-#, fuzzy
 msgid "Plugin name"
-msgstr "Pinname"
+msgstr "Pluginname"
 
 #: eeschema/dialogs/dialog_bom.cpp:455
-#, fuzzy
 msgid "This name already exists. Abort"
-msgstr "Dieses Plugin existiert bereits. Abbruch"
+msgstr "Dieser Name existiert bereits. Abbruch"
 
 #: eeschema/dialogs/dialog_bom.cpp:483 eeschema/dialogs/dialog_netlist.cpp:841
 msgid "Plugin files:"
@@ -6152,7 +6141,7 @@ msgstr "Plugin Dateien:"
 
 #: eeschema/dialogs/dialog_bom.cpp:567
 msgid "Plugin file name not found. Cannot edit plugin file"
-msgstr ""
+msgstr "Plugin Datei nicht gefunden. Das Plugin kann nicht editiert werden."
 
 #: eeschema/dialogs/dialog_bom.cpp:577
 msgid "No text editor selected in KiCad. Please choose it"
@@ -6306,20 +6295,22 @@ msgstr "Die Textgrösse des aktuell ausgewählten Feldes im Schaltplan"
 msgid "unit"
 msgstr "Einheit"
 
+# No translation needed
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:152
 #: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:244
 msgid "PosX"
-msgstr "PosX"
+msgstr ""
 
+# No translation needed
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:164
 #: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:258
 msgid "PosY"
-msgstr "PosY"
+msgstr ""
 
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:170
 #: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:264
 msgid "The Y coordinate of the text relative to the component"
-msgstr "Die Y-Koordinate des Textes relativ zu dem Bauteil"
+msgstr "Die Y-Koordinate des Textes relativ zum Bauteil"
 
 #: eeschema/dialogs/dialog_sch_sheet_props_base.cpp:28
 msgid "&File name:"
@@ -6327,7 +6318,7 @@ msgstr "&Dateiname:"
 
 #: eeschema/dialogs/dialog_sch_sheet_props_base.cpp:41
 msgid "Si&ze:"
-msgstr "&Grösse:"
+msgstr "&Größe:"
 
 #: eeschema/dialogs/dialog_sch_sheet_props_base.cpp:53
 msgid "&Sheet name:"
@@ -6336,7 +6327,7 @@ msgstr "&Schaltplanname:"
 #: eeschema/dialogs/dialog_sch_sheet_props_base.cpp:64
 #: eeschema/dialogs/dialog_edit_label_base.cpp:47
 msgid "&Size:"
-msgstr "&Grösse:"
+msgstr "&Größe:"
 
 #: eeschema/dialogs/dialog_sch_sheet_props_base.cpp:94
 msgid "Unique timestamp:"
@@ -6358,9 +6349,8 @@ msgid "Prefix references 'U' and 'IC' with 'X'"
 msgstr "Prefixreferenzen 'U' und 'IC' mit 'X'"
 
 #: eeschema/dialogs/dialog_netlist.cpp:386
-#, fuzzy
 msgid "Use net number as net name"
-msgstr "Verwende Netznummern"
+msgstr "Benutze Netznummer als Netzname"
 
 #: eeschema/dialogs/dialog_netlist.cpp:390
 msgid "Simulator command:"
@@ -6379,10 +6369,11 @@ msgstr "Netzliste Befehl:"
 msgid "Title:"
 msgstr "Titel:"
 
+# No translation needed
 #: eeschema/dialogs/dialog_netlist.cpp:572
 #, c-format
 msgid "%s Export"
-msgstr "%s Export"
+msgstr ""
 
 #: eeschema/dialogs/dialog_netlist.cpp:623
 msgid "SPICE netlist file (.cir)|*.cir"
@@ -6432,9 +6423,10 @@ msgstr "Voreinstellung für Pinnamengröße"
 msgid "Show gr&id"
 msgstr "Raste&r einblenden"
 
+# No translation needed
 #: eeschema/dialogs/dialog_bom_base.cpp:37
 msgid "Plugins"
-msgstr "Plugins"
+msgstr ""
 
 #: eeschema/dialogs/dialog_bom_base.cpp:58
 #: eeschema/dialogs/dialog_netlist_base.cpp:46
@@ -6463,10 +6455,10 @@ msgstr "Plugindatei editieren"
 msgid "Command line:"
 msgstr "Kommandozeile:"
 
+# No translation needed
 #: eeschema/dialogs/dialog_bom_base.cpp:102
-#, fuzzy
 msgid "Plugin Info:"
-msgstr "Plugin Dateien:"
+msgstr ""
 
 #: eeschema/dialogs/dialog_edit_component_in_lib.cpp:71
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.h:114
@@ -6534,10 +6526,11 @@ msgstr "Soll die Footprintfilterliste entfernt werden?"
 msgid "Add Footprint Filter"
 msgstr "Footprint Filter hinzufügen"
 
+# No translation needed
 #: eeschema/dialogs/dialog_edit_component_in_lib.cpp:506
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:244
 msgid "Footprint Filter"
-msgstr "Footprint Filter"
+msgstr ""
 
 #: eeschema/dialogs/dialog_edit_component_in_lib.cpp:523
 #, c-format
@@ -6545,9 +6538,8 @@ msgid "Foot print filter <%s> is already defined."
 msgstr "Footprintfilter <%s> ist bereits definiert."
 
 #: eeschema/dialogs/dialog_edit_component_in_lib.cpp:559
-#, fuzzy
 msgid "Edit footprint filter"
-msgstr "Keine Footprintdatei"
+msgstr "Footprintdatei bearbeiten"
 
 #: eeschema/dialogs/dialog_annotate_base.cpp:22
 msgid "Scope"
@@ -6597,9 +6589,10 @@ msgstr "Verwende erste freie Nummer bis Schaltplannummer x 100"
 msgid "Start to  sheet number*1000 and use first free number"
 msgstr "Verwende erste freie Nummer bis Schaltplannummer x 1000"
 
+# No translation needed
 #: eeschema/dialogs/dialog_annotate_base.cpp:157
 msgid "Dialog"
-msgstr "Dialog"
+msgstr ""
 
 #: eeschema/dialogs/dialog_annotate_base.cpp:169
 msgid "Automatically close this dialog"
@@ -6615,9 +6608,8 @@ msgid "Clear Annotation"
 msgstr "Lösche Annotationen"
 
 #: eeschema/dialogs/dialog_annotate_base.cpp:208
-#, fuzzy
 msgid "Annotate"
-msgstr "&Annotation"
+msgstr "Annotation"
 
 #: eeschema/dialogs/dialog_lib_edit_draw_item_base.cpp:22
 #: eeschema/dialogs/dialog_color_config.cpp:102
@@ -6672,11 +6664,13 @@ msgstr "Wähle das Ausgabeverzeichnis"
 
 #: eeschema/dialogs/dialog_plot_schematic.cpp:182
 #: pcbnew/dialogs/dialog_plot.cpp:321
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "Do you want to use a path relative to\n"
 "'%s'"
-msgstr "Möchten Sie die aktive Bibliothek wechseln?"
+msgstr ""
+"Möchten Sie einen relativen Pfad zu '%s'\n"
+"benutzen?"
 
 #: eeschema/dialogs/dialog_plot_schematic.cpp:185
 #: eeschema/dialogs/dialog_plot_schematic.cpp:193
@@ -6692,7 +6686,6 @@ msgstr "Ausgabeverzeichnis für Plot"
 
 #: eeschema/dialogs/dialog_plot_schematic.cpp:192
 #: pcbnew/dialogs/dialog_plot.cpp:330
-#, fuzzy
 msgid "Cannot make path relative (target volume different from file volume)!"
 msgstr ""
 "Kann keinen relativen Pfad erzeugen (Zieldatei und Platinendatei haben "
@@ -6709,6 +6702,7 @@ msgstr "Konnte die Plotdateien nicht in dem Verzeichnis '%s' anlegen."
 msgid "Units are interchangeable:"
 msgstr "Austauschbare Einheiten:"
 
+# No translation needed
 #: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:48
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:135
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:237
@@ -6721,21 +6715,24 @@ msgstr "Austauschbare Einheiten:"
 #: pcbnew/dialogs/dialog_create_array_base.cpp:199
 #: pcbnew/dialogs/dialog_create_array_base.cpp:218
 msgid "0"
-msgstr "0"
+msgstr ""
 
+# No translation needed
 #: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:48
 msgid "+90"
-msgstr "+90"
+msgstr ""
 
+# No translation needed
 #: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:48
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:135
 msgid "180"
-msgstr "180"
+msgstr ""
 
+# No translation needed
 #: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:48
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:135
 msgid "-90"
-msgstr "-90"
+msgstr ""
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:50
 msgid "Orientation (Degrees)"
@@ -6760,7 +6757,6 @@ msgid "Mirror"
 msgstr "Spiegeln"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:64
-#, fuzzy
 msgid "Converted Shape"
 msgstr "Ändere Form"
 
@@ -6781,16 +6777,15 @@ msgstr "Bauteilname"
 msgid "The name of the symbol in the library from which this component came"
 msgstr "Name des Symbols in der Bibliothek aus der dieses Bauteil stammt"
 
+# No translation needed
 #: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:81
-#, fuzzy
 msgid "Test"
-msgstr "Test Drc"
+msgstr ""
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:84
 #: eeschema/dialogs/dialog_lib_edit_text_base.cpp:41
-#, fuzzy
 msgid "Select"
-msgstr "Wähle Netz"
+msgstr "Wähle"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:93
 #: pcbnew/dialogs/dialog_netlist_fbp.cpp:31
@@ -6850,27 +6845,25 @@ msgstr ""
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:236
 msgid "The size of the currently selected field's text in the schematic"
-msgstr "Die Textgrösse des aktuell ausgewählten Feldes im Schaltplan"
+msgstr "Die Textgröße des aktuell ausgewählten Feldes im Schaltplan"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:250
 msgid "The X coordinate of the text relative to the component"
 msgstr "Die X-Koordinate des Textes relativ zu dem Bauteil"
 
 #: eeschema/dialogs/dialog_eeschema_config.cpp:128
-#, fuzzy, c-format
+#, c-format
 msgid "Project '%s'"
-msgstr ""
-"\n"
-"Projekt: "
+msgstr "Projekt '%s'"
 
 #: eeschema/dialogs/dialog_eeschema_config.cpp:304
 msgid "Library files:"
 msgstr "Bibliotheksdateien:"
 
 #: eeschema/dialogs/dialog_eeschema_config.cpp:364
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' : library already in use"
-msgstr "Bibliothek wird bereits verwendet"
+msgstr "Bibliothek '%s' wird bereits verwendet"
 
 #: eeschema/dialogs/dialog_eeschema_config.cpp:379
 msgid "Default Path for Libraries"
@@ -6928,11 +6921,11 @@ msgstr "&Sichtbar"
 
 #: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:117
 msgid "N&ame text size:"
-msgstr "Grösse der &Beschriftung:"
+msgstr "Größe der &Beschriftung:"
 
 #: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:129
 msgid "Number te&xt size:"
-msgstr "Grösse der &Nummerierung:"
+msgstr "Größe der &Nummerierung:"
 
 #: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:141
 msgid "&Length:"
@@ -6947,12 +6940,11 @@ msgid "Output directory:"
 msgstr "Ausgabeverzeichnis:"
 
 #: eeschema/dialogs/dialog_plot_schematic_base.cpp:31
-#, fuzzy
 msgid ""
 "Target directory for plot files. Can be absolute or relative to the "
 "schematic main file location."
 msgstr ""
-"Zielverzeichnis für Plotdateien. Kann sich absolut oder relativ zur "
+"Zielverzeichnis für Plotdateien. Dieses kann sich absolut oder relativ zur "
 "Platinendatei befinden."
 
 #: eeschema/dialogs/dialog_plot_schematic_base.cpp:35
@@ -6969,7 +6961,7 @@ msgstr "Seiteneinstellungen"
 #: eeschema/dialogs/dialog_plot_schematic_base.cpp:48
 #: eeschema/dialogs/dialog_plot_schematic_base.cpp:60
 msgid "Schematic size"
-msgstr "Schaltplangrösse"
+msgstr "Schaltplangröße"
 
 #: eeschema/dialogs/dialog_plot_schematic_base.cpp:48
 msgid "Force size A4"
@@ -7046,39 +7038,45 @@ msgstr "Ursprungspunkt"
 msgid "Pen width"
 msgstr "Stiftbreite"
 
+# No translation needed
 #: eeschema/dialogs/dialog_plot_schematic_base.cpp:86
 #: pcbnew/dialogs/dialog_plot_base.cpp:31
 msgid "Postscript"
-msgstr "Postscript"
+msgstr ""
 
+# No translation needed
 #: eeschema/dialogs/dialog_plot_schematic_base.cpp:86
 #: pcbnew/dialogs/dialog_plot_base.cpp:31
 #: pcbnew/dialogs/dialog_gendrill_base.cpp:74
 msgid "PDF"
-msgstr "PDF"
+msgstr ""
 
+# No translation needed
 #: eeschema/dialogs/dialog_plot_schematic_base.cpp:86
 #: pcbnew/dialogs/dialog_plot_base.cpp:31
 #: pcbnew/dialogs/dialog_gendrill_base.cpp:74
 msgid "SVG"
-msgstr "SVG"
+msgstr ""
 
+# No translation needed
 #: eeschema/dialogs/dialog_plot_schematic_base.cpp:86
 #: pcbnew/dialogs/dialog_plot_base.cpp:31
 #: pcbnew/dialogs/dialog_gendrill_base.cpp:74
 msgid "DXF"
-msgstr "DXF"
+msgstr ""
 
+# No translation needed
 #: eeschema/dialogs/dialog_plot_schematic_base.cpp:86
 #: pcbnew/dialogs/dialog_plot_base.cpp:31
 #: pcbnew/dialogs/dialog_gendrill_base.cpp:74
 msgid "HPGL"
-msgstr "HPGL"
+msgstr ""
 
+# No translation needed
 #: eeschema/dialogs/dialog_plot_schematic_base.cpp:88
 #: pcbnew/dialogs/dialog_plot_base.cpp:248
 msgid "Format"
-msgstr "Format"
+msgstr ""
 
 #: eeschema/dialogs/dialog_plot_schematic_base.cpp:93
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:216
@@ -7158,12 +7156,10 @@ msgid "Keywords\n"
 msgstr "Schlüsselwörter\n"
 
 #: eeschema/dialogs/dialog_choose_component.cpp:271
-#, fuzzy
 msgid "Unknown"
-msgstr "<unbekannt>"
+msgstr "Unbekannt"
 
 #: eeschema/dialogs/dialog_choose_component.cpp:277
-#, fuzzy
 msgid "Alias of "
 msgstr "Alias von"
 
@@ -7173,7 +7169,7 @@ msgstr "Voreingestellten Netznamen verwenden"
 
 #: eeschema/dialogs/dialog_netlist_base.cpp:70
 msgid "Default Netlist Filename:"
-msgstr "Voreingestellter Dateiname:"
+msgstr "Voreingestellter Netzlisten Dateiname:"
 
 #: eeschema/dialogs/dialog_netlist_base.cpp:136
 msgid "Browse Plugins"
@@ -7195,9 +7191,10 @@ msgstr "Verbindungstyp:"
 msgid "Wire"
 msgstr "Elektr. Verbindung"
 
+# No translation needed
 #: eeschema/dialogs/dialog_color_config.cpp:62
 msgid "Bus"
-msgstr "Bus"
+msgstr ""
 
 #: eeschema/dialogs/dialog_color_config.cpp:63 eeschema/sch_junction.h:86
 msgid "Junction"
@@ -7316,19 +7313,16 @@ msgid "Marker not found"
 msgstr "Marker nicht gefunden"
 
 #: eeschema/dialogs/dialog_erc.cpp:327
-#, fuzzy
 msgid "No error or warning"
-msgstr "ERC Warnung"
+msgstr "Keine Fehler oder Warnungen"
 
 #: eeschema/dialogs/dialog_erc.cpp:332
-#, fuzzy
 msgid "Generate warning"
-msgstr "Netzliste erstellen"
+msgstr "Erzeuge Warnhinweis"
 
 #: eeschema/dialogs/dialog_erc.cpp:337
-#, fuzzy
 msgid "Generate error"
-msgstr "Fehler beim erstellen "
+msgstr "Erzeuge Fehler"
 
 #: eeschema/dialogs/dialog_erc.cpp:442
 msgid "Annotation required!"
@@ -7340,7 +7334,7 @@ msgstr "ERC Datei"
 
 #: eeschema/dialogs/dialog_erc.cpp:550
 msgid "Electronic rule check file (.erc)|*.erc"
-msgstr "Electronic rule check Datei (.erc)|*.erc"
+msgstr "Electronische Regel Check (ERC) Datei (.erc)|*.erc"
 
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:53
 msgid "Measurement &units:"
@@ -7352,7 +7346,7 @@ msgstr "Voreinstellung für &Busbreite:"
 
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:100
 msgid "Default text &size:"
-msgstr "Voreinstellung für &Textgrösse:"
+msgstr "Voreinstellung für &Textgröße:"
 
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:133
 msgid "&Repeat label increment:"
@@ -7370,33 +7364,40 @@ msgstr "Minuten"
 msgid "Part id notation:"
 msgstr "Notation für Bauteil-Id:"
 
+# No translation needed
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:158
 msgid "A"
-msgstr "A"
+msgstr ""
 
+# No translation needed
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:158
 msgid ".A"
-msgstr ".A"
+msgstr ""
 
+# No translation needed
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:158
 msgid "-A"
-msgstr "-A"
+msgstr ""
 
+# No translation needed
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:158
 msgid "_A"
-msgstr "_A"
+msgstr ""
 
+# No translation needed
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:158
 msgid ".1"
-msgstr ".1"
+msgstr ""
 
+# No translation needed
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:158
 msgid "-1"
-msgstr "-1"
+msgstr ""
 
+# No translation needed
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:158
 msgid "_1"
-msgstr "_1"
+msgstr ""
 
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:179
 msgid "Show hi&dden pins"
@@ -7445,9 +7446,8 @@ msgid "User defined field names for schematic components. "
 msgstr "Benutzerdefinierte Feldnamen für Schaltplanbauteile. "
 
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:229
-#, fuzzy
 msgid "Field Settings"
-msgstr "Filtereinstellungen"
+msgstr "Feldeinstellungen"
 
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:254
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:189
@@ -7525,7 +7525,7 @@ msgstr "Oben ausrichten"
 
 #: eeschema/dialogs/dialog_lib_edit_text_base.cpp:105
 msgid "Vertical Justify"
-msgstr "Vertiktikale Ausrichtung"
+msgstr "Vertikale Ausrichtung"
 
 #: eeschema/dialogs/dialog_print_using_printer_base.cpp:22
 msgid "Print options:"
@@ -7557,32 +7557,32 @@ msgid "Print"
 msgstr "Drucken"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:219
-#, fuzzy, c-format
+#, c-format
 msgid "Component '%s' found in library '%s'"
-msgstr "Bauteilname <%s> konnte nicht in der Bibliothek <%s> gefunden werden."
+msgstr "Bauteilname '%s' konnte nicht in der Bibliothek '%s' gefunden werden."
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:225
-#, fuzzy, c-format
+#, c-format
 msgid "Component '%s' not found in any library"
-msgstr "Der Footprint %s konnte in keiner Bibliothek gefunden werden."
+msgstr "Bauteil '%s' konnte in keiner Bibliothek gefunden werden."
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:241
 msgid "However, some candidates are found:"
-msgstr ""
+msgstr "Einige Kandidaten konnten aber gefunden werden:"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:247
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' found in library '%s'"
-msgstr "Footprint '%s' konnte nicht in der Bibliothek '%s' gefunden werden."
+msgstr "'%s' in der Bibliothek '%s' gefunden"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:309
 msgid "No Component Name!"
 msgstr "Kein Bauteil Name!"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:318
-#, fuzzy, c-format
+#, c-format
 msgid "Component '%s' not found!"
-msgstr "Bauteil %s nicht gefunden."
+msgstr "Bauteil '%s' nicht gefunden."
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:392
 msgid "Illegal reference. A reference must start with a letter"
@@ -7629,23 +7629,21 @@ msgstr ""
 "Kann das Bauteil nicht aktualieseren"
 
 #: eeschema/dialogs/dialog_erc_base.cpp:40
-#, fuzzy
 msgid "ERC Report:"
-msgstr "ERC Bericht"
+msgstr "ERC Bericht:"
 
+# No translation needed
 #: eeschema/dialogs/dialog_erc_base.cpp:45
 msgid "Total:"
 msgstr ""
 
 #: eeschema/dialogs/dialog_erc_base.cpp:52
-#, fuzzy
 msgid "Warnings:"
-msgstr "Warnung"
+msgstr "Warnungen:"
 
 #: eeschema/dialogs/dialog_erc_base.cpp:59
-#, fuzzy
 msgid "Errors:"
-msgstr "Fehler"
+msgstr "Fehler:"
 
 #: eeschema/dialogs/dialog_erc_base.cpp:69
 msgid "Create ERC file report"
@@ -7656,9 +7654,8 @@ msgid "Error list:"
 msgstr "Fehlerliste:"
 
 #: eeschema/dialogs/dialog_erc_base.cpp:103
-#, fuzzy
 msgid "&Delete Markers"
-msgstr "Entferne Marker"
+msgstr "&Entferne Marker"
 
 #: eeschema/dialogs/dialog_erc_base.cpp:106
 msgid "&Run"
@@ -7668,18 +7665,20 @@ msgstr "&Starte"
 msgid "&Close"
 msgstr "&Abbrechen"
 
+# No translation needed
 #: eeschema/dialogs/dialog_erc_base.cpp:120
 msgid "ERC"
-msgstr "ERC"
+msgstr ""
 
 #: eeschema/dialogs/dialog_erc_base.cpp:125
 #: gerbview/dialogs/dialog_layers_select_to_pcb_base.cpp:86
 msgid "Reset"
 msgstr "Rücksetzen"
 
+# No translation needed.
 #: eeschema/dialogs/dialog_edit_label_base.cpp:25
 msgid "&Text:"
-msgstr "&Text:"
+msgstr ""
 
 #: eeschema/dialogs/dialog_edit_label_base.cpp:27
 msgid "Enter the text to be used within the schematic"
@@ -7734,8 +7733,8 @@ msgid ""
 "If not checked pins names and pins numbers are outside."
 msgstr ""
 "Wähle diese Option für Pinnamen innerhalb des Gehäuses und Pinnummern "
-"ausserhalb.\n"
-"Wenn nicht ausgewählt, befinden sich Pinnamen und -nummern ausserhalb."
+"außerhalb.\n"
+"Wenn nicht ausgewählt, befinden sich Pinnamen und -nummern außerhalb."
 
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:65
 msgid "Number of Units"
@@ -7763,12 +7762,11 @@ msgstr ""
 
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:98
 msgid "Define as power symbol"
-msgstr "Als Spannungsquellensymbol definieren"
+msgstr "Als Symbol für eine Spannungsquelle definieren"
 
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:99
 msgid "Check this option when the component is a power symbol"
-msgstr ""
-"Wähle diese Option, wenn das Bauteil einem Spannungsquellensymbol entspricht"
+msgstr "Wähle diese Option, wenn das Bauteil einer Spannungsquelle entspricht"
 
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:103
 msgid "All units are not interchangeable"
@@ -7870,31 +7868,32 @@ msgid "Unzip Project"
 msgstr "Projektdateien entpacken"
 
 #: kicad/files-io.cpp:76
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "\n"
 "Open '%s'\n"
 msgstr ""
 "\n"
-"Öffne <%s>\n"
+"Öffne '%s'\n"
 
 #: kicad/files-io.cpp:79
 msgid "Target Directory"
 msgstr "Zielverzeichnis"
 
 #: kicad/files-io.cpp:85
-#, fuzzy, c-format
+#, c-format
 msgid "Unzipping project in '%s'\n"
-msgstr "Entpacke Projekt nach <%s>\n"
+msgstr "Entpacke Projekt nach '%s'\n"
 
 #: kicad/files-io.cpp:107
-#, fuzzy, c-format
+#, c-format
 msgid "Extract file '%s'"
-msgstr "Extrahiere Datei <%s>"
+msgstr "Extrahiere Datei '%s'"
 
+# No translation needed
 #: kicad/files-io.cpp:117
 msgid " OK\n"
-msgstr " OK\n"
+msgstr ""
 
 #: kicad/files-io.cpp:120
 msgid " *ERROR*\n"
@@ -7948,9 +7947,9 @@ msgid "Permission error ?"
 msgstr "Möglicherweise aufgrund von fehlenden Zugriffsrechten?"
 
 #: kicad/class_treeproject_item.cpp:137
-#, fuzzy, c-format
+#, c-format
 msgid "Do you really want to delete '%s'"
-msgstr "Möchten Sie wirklich <%s> löschen?"
+msgstr "Möchten Sie wirklich '%s' löschen?"
 
 #: kicad/class_treeproject_item.cpp:142
 msgid "Delete File"
@@ -8005,7 +8004,7 @@ msgstr ""
 msgid "Problem whilst creating new project from template!"
 msgstr ""
 "Bei dem Versuch ein neues Projekt aus der Vorlage zu erstellen ist ein "
-"Problem aufgetreten"
+"Problem aufgetreten!"
 
 #: kicad/prjconfig.cpp:155
 msgid "Template Error"
@@ -8037,9 +8036,8 @@ msgid "KiCad project file '%s' not found"
 msgstr "KiCad Projektdatei %s konnte nicht gefunden werden."
 
 #: kicad/prjconfig.cpp:304
-#, fuzzy
 msgid "New Project Folder"
-msgstr "Projektdatei speichern"
+msgstr "Neuer Projektordner"
 
 #: kicad/menubar.cpp:206
 msgid "&Open Project"
@@ -8058,14 +8056,12 @@ msgid "&New Project"
 msgstr "&Neues Projekt"
 
 #: kicad/menubar.cpp:226
-#, fuzzy
 msgid "Create new blank project"
-msgstr "Ein leeres Projekt erstellen"
+msgstr "Neues leeres Projekt erstellen"
 
 #: kicad/menubar.cpp:229
-#, fuzzy
 msgid "New Project from &Template"
-msgstr "Projekt aus einer &Vorlage\tStrg+T"
+msgstr "Projekt aus einer &Vorlage"
 
 #: kicad/menubar.cpp:232
 msgid "Create a new project from a template"
@@ -8165,29 +8161,24 @@ msgid "PDF viewer preferences"
 msgstr "Einstellungen für PDF-Betrachter"
 
 #: kicad/menubar.cpp:352
-#, fuzzy
 msgid "Run Eeschema"
-msgstr "Eeschema beenden"
+msgstr "Eeschema starten"
 
 #: kicad/menubar.cpp:356
-#, fuzzy
 msgid "Run Library Editor"
-msgstr "Bibliothekseditor"
+msgstr "Bibliothekseditor starten"
 
 #: kicad/menubar.cpp:366
-#, fuzzy
 msgid "Run Footprint Editor"
-msgstr "Footprinteditor"
+msgstr "Footprinteditor starten"
 
 #: kicad/menubar.cpp:371
-#, fuzzy
 msgid "Run Gerbview"
-msgstr "GerbView beenden"
+msgstr "GerbView starten"
 
 #: kicad/menubar.cpp:376
-#, fuzzy
 msgid "Run Bitmap2Component"
-msgstr "Bauteil editieren"
+msgstr "Bitmap2Component starten"
 
 #: kicad/menubar.cpp:379 kicad/commandframe.cpp:86
 msgid ""
@@ -8198,27 +8189,24 @@ msgstr ""
 "von Eeschema oder Pcbnew"
 
 #: kicad/menubar.cpp:383
-#, fuzzy
 msgid "Run Pcb Calculator"
-msgstr "Pcb calculator"
+msgstr "Pcb Kalkulator starten"
 
 #: kicad/menubar.cpp:385 kicad/commandframe.cpp:90
 msgid "Pcb calculator - Calculator for components, track width, etc."
 msgstr ""
-"Pcb calculator - Taschenrechner für Bauelemente, Leiterbahnbreiten und "
+"Pcb Kalkulator - Taschenrechner für Bauelemente, Leiterbahnbreiten und "
 "Weiteres"
 
 #: kicad/menubar.cpp:388
-#, fuzzy
 msgid "Run Page Layout Editor"
-msgstr "Seitenlayoutbeschreibungsdatei"
+msgstr "Seitenlayout Editor starten"
 
 #: kicad/menubar.cpp:390 kicad/commandframe.cpp:93
 msgid "Pl editor - Worksheet layout editor"
-msgstr "Pl editor - Editor für Schaltplanlayouts"
+msgstr "Pl editor - Editor für Schaltplanlayouts (Platinenlayouts)"
 
 #: kicad/menubar.cpp:401
-#, fuzzy
 msgid "KiCad &Manual"
 msgstr "Das &KiCad-Benutzerhandbuch"
 
@@ -8255,9 +8243,8 @@ msgid "Eeschema - Electronic schematic editor"
 msgstr "Eeschema - Schaltplaneditor"
 
 #: kicad/commandframe.cpp:70
-#, fuzzy
 msgid "Schematic library editor"
-msgstr "Bibliothekseditor"
+msgstr "Schaltplaneditor"
 
 #: kicad/commandframe.cpp:73
 msgid "CvPcb - Associate footprint to components"
@@ -8268,20 +8255,21 @@ msgid "Pcbnew - Printed circuit board editor"
 msgstr "Pcbnew - Designer für gedruckte Leiterplatten"
 
 #: kicad/commandframe.cpp:79
-#, fuzzy
 msgid "PCB footprint editor"
-msgstr "Den Footprinteditor schließen"
+msgstr "PCB Footprinteditor"
 
 #: kicad/commandframe.cpp:82
 msgid "GerbView - Gerber viewer"
 msgstr "GerbView  - Betrachter für Gerberdaten"
 
 #: kicad/tree_project_frame.cpp:218
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "Current project directory:\n"
 "%s"
-msgstr "Speichere aktuelles Projekt"
+msgstr ""
+"Aktuelles Projektverzeichnis:\n"
+"%s"
 
 #: kicad/tree_project_frame.cpp:219
 msgid "Create New Directory"
@@ -8324,9 +8312,9 @@ msgid "&Delete File"
 msgstr "Datei &löschen"
 
 #: kicad/tree_project_frame.cpp:749
-#, fuzzy, c-format
+#, c-format
 msgid "Change filename: '%s'"
-msgstr "Dateinamen ändern: <%s>"
+msgstr "Dateinamen ändern: '%s'"
 
 #: kicad/tree_project_frame.cpp:752
 msgid "Change filename"
@@ -8340,7 +8328,7 @@ msgstr ""
 
 #: kicad/preferences.cpp:78
 msgid "Executable files ("
-msgstr "Ausführbare Dateien ( "
+msgstr "Ausführbare Dateien ("
 
 #: kicad/preferences.cpp:83
 msgid "Select Preferred Pdf Browser"
@@ -8356,9 +8344,9 @@ msgid "Visibles"
 msgstr "Sichtbarkeit"
 
 #: pcbnew/pcbframe.cpp:611
-#, fuzzy, c-format
+#, c-format
 msgid "The auto save file '%s' could not be removed!"
-msgstr "Die automatisch gespeicherte Datei <%s> konnte nicht gelöscht werden!"
+msgstr "Die automatisch gespeicherte Datei '%s' konnte nicht gelöscht werden!"
 
 #: pcbnew/pcbframe.cpp:959
 msgid " [new file]"
@@ -8386,7 +8374,7 @@ msgstr "Micro Durchkontaktierungen"
 
 #: pcbnew/class_pcb_layer_widget.cpp:62
 msgid "Show micro vias"
-msgstr "Zeige Micro-Durchkontaktierungen"
+msgstr "Zeige Micro Durchkontaktierungen"
 
 #: pcbnew/class_pcb_layer_widget.cpp:63
 msgid "Non Plated"
@@ -8466,18 +8454,16 @@ msgid "Show a marker on pads which have no net connected"
 msgstr "Marker an Pads anzeigen, welche an keinem Netz angeschlossen sind"
 
 #: pcbnew/class_pcb_layer_widget.cpp:76
-#, fuzzy
 msgid "Footprints Front"
-msgstr "Footprinttest"
+msgstr "Footprints Vorderseite"
 
 #: pcbnew/class_pcb_layer_widget.cpp:76
 msgid "Show footprints that are on board's front"
 msgstr "Footprints der Platinenvorderseite anzeigen"
 
 #: pcbnew/class_pcb_layer_widget.cpp:77
-#, fuzzy
 msgid "Footprints Back"
-msgstr "Footprints"
+msgstr "Footprints Rückseite"
 
 #: pcbnew/class_pcb_layer_widget.cpp:77
 msgid "Show footprints that are on board's back"
@@ -8505,11 +8491,11 @@ msgstr "Alle Kupferlagen einblenden"
 
 #: pcbnew/class_pcb_layer_widget.cpp:168
 msgid "Hide All Copper Layers But Active"
-msgstr "Alle Kupferlagen, ausser der aktiven, ausblenden"
+msgstr "Alle Kupferlagen, außer der aktiven, ausblenden"
 
 #: pcbnew/class_pcb_layer_widget.cpp:170
 msgid "Always Hide All Copper Layers But Active"
-msgstr "Alle Kupferlagen, ausser der aktiven, ausblenden"
+msgstr "Alle Kupferlagen, außer der aktiven, ausblenden"
 
 #: pcbnew/class_pcb_layer_widget.cpp:172
 msgid "Hide All Copper Layers"
@@ -8571,11 +8557,11 @@ msgstr "Siebdruck auf Platinenrückseite"
 
 #: pcbnew/class_pcb_layer_widget.cpp:371
 msgid "Solder mask on board's front"
-msgstr "Lötstoppmaske auf Platinenvorderseite"
+msgstr "Lötstopmaske auf Platinenvorderseite"
 
 #: pcbnew/class_pcb_layer_widget.cpp:372
 msgid "Solder mask on board's back"
-msgstr "Lötstoppmaske auf Platinenrückseite"
+msgstr "Lötstopmaske auf Platinenrückseite"
 
 #: pcbnew/class_pcb_layer_widget.cpp:373
 msgid "Explanatory drawings"
@@ -8594,29 +8580,24 @@ msgid "Board's perimeter definition"
 msgstr "Definition des Platinenumrisses"
 
 #: pcbnew/class_pcb_layer_widget.cpp:378
-#, fuzzy
 msgid "Board's edge setback outline"
 msgstr "Platinenumrisse"
 
 #: pcbnew/class_pcb_layer_widget.cpp:379
-#, fuzzy
 msgid "Footprint courtyards on board's front"
-msgstr "Footprintpads auf Platinenvorderseite anzeigen"
+msgstr "Footprint Umriss auf Platinenvorderseite"
 
 #: pcbnew/class_pcb_layer_widget.cpp:380
-#, fuzzy
 msgid "Footprint courtyards on board's back"
-msgstr "Zeige Footprintpads auf Platinenrückseite"
+msgstr "Footprint Umriss auf Platinenrückseite"
 
 #: pcbnew/class_pcb_layer_widget.cpp:381
-#, fuzzy
 msgid "Footprint assembly on board's front"
-msgstr "Footprintpads auf Platinenvorderseite anzeigen"
+msgstr "Footprint Montage auf Platinenvorderseite"
 
 #: pcbnew/class_pcb_layer_widget.cpp:382
-#, fuzzy
 msgid "Footprint assembly on board's back"
-msgstr "Zeige Footprintpads auf Platinenrückseite"
+msgstr "Footprint Montage auf Platinenrückseite"
 
 #: pcbnew/footprint_wizard_frame.cpp:120 pcbnew/footprint_wizard.cpp:82
 msgid "Footprint Wizard"
@@ -8649,7 +8630,6 @@ msgid "Show footprint in 3D viewer"
 msgstr "Footprint im 3D Betrachter anzeigen"
 
 #: pcbnew/footprint_wizard_frame.cpp:622
-#, fuzzy
 msgid "Add footprint to board"
 msgstr "Footprint der Platine hinzufügen"
 
@@ -8690,21 +8670,21 @@ msgstr "Netz Name"
 msgid "Net Code"
 msgstr "Netz Code"
 
+# No translation needed
 #: pcbnew/class_netinfo_item.cpp:113 pcbnew/class_board.cpp:945
 #: pcbnew/class_module.cpp:579
 #: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:61
 msgid "Pads"
-msgstr "Pads"
+msgstr ""
 
 #: pcbnew/class_netinfo_item.cpp:133 pcbnew/class_board.cpp:948
 #: pcbnew/dialogs/dialog_global_deletion_base.cpp:68
 msgid "Vias"
-msgstr "Durchkontakt."
+msgstr "Durchkontaktierung"
 
 #: pcbnew/class_netinfo_item.cpp:137
-#, fuzzy
 msgid "Net Length"
-msgstr "Netzlänge:"
+msgstr "Netzlänge"
 
 #: pcbnew/class_netinfo_item.cpp:141
 msgid "On Board"
@@ -8740,14 +8720,12 @@ msgid "Move Exactly"
 msgstr "Exakt verschieben"
 
 #: pcbnew/modedit_onclick.cpp:297
-#, fuzzy
 msgid "Edit Footprint"
-msgstr "Drucke Footprint"
+msgstr "Bearbeite Footprint"
 
 #: pcbnew/modedit_onclick.cpp:300
-#, fuzzy
 msgid "Transform Footprint"
-msgstr "Drucke Footprint"
+msgstr "Transformiere Footprint"
 
 #: pcbnew/modedit_onclick.cpp:308
 msgid "Move Pad"
@@ -8806,19 +8784,16 @@ msgid "Move Edge"
 msgstr "Linie verschieben"
 
 #: pcbnew/modedit_onclick.cpp:405
-#, fuzzy
 msgid "Duplicate Edge"
-msgstr "Fläche duplizieren"
+msgstr "Linie duplizieren"
 
 #: pcbnew/modedit_onclick.cpp:408
-#, fuzzy
 msgid "Move Edge Exactly"
-msgstr "Linie verschieben"
+msgstr "Linie exakt verschieben"
 
 #: pcbnew/modedit_onclick.cpp:411
-#, fuzzy
 msgid "Create Edge Array"
-msgstr "Erstelle neue Bibliothek"
+msgstr "Erstelle ein Linien Array"
 
 #: pcbnew/modedit_onclick.cpp:415
 msgid "Place edge"
@@ -8901,18 +8876,15 @@ msgid "footprint library '%s' cannot be deleted"
 msgstr "Die Footprintbibliothek '%s' konnte nicht gelöscht werden."
 
 #: pcbnew/moduleframe.cpp:521
-#, fuzzy
 msgid "Save the changes to the footprint before closing?"
-msgstr "Möchten Sie die Änderungen am Bauteil vor dem Beenden speichern?"
+msgstr "Möchten Sie die Änderungen am Footprint vor dem Beenden speichern?"
 
 #: pcbnew/moduleframe.cpp:542
-#, fuzzy
 msgid "Library is not set, the footprint could not be saved."
 msgstr ""
 "Bauteil konnte nicht gespeichert werden, da keine Bibliothek eingestellt ist."
 
 #: pcbnew/moduleframe.cpp:761
-#, fuzzy
 msgid "Footprint Editor "
 msgstr "Footprinteditor"
 
@@ -8921,9 +8893,8 @@ msgid "(no active library)"
 msgstr "(keine aktive Bibliothek)"
 
 #: pcbnew/moduleframe.cpp:777
-#, fuzzy
 msgid "Footprint Editor (active library: "
-msgstr "Bauteileeditor (aktive Bibliothek: "
+msgstr "Footprinteditor (aktive Bibliothek: "
 
 #: pcbnew/moduleframe.cpp:870 pcbnew/pcbnew_config.cpp:132
 #, c-format
@@ -8969,23 +8940,24 @@ msgid "Unsupported DRAWSEGMENT type %s"
 msgstr "Nicht unterstützter DRAWSEGMENT Typ %s"
 
 #: pcbnew/specctra_export.cpp:1126
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "Unable to find the next segment with an endpoint of (%s mm, %s mm).\n"
 "Edit Edge.Cuts perimeter graphics, making them contiguous polygons each."
 msgstr ""
 "Konnte das nächste Segment mit dem Endpunkt (%s mm, %s mm) nicht finden.\n"
-"Editiere Edge.Cuts Umfang/Umkreis Grafik, um diese angrenzenden Polygonen zu "
-"machen."
+"Editiere Edge.Cuts Umfang/Umkreis Grafik, um diese zu angrenzenden Polygonen "
+"zu machen."
 
 #: pcbnew/specctra_export.cpp:1245
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "Unable to find the next segment with an endpoint of (%s mm, %s mm).\n"
 "Edit Edge.Cuts interior graphics, making them contiguous polygons each."
 msgstr ""
-"Konnte kein weiteres Segment finden, mit einem Endpunkt von (%s mm, %s mm).\n"
-"???"
+"Konnte das nächste Segment mit dem Endpunkt (%s mm, %s mm) nicht finden.\n"
+"Editiere Edge.Cuts Innenraum Grafik, um diese zu angrenzenden Polygonen zu "
+"machen."
 
 #: pcbnew/specctra_export.cpp:1396
 #, c-format
@@ -9005,8 +8977,10 @@ msgid ""
 "line: %d\n"
 "offset: %d"
 msgstr ""
-"Unzulässige Gleitkommazahl in Datei: <%s>\n"
-"Zeile: %d, Spalte: %d"
+"Unzulässige Gleitkommazahl in\n"
+"Datei: <%s>\n"
+"Zeile: %d\n"
+"Spalte: %d"
 
 #: pcbnew/pcb_parser.cpp:146
 #, c-format
@@ -9016,8 +8990,10 @@ msgid ""
 "line: %d\n"
 "offset: %d"
 msgstr ""
-"Fehlende Gleitkommazahl in Datei: <%s>\n"
-"Zeile: %d, Spalte: %d"
+"Fehlende Gleitkommazahl in\n"
+"Datei: <%s>\n"
+"Zeile: %d\n"
+"Spalte: %d"
 
 #: pcbnew/pcb_parser.cpp:590
 #, c-format
@@ -9025,11 +9001,10 @@ msgid "page type \"%s\" is not valid "
 msgstr "Ungültiger Seitentyp \"%s\""
 
 #: pcbnew/pcb_parser.cpp:822
-#, fuzzy, c-format
+#, c-format
 msgid "Layer '%s' in file '%s' at line %d, is not in fixed layer hash"
 msgstr ""
-"Lage '%s' in Datei <%s>, Zeile %d an Position %d wurde nicht in der "
-"Lagensektion definiert."
+"Lage '%s' in Datei '%s' in Zeile %d wurde nicht in der Lagensektion fixiert."
 
 #: pcbnew/pcb_parser.cpp:855
 #, c-format
@@ -9037,15 +9012,17 @@ msgid "%d is not a valid layer count"
 msgstr "%d ist keine gültige Lagenanzahl"
 
 #: pcbnew/pcb_parser.cpp:886
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "Layer '%s' in file\n"
 "'%s'\n"
 "at line %d, position %d\n"
 "was not defined in the layers section"
 msgstr ""
-"Lage '%s' in Datei <%s>, Zeile %d an Position %d wurde nicht in der "
-"Lagensektion definiert."
+"Lage '%s' in Datei\n"
+"'%s'\n"
+"Zeile %d an Position %d\n"
+"wurde nicht in der Lagensektion definiert."
 
 #: pcbnew/pcb_parser.cpp:1281
 #, c-format
@@ -9068,17 +9045,17 @@ msgstr ""
 #: pcbnew/pcb_parser.cpp:1924
 #, c-format
 msgid "cannot handle module text type %s"
-msgstr "Kann den Bauteiletexttyp %s nicht verarbeiten."
+msgstr "Kann den Bauteil Texttyp %s nicht verarbeiten."
 
 #: pcbnew/pcb_parser.cpp:2875
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "There is a zone that belongs to a not existing net\n"
 "\"%s\"\n"
 "you should verify and edit it (run DRC test)."
 msgstr ""
-"Es ist eine Zone vorhanden, welche einem nicht existierenden Netz (%s) "
-"zugeordnet ist. Dies sollte überprüft werden."
+"Es ist eine Zone vorhanden, welche einem nicht existierenden Netz (%s)\n"
+"zugeordnet ist. Dies sollte überprüft und angepasst werden (DRC Test)."
 
 #: pcbnew/class_drc_item.cpp:43
 msgid "Unconnected pads"
@@ -9137,11 +9114,12 @@ msgstr "Kupferfläche innerhalb einer Kupferfläche"
 
 #: pcbnew/class_drc_item.cpp:77
 msgid "Copper areas intersect or are too close"
-msgstr "Kupferflächen überkreuzen sich oder liegen zu dicht beisammen"
+msgstr "Kupferflächen überschneiden sich oder liegen zu dicht beisammen"
 
 #: pcbnew/class_drc_item.cpp:80
 msgid "Copper area belongs a net which has no pads. This is strange"
 msgstr ""
+"Die Kupferlage gehört einem Netz was keine Pads besitzt. Das ist unüblich."
 
 #: pcbnew/class_drc_item.cpp:83
 msgid "Hole near pad"
@@ -9157,35 +9135,35 @@ msgstr "Zu kleine Leiterbahnbreite"
 
 #: pcbnew/class_drc_item.cpp:89
 msgid "Too small via size"
-msgstr "Zu kleine Grösse für Durchkontaktierung"
+msgstr "Zu kleine Größe für Durchkontaktierung"
 
 #: pcbnew/class_drc_item.cpp:91
 msgid "Too small micro via size"
-msgstr "Zu kleine Grösse für Micro Durchkontaktierung"
+msgstr "Zu kleine Größe für Micro Durchkontaktierung"
 
 #: pcbnew/class_drc_item.cpp:95
 msgid "NetClass Track Width &lt; global limit"
-msgstr "Netzklasse Leiterbahnbreite &lt; Globale Grenzwert"
+msgstr "Netzklasse Leiterbahnbreite &lt; Globaler Grenzwert"
 
 #: pcbnew/class_drc_item.cpp:97
 msgid "NetClass Clearance &lt; global limit"
-msgstr "Netzklasse Abstandsmaß &lt; Globale Grenzwert"
+msgstr "Netzklasse Abstandsmaß &lt; Globaler Grenzwert"
 
 #: pcbnew/class_drc_item.cpp:99
 msgid "NetClass Via Dia &lt; global limit"
-msgstr "Netzklasse DuKo-Durchmesser &lt; Globale Grenzwert"
+msgstr "Netzklasse DuKo-Durchmesser &lt; Globaler Grenzwert"
 
 #: pcbnew/class_drc_item.cpp:101
 msgid "NetClass Via Drill &lt; global limit"
-msgstr "Netzklasse DuKo-Bohrdurchmesser &lt; Globale Grenzwert"
+msgstr "Netzklasse DuKo-Bohrdurchmesser &lt; Globaler Grenzwert"
 
 #: pcbnew/class_drc_item.cpp:103
 msgid "NetClass uVia Dia &lt; global limit"
-msgstr "Netzklasse uDuKo-Durchmesser &lt; Globale Grenzwert"
+msgstr "Netzklasse uDuKo-Durchmesser &lt; Globaler Grenzwert"
 
 #: pcbnew/class_drc_item.cpp:105
 msgid "NetClass uVia Drill &lt; global limit"
-msgstr "Netzklasse uDuKo-Durchmesser &lt; Globale Grenzwert"
+msgstr "Netzklasse uDuKo-Durchmesser &lt; Globaler Grenzwert"
 
 #: pcbnew/class_drc_item.cpp:108
 msgid "Via inside a keepout area"
@@ -9200,19 +9178,16 @@ msgid "Pad inside a keepout area"
 msgstr "Pad innerhalb einer Sperrfläche"
 
 #: pcbnew/class_drc_item.cpp:117
-#, fuzzy
 msgid "Via inside a text"
-msgstr "Durchkontaktierung innerhalb einer Sperrfläche"
+msgstr "Durchkontaktierung innerhalb eines Textes"
 
 #: pcbnew/class_drc_item.cpp:120
-#, fuzzy
 msgid "Track inside a text"
-msgstr "Leiterbahn innerhalb einer Sperrfläche"
+msgstr "Leiterbahn innerhalb eines Textes"
 
 #: pcbnew/class_drc_item.cpp:123
-#, fuzzy
 msgid "Pad inside a text"
-msgstr "Pad innerhalb einer Sperrfläche"
+msgstr "Pad innerhalb eines Textes"
 
 #: pcbnew/toolbars_update_user_interface.cpp:135
 msgid "Disable design rule checking"
@@ -9231,9 +9206,8 @@ msgid "Show board ratsnest"
 msgstr "Netzlinien der Platine einblenden"
 
 #: pcbnew/toolbars_update_user_interface.cpp:155
-#, fuzzy
 msgid "Hide footprint ratsnest"
-msgstr "Footprintnetzlinien einblenden"
+msgstr "Footprintnetzlinien ausblenden"
 
 #: pcbnew/toolbars_update_user_interface.cpp:156
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:105
@@ -9273,9 +9247,8 @@ msgid "High contrast display mode"
 msgstr "Bild in hohem Kontrast darstellen"
 
 #: pcbnew/muonde.cpp:201
-#, fuzzy
 msgid "Length of Trace:"
-msgstr "Länge in Package"
+msgstr "Länge des Traces"
 
 #: pcbnew/muonde.cpp:212
 msgid "Requested length < minimum length"
@@ -9286,9 +9259,8 @@ msgid "Requested length too large"
 msgstr "Gewünschte Länge zu groß"
 
 #: pcbnew/muonde.cpp:232
-#, fuzzy
 msgid "Component Value:"
-msgstr "Bauteilwert"
+msgstr "Bauteilwert:"
 
 #: pcbnew/muonde.cpp:587
 msgid "Gap"
@@ -9307,9 +9279,8 @@ msgid "Create microwave module"
 msgstr "Erstelle Microwave-Bauteil"
 
 #: pcbnew/muonde.cpp:628
-#, fuzzy
 msgid "Angle in degrees:"
-msgstr "Winkel (0.1Grad):"
+msgstr "Winkel in Grad:"
 
 #: pcbnew/muonde.cpp:641
 msgid "Incorrect number, abort"
@@ -9321,7 +9292,7 @@ msgstr "Komplexe Form"
 
 #: pcbnew/muonde.cpp:807
 msgid "Read Shape Description File..."
-msgstr "Lese Form Beschreibungsdatei..."
+msgstr "Lese Form Beschreibungsdatei ..."
 
 #: pcbnew/muonde.cpp:812
 msgid "Symmetrical"
@@ -9345,21 +9316,19 @@ msgstr "Datei nicht gefunden"
 
 #: pcbnew/muonde.cpp:950
 msgid "Shape has a null size!"
-msgstr "Die Form hat eine Grösse von Null!"
+msgstr "Die Form hat eine Größe von Null!"
 
 #: pcbnew/muonde.cpp:956
 msgid "Shape has no points!"
 msgstr "Die Form hat keine Punkte!"
 
 #: pcbnew/muonde.cpp:1050
-#, fuzzy
 msgid "No pad for this footprint"
-msgstr "Kein Pad für dieses Bauteil"
+msgstr "Kein Pad für diesen Footprint"
 
 #: pcbnew/muonde.cpp:1058
-#, fuzzy
 msgid "Only one pad for this footprint"
-msgstr "Nur ein Pad für dieses Bauteil"
+msgstr "Nur ein Pad für diese Footprint"
 
 #: pcbnew/muonde.cpp:1069
 msgid "Gap:"
@@ -9394,7 +9363,6 @@ msgid "Keepout"
 msgstr "Sperrfläche"
 
 #: pcbnew/class_zone.cpp:633
-#, fuzzy
 msgid "<unknown>"
 msgstr "<unbekannt>"
 
@@ -9430,17 +9398,14 @@ msgid "Polygons"
 msgstr "Polygone"
 
 #: pcbnew/class_zone.cpp:663
-#, fuzzy
 msgid "Fill Mode"
 msgstr "Füllmodus"
 
 #: pcbnew/class_zone.cpp:667
-#, fuzzy
 msgid "Hatch Lines"
 msgstr "Schraffurlinien"
 
 #: pcbnew/class_zone.cpp:672
-#, fuzzy
 msgid "Corner Count"
 msgstr "Anzahl Löcher"
 
@@ -9467,32 +9432,31 @@ msgstr "Abbruch\n"
 
 #: pcbnew/drc.cpp:209
 msgid "Pad clearances...\n"
-msgstr "Prüfe Padabstandsflächen...\n"
+msgstr "Prüfe Padabstandsflächen ...\n"
 
 #: pcbnew/drc.cpp:219
 msgid "Track clearances...\n"
-msgstr "Prüfe Leiterbahnabstandsflächen...\n"
+msgstr "Prüfe Leiterbahnabstandsflächen ...\n"
 
 #: pcbnew/drc.cpp:229
 msgid "Fill zones...\n"
-msgstr "Fülle Flächen...\n"
+msgstr "Fülle Flächen ...\n"
 
 #: pcbnew/drc.cpp:239
 msgid "Test zones...\n"
-msgstr "Prüfe Flächenabstände...\n"
+msgstr "Prüfe Flächenabstände ...\n"
 
 #: pcbnew/drc.cpp:250
 msgid "Unconnected pads...\n"
-msgstr "Prüfe nicht angeschlossene Pads...\n"
+msgstr "Prüfe nicht angeschlossene Pads ...\n"
 
 #: pcbnew/drc.cpp:262
 msgid "Keepout areas ...\n"
 msgstr "Sperrflächen ...\n"
 
 #: pcbnew/drc.cpp:272
-#, fuzzy
 msgid "Test texts...\n"
-msgstr "Prüfe Flächenabstände...\n"
+msgstr "Prüfe Flächenabstände ...\n"
 
 #: pcbnew/drc.cpp:285
 msgid "Finished"
@@ -9567,19 +9531,21 @@ msgstr "Kein '%s' Package in Bibliothek '%s'"
 msgid "File '%s' is not readable."
 msgstr "Datei '%s' ist nicht lesbar."
 
+# No translation needed
 #: pcbnew/class_marker_pcb.cpp:97
 msgid "Marker"
-msgstr "Marker"
+msgstr ""
 
 #: pcbnew/class_marker_pcb.cpp:101
 #, c-format
 msgid "ErrType (%d)- %s:"
 msgstr "Fehler (%d) - %s:"
 
+# No translation needed
 #: pcbnew/class_marker_pcb.cpp:134
 #, c-format
 msgid "Marker @(%d,%d)"
-msgstr "Marker @(%d,%d)"
+msgstr ""
 
 #: pcbnew/specctra_import.cpp:84
 msgid "Merge Specctra Session file:"
@@ -9660,14 +9626,13 @@ msgid "Change ALL modules ?"
 msgstr "ALLE Bauteile ändern?"
 
 #: pcbnew/xchgmod.cpp:396
-#, fuzzy, c-format
+#, c-format
 msgid "Change footprint '%s' (from '%s') to '%s'"
 msgstr "Ändere das Bauteil '%s' (von '%s') nach '%s'"
 
 #: pcbnew/xchgmod.cpp:527
-#, fuzzy
 msgid "No footprints!"
-msgstr "Neuer Footprint"
+msgstr "Keine Footprints!"
 
 #: pcbnew/xchgmod.cpp:538
 msgid "Save Component Files"
@@ -9699,9 +9664,9 @@ msgstr ""
 "werden."
 
 #: pcbnew/loadcmp.cpp:438
-#, fuzzy, c-format
+#, c-format
 msgid "Footprints [%d items]"
-msgstr "Footprinttest"
+msgstr "Footprints [%d Elemente]"
 
 #: pcbnew/loadcmp.cpp:455
 msgid "No footprint found."
@@ -9725,9 +9690,9 @@ msgid "Module"
 msgstr "Bauteil"
 
 #: pcbnew/loadcmp.cpp:559
-#, fuzzy, c-format
+#, c-format
 msgid "Footprint '%s' saved"
-msgstr "Footprint %s auf %s"
+msgstr "Footprint '%s' gespeichert"
 
 #: pcbnew/loadcmp.cpp:573
 #, c-format
@@ -9737,16 +9702,15 @@ msgstr "Die Footprintbibliothek '%s' wurde gespeichert als '%s'."
 #: pcbnew/class_mire.cpp:204
 #, c-format
 msgid "Target size %s"
-msgstr "Zielgrösse %s"
+msgstr "Zielgröße %s"
 
 #: pcbnew/class_board.cpp:98
 msgid "This is the default net class."
 msgstr "Dies ist die voreingestellte Netzklasse."
 
 #: pcbnew/class_board.cpp:951
-#, fuzzy
 msgid "Track Segments"
-msgstr "Segment ziehen"
+msgstr "Leiterbahn Segmenten folgen"
 
 #: pcbnew/class_board.cpp:954
 msgid "Nodes"
@@ -9761,9 +9725,8 @@ msgid "Links"
 msgstr "Verbindungen"
 
 #: pcbnew/class_board.cpp:968
-#, fuzzy
 msgid "Connections"
-msgstr "Keine Verbindung"
+msgstr "Verbindungen"
 
 #: pcbnew/class_board.cpp:971 pcbnew/dialogs/dialog_drc_base.cpp:184
 msgid "Unconnected"
@@ -9843,13 +9806,13 @@ msgstr ""
 "gefunden werden. ***\n"
 
 #: pcbnew/class_board.cpp:2611
-#, fuzzy, c-format
+#, c-format
 msgid "* Warning: copper zone (net name '%s'): net has no pad*\n"
-msgstr "*** Warnung: Ungültiges Bauteil '%s' mit Footprint Id '%s'. ***\n"
+msgstr "* Warnung: Kupferzone (Netz Name '%s'): Netz hat kein Pad *\n"
 
 #: pcbnew/build_BOM_from_board.cpp:61
 msgid "Comma separated value files (*.csv)|*.csv"
-msgstr "Comma separated value Dateien (*.csv)|*.csv"
+msgstr "Komma separierte Datei (*.csv)|*.csv"
 
 #: pcbnew/build_BOM_from_board.cpp:86
 msgid "No Modules!"
@@ -9857,7 +9820,7 @@ msgstr "Keine Bauteile!"
 
 #: pcbnew/build_BOM_from_board.cpp:96
 msgid "Save Bill of Materials"
-msgstr "Stückliste speichern"
+msgstr "Stückliste speichern (BOM)"
 
 #: pcbnew/build_BOM_from_board.cpp:109
 #, c-format
@@ -9866,7 +9829,7 @@ msgstr "Konnte Datei <%s> nicht erstellen"
 
 #: pcbnew/build_BOM_from_board.cpp:116
 msgid "Id"
-msgstr "Id"
+msgstr "ID"
 
 #: pcbnew/build_BOM_from_board.cpp:117
 msgid "Designator"
@@ -9894,19 +9857,17 @@ msgid "Reference:"
 msgstr "Referenz:"
 
 #: pcbnew/modules.cpp:66
-#, fuzzy
 msgid "Search for footprint"
 msgstr "Suche Footprint"
 
 #: pcbnew/modules.cpp:264
-#, fuzzy, c-format
+#, c-format
 msgid "Delete Footprint %s (value %s) ?"
-msgstr "Bauteil %s (Wert %s) entfernen?"
+msgstr "Footprint %s (Wert %s) entfernen?"
 
 #: pcbnew/class_drawsegment.cpp:366
-#, fuzzy
 msgid "Drawing"
-msgstr "Zeichnungen"
+msgstr "Zeichnung"
 
 #: pcbnew/class_drawsegment.cpp:370
 msgid "Shape"
@@ -9941,7 +9902,7 @@ msgstr ""
 #: pcbnew/zones_by_polygon.cpp:355 pcbnew/zones_by_polygon.cpp:413
 #: pcbnew/zones_by_polygon.cpp:800
 msgid "Area: DRC outline error"
-msgstr "Bereich: DRC Fehler"
+msgstr "Bereich: DRC Umriss Fehler"
 
 #: pcbnew/zones_by_polygon.cpp:528
 msgid "Error: a keepout area is allowed only on copper layers"
@@ -9956,7 +9917,7 @@ msgstr ""
 #: pcbnew/zones_by_polygon.cpp:734
 msgid "DRC error: closing this area creates a drc error with an other area"
 msgstr ""
-"DRC Fehler: Der Abschluß dieser Fläche erzeugt einen DRC Fehler gegenüber "
+"DRC Fehler: Der Abschluss dieser Fläche erzeugt einen DRC Fehler gegenüber "
 "einer anderen Fläche"
 
 #: pcbnew/onleftclick.cpp:252 pcbnew/tools/drawing_tool.cpp:961
@@ -9969,13 +9930,13 @@ msgid "Tracks on Copper layers only "
 msgstr "Leiterbahnen nur auf Kupferlagen"
 
 #: pcbnew/onleftclick.cpp:335
-#, fuzzy
 msgid "Texts not allowed on Edge Cut layer"
 msgstr "Auf Kupferlagen ist kein Text erlaubt."
 
 #: pcbnew/onleftclick.cpp:384 pcbnew/tools/drawing_tool.cpp:320
 msgid "Dimension not allowed on Copper or Edge Cut layers"
-msgstr "Auf Kupferlagen sind keine Bemaßungen erlaubt."
+msgstr ""
+"Auf Kupferlagen und der Lage der Außenkanten sind keine Bemaßungen erlaubt."
 
 #: pcbnew/tool_pcb.cpp:50
 msgid ""
@@ -10003,14 +9964,12 @@ msgid "Page settings for paper size and texts"
 msgstr "Einstellungen für Seitengrösse und dargestellte Texte"
 
 #: pcbnew/tool_pcb.cpp:233
-#, fuzzy
 msgid "Open footprint editor"
-msgstr "Den Footprinteditor schließen"
+msgstr "Den Footprinteditor öffnen"
 
 #: pcbnew/tool_pcb.cpp:237 pcbnew/tool_modedit.cpp:65
-#, fuzzy
 msgid "Open footprint viewer"
-msgstr "Footprintbetrachter"
+msgstr "Den Footprintbetrachter öffnen"
 
 #: pcbnew/tool_pcb.cpp:247 pcbnew/menubar_pcbframe.cpp:237
 msgid "Print board"
@@ -10029,7 +9988,6 @@ msgid "Perform design rules check"
 msgstr "Design Rules Check ausführen"
 
 #: pcbnew/tool_pcb.cpp:293
-#, fuzzy
 msgid "Mode footprint: manual and automatic movement and placement"
 msgstr ""
 "Footprint-Modus für manuelles und automatisches Verschieben und Platzieren "
@@ -10040,7 +9998,6 @@ msgid "Mode track: autorouting"
 msgstr "Leiterbahn-Modus für das automatische Routing"
 
 #: pcbnew/tool_pcb.cpp:302
-#, fuzzy
 msgid "Fast access to the FreeROUTE external advanced router"
 msgstr ""
 "Schneller Zugriff auf webbasierten und fortschrittlichen Router namens "
@@ -10051,9 +10008,8 @@ msgid "Show/Hide the Python Scripting console"
 msgstr "Python Skriptkonsole ein-/ausblenden"
 
 #: pcbnew/tool_pcb.cpp:352
-#, fuzzy
 msgid "Show footprint ratsnest when moving"
-msgstr "Netzlinien während des Verschiebens eines Bauteils anzeigen"
+msgstr "Footprint Netzlinien anzeigen beim Bewegen"
 
 #: pcbnew/tool_pcb.cpp:358
 msgid "Enable automatic track deletion"
@@ -10069,7 +10025,7 @@ msgstr "Flächenumrisse nur innerhalb von Füllflächen einblenden"
 
 #: pcbnew/tool_pcb.cpp:387 pcbnew/tool_modedit.cpp:239
 msgid "Enable high contrast display mode"
-msgstr "Bild in hohem Kontrast darstellen"
+msgstr "Bild mit hohem Kontrast darstellen"
 
 #: pcbnew/tool_pcb.cpp:427 pcbnew/edit.cpp:1493
 msgid "Highlight net"
@@ -10116,15 +10072,15 @@ msgstr "Grafischen Kreisbogen hinzufügen"
 
 #: pcbnew/tool_pcb.cpp:458 pcbnew/menubar_pcbframe.cpp:399
 msgid "Add text on copper layers or graphic text"
-msgstr "Text einer Kupferlage hinzufügen"
+msgstr "Text oder Grafik einer Kupferlage hinzufügen"
 
-#: pcbnew/tool_pcb.cpp:462 pcbnew/menubar_pcbframe.cpp:417
-#: pcbnew/edit.cpp:1485 pcbnew/tools/drawing_tool.cpp:260
+#: pcbnew/tool_pcb.cpp:462 pcbnew/menubar_pcbframe.cpp:417 pcbnew/edit.cpp:1485
+#: pcbnew/tools/drawing_tool.cpp:260
 msgid "Add dimension"
 msgstr "Bemaßung hinzufügen"
 
-#: pcbnew/tool_pcb.cpp:465 pcbnew/menubar_pcbframe.cpp:421
-#: pcbnew/edit.cpp:1453 pcbnew/tools/drawing_tool.cpp:463
+#: pcbnew/tool_pcb.cpp:465 pcbnew/menubar_pcbframe.cpp:421 pcbnew/edit.cpp:1453
+#: pcbnew/tools/drawing_tool.cpp:463
 msgid "Add layer alignment target"
 msgstr "Orientierungspunkt hinzufügen"
 
@@ -10162,7 +10118,7 @@ msgstr ""
 
 #: pcbnew/tool_pcb.cpp:524
 msgid "Create a polynomial shape for microwave applications"
-msgstr "Polynimische Form für Mikrowellen-Applikationen erstellen"
+msgstr "Polynomische Form für Mikrowellen-Applikationen erstellen"
 
 #: pcbnew/tool_pcb.cpp:591
 msgid ""
@@ -10173,31 +10129,37 @@ msgstr ""
 "Breite einer bestehenden Leiterbahn verwenden oder aus den aktuellen "
 "Einstellungen."
 
+# No translation needed
 #: pcbnew/tool_pcb.cpp:639
 #, c-format
 msgid "Track: %.3f mm (%.2f mils)"
 msgstr ""
 
+# No translation needed
 #: pcbnew/tool_pcb.cpp:642
 #, c-format
 msgid "Track: %.2f mils (%.3f mm)"
 msgstr ""
 
+# No translation needed
 #: pcbnew/tool_pcb.cpp:677
 #, c-format
 msgid "Via: %.2f mm (%.1f mils)"
 msgstr ""
 
+# No translation needed
 #: pcbnew/tool_pcb.cpp:680
 #, c-format
 msgid "Via: %.1f mils (%.2f mm)"
 msgstr ""
 
+# No translation needed
 #: pcbnew/tool_pcb.cpp:693
 #, c-format
 msgid "%.2f mm (%.1f mils)"
 msgstr ""
 
+# No translation needed
 #: pcbnew/tool_pcb.cpp:696
 #, c-format
 msgid "%.1f mils (%.2f mm)"
@@ -10213,7 +10175,7 @@ msgstr "Platinendatei öffnen"
 
 #: pcbnew/files.cpp:159
 msgid "Save Board File As"
-msgstr "Platinendatei speichern unter..."
+msgstr "Platinendatei speichern unter ..."
 
 #: pcbnew/files.cpp:184
 #, c-format
@@ -10245,9 +10207,9 @@ msgid "noname"
 msgstr "namenlos"
 
 #: pcbnew/files.cpp:402
-#, fuzzy, c-format
+#, c-format
 msgid "PCB file '%s' is already open."
-msgstr "Diese Datei ist bereits geöffnet."
+msgstr "Die PCB Datei '%s' ist bereits geöffnet."
 
 #: pcbnew/files.cpp:412
 msgid "The current board has been modified.  Do you wish to save the changes?"
@@ -10258,7 +10220,7 @@ msgstr ""
 #: pcbnew/files.cpp:438
 #, c-format
 msgid "Board '%s' does not exist.  Do you wish to create it?"
-msgstr ""
+msgstr "Die Platine '%s' existiert nicht. Möchten Sie diese erstellen?"
 
 #: pcbnew/files.cpp:534
 msgid ""
@@ -10269,38 +10231,38 @@ msgstr ""
 "Wenn Sie die Datei erneut speichern wird diese im neuen Dateiformat angelegt."
 
 #: pcbnew/files.cpp:632
-#, fuzzy, c-format
+#, c-format
 msgid "Warning: unable to create backup file '%s'"
-msgstr "Achtung: Konnte Wiederherstellungsdatei nicht erstellen"
+msgstr "Achtung: Konnte Wiederherstellungsdatei '%s' nicht erstellen"
 
 #: pcbnew/files.cpp:659 pcbnew/files.cpp:754
-#, fuzzy, c-format
+#, c-format
 msgid "No access rights to write to file '%s'"
-msgstr "Ein Fehler ist beim Schreiben von Datei <%s> aufgetreten."
+msgstr "Keine Zugriffsrechte um Datei '%s' schreiben zu können."
 
 #: pcbnew/files.cpp:700 pcbnew/files.cpp:780
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "Error saving board file '%s'.\n"
 "%s"
 msgstr ""
-"Fehler beim Speichern der Platine.\n"
+"Fehler beim Speichern der Platine '%s'.\n"
 "%s"
 
 #: pcbnew/files.cpp:706
-#, fuzzy, c-format
+#, c-format
 msgid "Failed to create '%s'"
-msgstr "Konnte Datei nicht erstellen"
+msgstr "Konnte Datei '%s' nicht erstellen"
 
 #: pcbnew/files.cpp:732
-#, fuzzy, c-format
+#, c-format
 msgid "Backup file: '%s'"
-msgstr "Wiederherstellungsdatei:"
+msgstr "Wiederherstellungsdatei: '%s'"
 
 #: pcbnew/files.cpp:734
-#, fuzzy, c-format
+#, c-format
 msgid "Wrote board file: '%s'"
-msgstr "Platinendatei geschrieben:"
+msgstr "Platinendatei geschrieben: '%s'"
 
 #: pcbnew/files.cpp:789
 #, c-format
@@ -10308,6 +10270,8 @@ msgid ""
 "Board copied to:\n"
 "'%s'"
 msgstr ""
+"Platine kopiert nach:\n"
+"'%s'"
 
 #: pcbnew/hotkeys_board_editor.cpp:62
 #, c-format
@@ -10357,9 +10321,8 @@ msgid "Save footprint in active library"
 msgstr "Footprint in aktiver Bibliothek speichern"
 
 #: pcbnew/tool_modedit.cpp:62
-#, fuzzy
 msgid "Create new library and save current footprint"
-msgstr "Neue Bibliothek erstellen und aktuelles Bauteil speichern"
+msgstr "Neue Bibliothek erstellen und aktuellen Footprint speichern"
 
 #: pcbnew/tool_modedit.cpp:69
 msgid "Delete part from active library"
@@ -10371,37 +10334,30 @@ msgid "New footprint"
 msgstr "Neuer Footprint"
 
 #: pcbnew/tool_modedit.cpp:78
-#, fuzzy
 msgid "New footprint using wizard"
-msgstr "Footprint der Platine hinzufügen"
+msgstr "Neuen Footprint mittels Wizard"
 
 #: pcbnew/tool_modedit.cpp:84
-#, fuzzy
 msgid "Load footprint from library"
-msgstr "Bauteilfootprint aus einer Bibliothek öffnen"
+msgstr "Bauteilfootprint aus einer Bibliothek laden"
 
 #: pcbnew/tool_modedit.cpp:89
-#, fuzzy
 msgid "Load footprint from current board"
-msgstr "Bauteilfootprint von aktueller Plaine laden"
+msgstr "Footprint von aktueller Plaine laden"
 
 #: pcbnew/tool_modedit.cpp:93
-#, fuzzy
 msgid "Update footprint in current board"
-msgstr "Bauteil auf aktueller Platine aktualisieren"
+msgstr "Footprint in aktueller Platine aktualisieren"
 
 #: pcbnew/tool_modedit.cpp:97
-#, fuzzy
 msgid "Insert footprint into current board"
-msgstr "Footprint der Platine hinzufügen"
+msgstr "Footprint in aktueller Platine hinzufügen"
 
 #: pcbnew/tool_modedit.cpp:101
-#, fuzzy
 msgid "Import footprint"
 msgstr "Footprint importieren"
 
 #: pcbnew/tool_modedit.cpp:104
-#, fuzzy
 msgid "Export footprint"
 msgstr "Footprint exportieren"
 
@@ -10410,12 +10366,10 @@ msgid "Undo last edition"
 msgstr "Letzte Änderung rückgängig machen"
 
 #: pcbnew/tool_modedit.cpp:116
-#, fuzzy
 msgid "Footprint properties"
-msgstr "Footprint Texteigenschaften"
+msgstr "Footprint Eigenschaften"
 
 #: pcbnew/tool_modedit.cpp:120
-#, fuzzy
 msgid "Print footprint"
 msgstr "Drucke Footprint"
 
@@ -10424,9 +10378,8 @@ msgid "Pad settings"
 msgstr "Pad Einstellungen"
 
 #: pcbnew/tool_modedit.cpp:143
-#, fuzzy
 msgid "Check footprint"
-msgstr "Neuer Footprint"
+msgstr "Footprint überprüfen"
 
 #: pcbnew/tool_modedit.cpp:164 pcbnew/tools/module_tools.cpp:87
 msgid "Add pads"
@@ -10437,9 +10390,8 @@ msgid "Add Text"
 msgstr "Text hinzufügen"
 
 #: pcbnew/tool_modedit.cpp:181
-#, fuzzy
 msgid "Place the footprint reference anchor"
-msgstr "Referenzpunkt für Bauteilfootprint setzen"
+msgstr "Referenzpunkt für Footprint Anker setzen"
 
 #: pcbnew/tool_modedit.cpp:210
 msgid "Display Polar Coord ON"
@@ -10459,7 +10411,7 @@ msgstr "Text als Umriss darstellen"
 
 #: pcbnew/tool_modedit.cpp:235
 msgid "Show Edges Sketch"
-msgstr "Linien als Umriss darstellen"
+msgstr "Außenkante als Umriss darstellen"
 
 #: pcbnew/modview_frame.cpp:104
 msgid "Footprint Library Browser"
@@ -10499,7 +10451,7 @@ msgstr "&Öffnen"
 
 #: pcbnew/menubar_pcbframe.cpp:74
 msgid "Delete current board and load new board"
-msgstr "Aktuelle Platine entfernen und eine bestehende öffnen"
+msgstr "Aktuelle Platine entfernen und eine neue öffnen"
 
 #: pcbnew/menubar_pcbframe.cpp:95
 msgid "Open a recent opened board"
@@ -10510,11 +10462,12 @@ msgid "&Append Board"
 msgstr "Platine &hinzufügen..."
 
 #: pcbnew/menubar_pcbframe.cpp:101
-#, fuzzy
 msgid ""
 "Append another Pcbnew board to the current loaded board. Available only when "
 "Pcbnew runs in stand alone mode"
-msgstr "Eine andere Pcbnew-Platine der gegenwärtigen hinzufügen"
+msgstr ""
+"Eine andere Pcbnew-Platine der gegenwärtigen hinzufügen. Nur möglich wen "
+"Pcbnew im Einzelmodus läuft."
 
 #: pcbnew/menubar_pcbframe.cpp:111
 msgid "Save current board"
@@ -10526,16 +10479,15 @@ msgstr "Speichern &unter..."
 
 #: pcbnew/menubar_pcbframe.cpp:123
 msgid "Save the current board as..."
-msgstr "Aktuelle Platine speichern unter..."
+msgstr "Aktuelle Platine speichern unter ..."
 
 #: pcbnew/menubar_pcbframe.cpp:130
 msgid "Sa&ve Copy As..."
-msgstr "Kopie Speichern &unter..."
+msgstr "Kopie Speichern &unter ..."
 
 #: pcbnew/menubar_pcbframe.cpp:132
-#, fuzzy
 msgid "Save a copy of the current board as..."
-msgstr "Aktuelle Platine speichern unter..."
+msgstr "Aktuelle Platine als Kopie speichern unter ..."
 
 #: pcbnew/menubar_pcbframe.cpp:139
 msgid "Revert to Last"
@@ -10555,12 +10507,10 @@ msgstr ""
 "Platine entfernen und zuletzt gespeicherte Wiederherstellungsdatei öffnen"
 
 #: pcbnew/menubar_pcbframe.cpp:152
-#, fuzzy
 msgid "&Footprint Position (.pos) File"
-msgstr "Bauteile &Positionsdatei (.pos)"
+msgstr "Footprint &Positionsdatei (.pos)"
 
 #: pcbnew/menubar_pcbframe.cpp:153
-#, fuzzy
 msgid "Generate footprint position file for pick and place"
 msgstr "Datei mit Bauteilepositionen für Bauteileplatzierung erstellen"
 
@@ -10573,14 +10523,12 @@ msgid "Generate excellon2 drill file"
 msgstr "Excellon2 Bohrdatei erstellen"
 
 #: pcbnew/menubar_pcbframe.cpp:162
-#, fuzzy
 msgid "&Footprint (.rpt) Report"
-msgstr "Bauteile &Reportdatei (.rpt)"
+msgstr "Footprint &Reportdatei (.rpt)"
 
 #: pcbnew/menubar_pcbframe.cpp:163
-#, fuzzy
 msgid "Create a report of all footprints on the current board"
-msgstr "Eine Zusammenfassung aller Bauteile der aktuellen Platine erstellen"
+msgstr "Eine Zusammenfassung aller Footprints der aktuellen Platine erstellen"
 
 #: pcbnew/menubar_pcbframe.cpp:167
 msgid "IPC-D-356 Netlist File"
@@ -10604,7 +10552,7 @@ msgstr "&BOM Datei"
 
 #: pcbnew/menubar_pcbframe.cpp:178
 msgid "Create a bill of materials from schematic"
-msgstr "Aus dem Schaltplan eine Stückliste erstellen"
+msgstr "Aus dem Schaltplan eine Stückliste erstellen (BOM)"
 
 #: pcbnew/menubar_pcbframe.cpp:182
 msgid "&Fabrication Outputs"
@@ -10614,9 +10562,10 @@ msgstr "&Fertigungsdateien"
 msgid "Generate files for fabrication"
 msgstr "Dateien für die Herstellung erstellen"
 
+# No translation needed
 #: pcbnew/menubar_pcbframe.cpp:190
 msgid "&Specctra Session"
-msgstr "&Specctra Session"
+msgstr ""
 
 #: pcbnew/menubar_pcbframe.cpp:191
 msgid "Import a routed \"Specctra Session\" (*.ses) file"
@@ -10640,33 +10589,37 @@ msgstr "&Importieren"
 msgid "Import files"
 msgstr "Dateien importieren"
 
+# No translation needed
 #: pcbnew/menubar_pcbframe.cpp:208
 msgid "&Specctra DSN"
-msgstr "&Specctra DSN"
+msgstr ""
 
 #: pcbnew/menubar_pcbframe.cpp:209
 msgid "Export the current board to a \"Specctra DSN\" file"
 msgstr "Die aktuelle Platine in eine \"Specctra DSN\" Datei exportieren"
 
+# No translation needed
 #: pcbnew/menubar_pcbframe.cpp:213
 msgid "&GenCAD"
-msgstr "&GenCAD"
+msgstr ""
 
 #: pcbnew/menubar_pcbframe.cpp:213
 msgid "Export GenCAD format"
 msgstr "GenCAD Format exportieren"
 
+# No translation needed
 #: pcbnew/menubar_pcbframe.cpp:217
 msgid "&VRML"
-msgstr "&VRML"
+msgstr ""
 
 #: pcbnew/menubar_pcbframe.cpp:218
 msgid "Export a VRML board representation"
 msgstr "Eine VRML Platinendarstellung exportieren"
 
+# No translation needed
 #: pcbnew/menubar_pcbframe.cpp:222
 msgid "I&DFv3 Export"
-msgstr "I&DFv3"
+msgstr ""
 
 #: pcbnew/menubar_pcbframe.cpp:222
 msgid "IDFv3 board and component export"
@@ -10682,7 +10635,7 @@ msgstr "Platine exportieren"
 
 #: pcbnew/menubar_pcbframe.cpp:232
 msgid "Page s&ettings"
-msgstr "Seite ein&richten..."
+msgstr "Seite ein&richten"
 
 #: pcbnew/menubar_pcbframe.cpp:237 pcbnew/menubar_modedit.cpp:141
 #: gerbview/menubar.cpp:135
@@ -10743,9 +10696,8 @@ msgid "&Global Deletions"
 msgstr "&Globales Entfernen"
 
 #: pcbnew/menubar_pcbframe.cpp:297
-#, fuzzy
 msgid "Delete tracks, footprints, texts... on board"
-msgstr "Leiterbahnen, Bauteile, Texte... auf Platine entfernen"
+msgstr "Leiterbahnen, Bauteile, Texte ... auf Platine entfernen"
 
 #: pcbnew/menubar_pcbframe.cpp:301
 msgid "&Cleanup Tracks and Vias"
@@ -10756,8 +10708,8 @@ msgid ""
 "Clean stubs, vias, delete break points, or connect dangling tracks to pads "
 "and vias"
 msgstr ""
-"Stubs, Vias entfernen, Break Points löschen oder baumelnde Leiterbahnen mit "
-"Pads und Vias verbinden"
+"Stubs, DoKu's entfernen, Break Points löschen oder baumelnde Leiterbahnen "
+"mit Pads und DoKu's verbinden"
 
 #: pcbnew/menubar_pcbframe.cpp:306
 msgid "&Swap Layers"
@@ -10773,10 +10725,9 @@ msgid "&Reset Footprint Field Sizes"
 msgstr "Werte von Footprintfeldern zu&rücksetzen"
 
 #: pcbnew/menubar_pcbframe.cpp:312
-#, fuzzy
 msgid "Reset text size and width of all footprint fields to current defaults"
 msgstr ""
-"Textgrösse und -breite aller Bauteilefelder zu gegenwärtiger Voreinstellung "
+"Textgröße und -breite aller Footprintfelder zu gegenwärtiger Voreinstellung "
 "rücksetzen"
 
 #: pcbnew/menubar_pcbframe.cpp:349
@@ -10809,7 +10760,7 @@ msgstr "Canvas nach Open&GL umschalten"
 
 #: pcbnew/menubar_pcbframe.cpp:369
 msgid "Switch the canvas implementation to OpenGL"
-msgstr "Schaltet die Canvasimplementierung auf OpenGL um"
+msgstr "Schaltet die Canvas Implementierung auf OpenGL um"
 
 #: pcbnew/menubar_pcbframe.cpp:372
 msgid "&Switch canvas to Cairo"
@@ -10817,12 +10768,12 @@ msgstr "Canvas nach &Cairo umschalten"
 
 #: pcbnew/menubar_pcbframe.cpp:376
 msgid "Switch the canvas implementation to Cairo"
-msgstr "Schaltet die Canvasimplementierung auf Cairo um"
+msgstr "Schaltet die Canvas Implementierung auf Cairo um"
 
+# No translation needed
 #: pcbnew/menubar_pcbframe.cpp:382
-#, fuzzy
 msgid "&Footprint"
-msgstr "Footprint"
+msgstr ""
 
 #: pcbnew/menubar_pcbframe.cpp:387
 msgid "&Track"
@@ -10861,18 +10812,16 @@ msgid "Single Track"
 msgstr "Einzelne Leiterbahn"
 
 #: pcbnew/menubar_pcbframe.cpp:440
-#, fuzzy
 msgid "Interactively route a single track"
-msgstr "Einstellungen des interaktiven Routers"
+msgstr "Interaktives Routen einer einzelnen Leiterbahn"
 
 #: pcbnew/menubar_pcbframe.cpp:444
 msgid "Differential Pair"
-msgstr "Differenzielles Paar"
+msgstr "differenzielles Paar"
 
 #: pcbnew/menubar_pcbframe.cpp:445
-#, fuzzy
 msgid "Interactively route a differential pair"
-msgstr "Werkzeug für interaktiven Router und Drag&Drop."
+msgstr "Interaktives Routen eines differenziellen Paares"
 
 #: pcbnew/menubar_pcbframe.cpp:451 pcbnew/router/router_menus.h:816
 msgid "Tune Track Length"
@@ -10880,23 +10829,23 @@ msgstr "Leiterbahnlänge anpassen"
 
 #: pcbnew/menubar_pcbframe.cpp:452
 msgid "Tune length of a single track"
-msgstr ""
+msgstr "Leiterbahnlänge einer einzelnen Leiterbahn anpassen"
 
 #: pcbnew/menubar_pcbframe.cpp:456
 msgid "Tune Differential Pair Length"
-msgstr "Länge von Differenziellem Paar anpassen"
+msgstr "Länge von differenziellem Signalpaar anpassen"
 
 #: pcbnew/menubar_pcbframe.cpp:457
 msgid "Tune length of a differential pair"
-msgstr ""
+msgstr "Leiterbahnlänge eines differenziellen Signalpaares anpassen"
 
 #: pcbnew/menubar_pcbframe.cpp:461
 msgid "Tune Differential Pair Skew/Phase"
-msgstr "Skew/Phase von  Differenziellem Paar anpassen"
+msgstr "Skew/Phase von  differenziellem Signalpaar anpassen"
 
 #: pcbnew/menubar_pcbframe.cpp:462
 msgid "Tune skew/phase of a differential pair"
-msgstr ""
+msgstr "Anpassen von Versatz und Abstimmung eines differenziellem Signalpaares"
 
 #: pcbnew/menubar_pcbframe.cpp:483 pcbnew/menubar_modedit.cpp:285
 msgid "Li&brary Tables"
@@ -10934,15 +10883,13 @@ msgstr "&Darstellung"
 
 #: pcbnew/menubar_pcbframe.cpp:510
 msgid "Select how items (pads, tracks texts ... ) are displayed"
-msgstr "Wähle wie Elemente (Pads, Leiterbahnentext, ...) dargestellt werden"
+msgstr "Wähle wie Elemente (Pads, Leiterbahnen Text, ...) dargestellt werden"
 
 #: pcbnew/menubar_pcbframe.cpp:514
-#, fuzzy
 msgid "Interactive Routing"
 msgstr "Interaktiver Router"
 
 #: pcbnew/menubar_pcbframe.cpp:515
-#, fuzzy
 msgid "Configure Interactive Routing."
 msgstr "Einstellungen des interaktiven Routers"
 
@@ -10952,7 +10899,7 @@ msgstr "&Raster"
 
 #: pcbnew/menubar_pcbframe.cpp:522
 msgid "Adjust user grid dimensions"
-msgstr "Rastergrösse anpassen"
+msgstr "Benutzerdefinierte Rastergröße anpassen"
 
 #: pcbnew/menubar_pcbframe.cpp:526
 msgid "Te&xts and Drawings"
@@ -10960,23 +10907,24 @@ msgstr "Te&xte und Zeichnungen"
 
 #: pcbnew/menubar_pcbframe.cpp:527
 msgid "Adjust dimensions for texts and drawings"
-msgstr "Grösse für Texte und Zeichnungen anpassen"
+msgstr "Größe für Texte und Zeichnungen anpassen"
 
+# No translation needed
 #: pcbnew/menubar_pcbframe.cpp:531
 msgid "&Pads"
-msgstr "&Pads"
+msgstr ""
 
 #: pcbnew/menubar_pcbframe.cpp:531
 msgid "Adjust default pad characteristics"
-msgstr "Standard Padeigenschaften einstellen"
+msgstr "Standard Pad Eigenschaften einstellen"
 
 #: pcbnew/menubar_pcbframe.cpp:535
 msgid "Pads &Mask Clearance"
-msgstr "Padabstands&maske"
+msgstr "Pad Abstands&maske"
 
 #: pcbnew/menubar_pcbframe.cpp:536
 msgid "Adjust the global clearance between pads and the solder resist mask"
-msgstr "Globale Abstandsflächen zwischen Pads und Lötstoppmaske anpassen"
+msgstr "Globale Abstandsflächen zwischen Pads und Lötstopmaske anpassen"
 
 #: pcbnew/menubar_pcbframe.cpp:540
 msgid "Differential Pairs"
@@ -10984,7 +10932,7 @@ msgstr "Differenzielle Paare"
 
 #: pcbnew/menubar_pcbframe.cpp:541
 msgid "Define the global gap/width for differential pairs."
-msgstr ""
+msgstr "Globalen Abstand/Weite für differenzielle Paare einstellen"
 
 #: pcbnew/menubar_pcbframe.cpp:546
 msgid "Save dimension preferences"
@@ -11030,19 +10978,20 @@ msgstr "&Lagenpaar"
 msgid "Change the active layer pair"
 msgstr "Das aktive Lagenpaar auswählen"
 
+# No translation needed
 #: pcbnew/menubar_pcbframe.cpp:598
 msgid "&DRC"
-msgstr "&DRC"
+msgstr ""
 
+# No translation needed
 #: pcbnew/menubar_pcbframe.cpp:602
 msgid "&FreeRoute"
-msgstr "&FreeRoute"
+msgstr ""
 
 #: pcbnew/menubar_pcbframe.cpp:603
 msgid "Fast access to the Web Based FreeROUTE advanced router"
 msgstr ""
-"Schneller Zugriff auf webbasierten und fortschrittlichen Router namens "
-"FreeROUTE"
+"Schneller Zugriff auf webbasierten und fortschrittlichen Router FreeROUTE"
 
 #: pcbnew/menubar_pcbframe.cpp:608
 msgid "&Scripting Console"
@@ -11077,10 +11026,10 @@ msgstr "&Über Pcbnew"
 msgid "About Pcbnew printed circuit board designer"
 msgstr "Über Pcbnew, Designer für gedruckte Leiterplatten"
 
+# No translation needed
 #: pcbnew/menubar_pcbframe.cpp:648
-#, fuzzy
 msgid "&Route"
-msgstr "&FreeRoute"
+msgstr ""
 
 #: pcbnew/menubar_pcbframe.cpp:650
 msgid "D&imensions"
@@ -11093,7 +11042,7 @@ msgstr "Design &Regeln"
 #: pcbnew/netlist_reader.cpp:100
 #, c-format
 msgid "Cannot open file %s for reading."
-msgstr "Konnte Datei <%s> nicht öffnen."
+msgstr "Konnte Datei '%s' nicht öffnen."
 
 #: pcbnew/netlist_reader.cpp:205
 #, c-format
@@ -11103,39 +11052,38 @@ msgid ""
 "line: %d"
 msgstr ""
 "Unzulässige PFID in\n"
-"Datei: '%s'\n"
+"Datei: <%s>\n"
 "Zeile: %d"
 
 #: pcbnew/legacy_netlist_reader.cpp:121
 msgid "Cannot parse time stamp in component section of netlist."
 msgstr ""
-"Konnte einen Zeitstempel in der Bauteilesektion der Netzliste nicht parsen."
+"Konnte einen Zeitstempel in der Bauteilsektion der Netzliste nicht parsen."
 
 #: pcbnew/legacy_netlist_reader.cpp:131
 msgid "Cannot parse footprint name in component section of netlist."
 msgstr ""
-"Konnte einen Footprintnamen in der Bauteilesektion der Netzliste nicht "
-"parsen."
+"Konnte einen Footprintnamen in der Bauteilsektion der Netzliste nicht parsen."
 
 #: pcbnew/legacy_netlist_reader.cpp:145
 msgid "Cannot parse reference designator in component section of netlist."
 msgstr ""
-"Konnte einen Referenzbezeichner in der Bauteilesektion der Netzliste nicht "
+"Konnte einen Referenzbezeichner in der Bauteilsektion der Netzliste nicht "
 "parsen."
 
 #: pcbnew/legacy_netlist_reader.cpp:155
 msgid "Cannot parse value in component section of netlist."
-msgstr "Konnte einen Wert in der Bauteilesektion der Netzliste nicht parsen."
+msgstr "Konnte einen Wert in der Bauteilsektion der Netzliste nicht parsen."
 
 #: pcbnew/legacy_netlist_reader.cpp:192
 msgid "Cannot parse pin name in component net section of netlist."
 msgstr ""
-"Konnte einen Pinnamen in der Bauteilesektion der Netzliste nicht parsen."
+"Konnte einen Pinnamen in der Bauteilsektion der Netzliste nicht parsen."
 
 #: pcbnew/legacy_netlist_reader.cpp:201
 msgid "Cannot parse net name in component net section of netlist."
 msgstr ""
-"Konnte einen Netznamen in der Bauteilesektion der Netzliste nicht parsen."
+"Konnte einen Netznamen in der Bauteilsektion der Netzliste nicht parsen."
 
 #: pcbnew/legacy_netlist_reader.cpp:249
 #, c-format
@@ -11149,13 +11097,13 @@ msgid "Last Change"
 msgstr "Letzte Änderung"
 
 #: pcbnew/class_module.cpp:565
-#, fuzzy
 msgid "Netlist Path"
-msgstr "Netzlistepfad"
+msgstr "Netzlistenpfad"
 
+# No translation needed
 #: pcbnew/class_module.cpp:589 pcbnew/class_track.cpp:1121
 msgid "Status"
-msgstr "Status"
+msgstr ""
 
 #: pcbnew/class_module.cpp:606
 #: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:98
@@ -11183,9 +11131,9 @@ msgid "Doc: %s"
 msgstr "Beschreibung: %s"
 
 #: pcbnew/class_module.cpp:632
-#, fuzzy, c-format
+#, c-format
 msgid "Key Words: %s"
-msgstr "Schlüsselwörter: "
+msgstr "Schlüsselwörter: %s"
 
 #: pcbnew/class_module.cpp:798
 #, c-format
@@ -11209,14 +11157,12 @@ msgid "Select Net"
 msgstr "Wähle Netz"
 
 #: pcbnew/edgemod.cpp:213
-#, fuzzy
 msgid ""
 "The graphic item will be on a copper layer.\n"
 "This is very dangerous. Are you sure?"
 msgstr ""
-"Das grafische Element wird auf einer Kupferlage sein. Dies ist sehr "
-"gefährlich.\n"
-"Sind Sie sich sicher?"
+"Das grafische Element wird auf einer Kupferlage sein.\n"
+"Dies ist sehr gefährlich. Sind Sie sich sicher?"
 
 #: pcbnew/edgemod.cpp:254
 msgid "New Width:"
@@ -11266,7 +11212,7 @@ msgstr "Über Pcbnew Platinendesigner"
 #: pcbnew/zones_by_polygon_fill_functions.cpp:44
 #, c-format
 msgid "Filling zone %d out of %d (net %s)..."
-msgstr "Fülle Flöche %d von %d (Netz %s)..."
+msgstr "Fülle Fläche %d von %d (Netz %s) ..."
 
 #: pcbnew/zones_by_polygon_fill_functions.cpp:135
 msgid "Fill All Zones"
@@ -11274,11 +11220,11 @@ msgstr "Fülle alle Flächen"
 
 #: pcbnew/zones_by_polygon_fill_functions.cpp:140
 msgid "Starting zone fill..."
-msgstr "Beginne Flächen zu füllen..."
+msgstr "Beginne Flächen zu füllen ..."
 
 #: pcbnew/zones_by_polygon_fill_functions.cpp:168
 msgid "Updating ratsnest..."
-msgstr "Aktualisiere Netzlinien..."
+msgstr "Aktualisiere Netzlinien ..."
 
 #: pcbnew/editrack.cpp:815
 msgid "Track Len"
@@ -11294,7 +11240,7 @@ msgstr "Pad zu Die"
 
 #: pcbnew/editrack.cpp:826
 msgid "Segs Count"
-msgstr "Segm.anzahl"
+msgstr "Segmentanzahl"
 
 #: pcbnew/class_board_item.cpp:43 pcbnew/class_pad.cpp:857
 msgid "Rect"
@@ -11313,9 +11259,10 @@ msgstr "Polygon"
 msgid "Dimension"
 msgstr "Abmessung"
 
+# No translation needed
 #: pcbnew/class_pcb_text.cpp:127
 msgid "PCB Text"
-msgstr "PCB Text"
+msgstr ""
 
 #: pcbnew/class_pcb_text.cpp:140 pcbnew/class_text_mod.cpp:416
 #: pcbnew/dialogs/dialog_edit_module_text_base.cpp:64
@@ -11358,7 +11305,7 @@ msgstr "* Warnung: Bauteil '%s' enthält Footprint '%s', anstelle von '%s'\n"
 #: pcbnew/netlist.cpp:272
 #, c-format
 msgid "*** Warning: Component '%s' footprint ID '%s' is not valid. ***\n"
-msgstr "*** Warnung: Ungültiges Bauteil '%s' mit Footprint Id '%s'. ***\n"
+msgstr "*** Warnung: Ungültiges Bauteil '%s' mit Footprint ID '%s'. ***\n"
 
 #: pcbnew/netlist.cpp:294
 #, c-format
@@ -11383,7 +11330,7 @@ msgid ""
 "Continue ?"
 msgstr ""
 "Durch diese Operation geht der gegenwärtige Footprint verloren,\n"
-"was anschließend nicht mehr rückgäng gemacht werden kann.\n"
+"was anschließend nicht mehr rückgängig gemacht werden kann.\n"
 "Möchten Sie trotzdem fortfahren?"
 
 #: pcbnew/kicad_plugin.cpp:215
@@ -11417,12 +11364,12 @@ msgstr ""
 #: pcbnew/kicad_plugin.cpp:1280 pcbnew/legacy_plugin.cpp:98
 #, c-format
 msgid "unknown pad type: %d"
-msgstr "unbekannter Padtyp: %d"
+msgstr "unbekannter Pad Typ: %d"
 
 #: pcbnew/kicad_plugin.cpp:1293 pcbnew/legacy_plugin.cpp:99
 #, c-format
 msgid "unknown pad attribute: %d"
-msgstr "unbekanntes Padattribut: %d"
+msgstr "unbekanntes Pad Attribut: %d"
 
 #: pcbnew/kicad_plugin.cpp:1475
 #, c-format
@@ -11469,7 +11416,7 @@ msgid ""
 "logging, no need to set a Value."
 msgstr ""
 "Aktiviert das Logging. Diese Option schaltet das Logging ein, so dass kein "
-"Wert gesetzt werden muß."
+"Wert gesetzt werden muss."
 
 #: pcbnew/plugin.cpp:131
 msgid "User name for <b>login</b> to some special library server."
@@ -11493,7 +11440,7 @@ msgid ""
 "Continue?"
 msgstr ""
 "Durch diese Operation gehen die Änderungen am Footprint verloren,\n"
-"was anschließend nicht mehr rückgäng gemacht werden kann.\n"
+"was anschließend nicht mehr rückgängig gemacht werden kann.\n"
 "Möchten Sie trotzdem fortfahren?"
 
 #: pcbnew/modedit.cpp:396
@@ -11545,56 +11492,48 @@ msgid "&New Footprint"
 msgstr "&Neuer Footprint"
 
 #: pcbnew/menubar_modedit.cpp:74
-#, fuzzy
 msgid "Create new footprint"
-msgstr "Aktueller Footprint"
+msgstr "Neuen Footprint erstellen"
 
 #: pcbnew/menubar_modedit.cpp:82
-#, fuzzy
 msgid "&Import Footprint From File"
-msgstr "Bauteil aus einer Datei &importieren"
+msgstr "Footprint aus einer Datei &importieren"
 
 #: pcbnew/menubar_modedit.cpp:83
 msgid "Import footprint from an existing file"
 msgstr "Importiere Bauteilfootprint aus einer bestehenden Datei"
 
 #: pcbnew/menubar_modedit.cpp:88
-#, fuzzy
 msgid "Load Footprint From Current Li&brary"
-msgstr "Bauteil aus aktueller Bi&bliothek laden"
+msgstr "Footprint aus aktueller Bi&bliothek laden"
 
 #: pcbnew/menubar_modedit.cpp:89
-#, fuzzy
 msgid "Open a footprint from library"
 msgstr "Bauteilfootprint aus einer Bibliothek öffnen"
 
 #: pcbnew/menubar_modedit.cpp:94
-#, fuzzy
 msgid "Load Footprint From &Current Board"
-msgstr "Bauteil von aktueller P&latine laden"
+msgstr "Footprint von aktueller P&latine laden"
 
 #: pcbnew/menubar_modedit.cpp:95
-#, fuzzy
 msgid "Load a footprint from the current board"
-msgstr "Bauteilfootprint von aktueller Plaine laden"
+msgstr "Bauteilfootprint von aktueller Platine laden"
 
 #: pcbnew/menubar_modedit.cpp:100
-#, fuzzy
 msgid "&Load Footprint"
-msgstr "Footprint speichern"
+msgstr "Footprint laden"
 
 #: pcbnew/menubar_modedit.cpp:101
-#, fuzzy
 msgid "Load footprint"
-msgstr "Alle Footprints sperren"
+msgstr "Footprints laden"
 
 #: pcbnew/menubar_modedit.cpp:107
 msgid "Save Current Library As..."
-msgstr "Aktuelle Bibliothek speichern &unter..."
+msgstr "Aktuelle Bibliothek speichern &unter ..."
 
 #: pcbnew/menubar_modedit.cpp:108
 msgid "Save entire current library under a new name."
-msgstr "Gegenwärtige Bibliothek unter einem neuen Namen speichern"
+msgstr "Gegenwärtige Bibliothek unter einem neuen Namen speichern."
 
 #: pcbnew/menubar_modedit.cpp:112
 msgid "&Save Footprint in Active Library"
@@ -11613,18 +11552,16 @@ msgid "&Export Footprint"
 msgstr "Footprint &exportieren"
 
 #: pcbnew/menubar_modedit.cpp:128
-#, fuzzy
 msgid "Save currently loaded footprint into file"
-msgstr "Gegenwärtiges Bauteil speichern"
+msgstr "Gegenwärtigen Footprint in einer Datei speichern"
 
 #: pcbnew/menubar_modedit.cpp:133
 msgid "&Import DXF File"
 msgstr "DXF-Datei &importieren"
 
 #: pcbnew/menubar_modedit.cpp:142
-#, fuzzy
 msgid "Print current footprint"
-msgstr "Drucke auf aktuell gewählten Drucker"
+msgstr "Drucke auf aktuellen Footprint"
 
 #: pcbnew/menubar_modedit.cpp:151
 msgid "Close footprint editor"
@@ -11647,9 +11584,8 @@ msgid "Edit &Properties"
 msgstr "&Eigenschaften editieren"
 
 #: pcbnew/menubar_modedit.cpp:180
-#, fuzzy
 msgid "Edit footprint properties"
-msgstr "Eigenschaften des Bauteils editieren"
+msgstr "Eigenschaften des Footprints editieren"
 
 #: pcbnew/menubar_modedit.cpp:188
 msgid "&Size and Width"
@@ -11657,11 +11593,11 @@ msgstr "&Größe und Breite"
 
 #: pcbnew/menubar_modedit.cpp:189
 msgid "Adjust width for texts and drawings"
-msgstr "Anpassen der Breite für Text und Zeichnungen"
+msgstr "Anpassen der Breite für Texte und Zeichnungen"
 
 #: pcbnew/menubar_modedit.cpp:194
 msgid "&Pad Setting"
-msgstr "&Padeinstellungen"
+msgstr "&Pad Einstellungen"
 
 #: pcbnew/menubar_modedit.cpp:194
 msgid "Edit settings for new pads"
@@ -11669,19 +11605,21 @@ msgstr "Einstellungen für neue Pads ändern"
 
 #: pcbnew/menubar_modedit.cpp:199
 msgid "&User Grid Size"
-msgstr "&Raster Einstellungen"
+msgstr "Benutzerdef. &Raster Einstellungen"
 
 #: pcbnew/menubar_modedit.cpp:199
 msgid "Adjust user grid"
-msgstr "Raster anpassen"
+msgstr "Benutzerdefiniertes Raster anpassen"
 
+# No translation needed
 #: pcbnew/menubar_modedit.cpp:246
 msgid "&Pad"
-msgstr "&Pad"
+msgstr ""
 
+# No translation needed
 #: pcbnew/menubar_modedit.cpp:269
 msgid "&Text"
-msgstr "&Text"
+msgstr ""
 
 #: pcbnew/menubar_modedit.cpp:269
 msgid "Add graphic text"
@@ -11692,18 +11630,16 @@ msgid "A&nchor"
 msgstr "A&nker"
 
 #: pcbnew/menubar_modedit.cpp:277
-#, fuzzy
 msgid "Place footprint reference anchor"
 msgstr "Referenzpunkt für Bauteilfootprint setzen"
 
 #: pcbnew/menubar_modedit.cpp:290
-#, fuzzy
 msgid "&Settings"
-msgstr "Einstellungen"
+msgstr "&Einstellungen"
 
 #: pcbnew/menubar_modedit.cpp:290
 msgid "Select default parameters values in Footprint Editor"
-msgstr ""
+msgstr "Auswahl Standardwerte der Parameter im Footprint Editor"
 
 #: pcbnew/menubar_modedit.cpp:329
 msgid "Di&mensions"
@@ -11717,9 +11653,10 @@ msgstr "Eine REFERENZ kann nicht entfernt werden!"
 msgid "Cannot delete VALUE!"
 msgstr "WERT kann nicht entfernt werden!"
 
+# No translation needed
 #: pcbnew/class_text_mod.cpp:383
 msgid "Ref."
-msgstr "Ref."
+msgstr ""
 
 # Different translation needed here depending on the context.
 # For menu item...
@@ -11839,7 +11776,8 @@ msgstr ""
 #, c-format
 msgid "Unable to rename tempfile '%s' to library file '%s'"
 msgstr ""
-"Konnte die temporäre Datei '%s' nicht in die Bibliotheksdatei '%s' umbennen."
+"Konnte die temporäre Datei '%s' nicht in die Bibliotheksdatei '%s' "
+"umbenennen."
 
 #: pcbnew/legacy_plugin.cpp:4677
 #, c-format
@@ -11855,10 +11793,10 @@ msgstr "Die Bibliothek '%s' kann nicht gelöscht werden."
 msgid "TimeStamp"
 msgstr "Zeitstempel"
 
+# No translation needed
 #: pcbnew/class_edge_mod.cpp:264
-#, fuzzy
 msgid "Footprint Layer"
-msgstr "Footprint"
+msgstr ""
 
 #: pcbnew/class_edge_mod.cpp:276
 #, c-format
@@ -11870,15 +11808,14 @@ msgid ""
 "This item has an illegal layer id.\n"
 "Now, forced on the drawings layer. Please, fix it"
 msgstr ""
-"Dieses Element besitzt eine ungültige Id und wurde deshalb\n"
+"Dieses Element besitzt eine ungültige ID und wurde deshalb\n"
 "auf der Lage für Symbole und Zeichnungen platziert.\n"
 "Bitte korrigieren Sie dies ggfs."
 
 #: pcbnew/dimension.cpp:202 pcbnew/dialogs/dialog_pcb_text_properties.cpp:248
 #: pcbnew/dialogs/dialog_edit_module_text.cpp:231
 msgid "The text thickness is too large for the text size. It will be clamped"
-msgstr ""
-"Die Textstärke ist für diese Textgrösse zu groß. Text wird eingeklemmt."
+msgstr "Die Textstärke ist für diesen Text zu groß. Text wird eingeklemmt."
 
 #: pcbnew/block.cpp:292
 msgid "Block Operation"
@@ -11897,12 +11834,12 @@ msgstr "<%s> nicht gefunden"
 #: pcbnew/cross-probing.cpp:118
 #, c-format
 msgid "%s pin %s not found"
-msgstr "<%s> Pin <%s> nicht gefunden"
+msgstr "%s Pin %s nicht gefunden"
 
 #: pcbnew/cross-probing.cpp:123
 #, c-format
 msgid "%s pin %s found"
-msgstr "<%s> Pin <%s> gefunden"
+msgstr "%s Pin %s gefunden"
 
 #: pcbnew/pcbnew_config.cpp:80 pcbnew/dialogs/dialog_general_options.cpp:241
 #: gerbview/options.cpp:88 gerbview/menubar.cpp:155 gerbview/menubar.cpp:157
@@ -11920,7 +11857,7 @@ msgstr "&Lagenmanager einblenden"
 #: gerbview/excellon_read_drill_file.cpp:199
 #, c-format
 msgid "File %s not found"
-msgstr "Datei <%s> nicht gefunden."
+msgstr "Datei %s nicht gefunden."
 
 #: pcbnew/pcbnew_config.cpp:435
 msgid "Save Macros File"
@@ -11935,24 +11872,20 @@ msgid "Warning: The Top Layer and Bottom Layer are same."
 msgstr "Achtung: Bestückungsseite und Lötseite sind die selben."
 
 #: pcbnew/onrightclick.cpp:156
-#, fuzzy
 msgid "Lock Footprint"
-msgstr "Alle Footprints sperren"
+msgstr "Footprints sperren"
 
 #: pcbnew/onrightclick.cpp:163
-#, fuzzy
 msgid "Unlock Footprint"
 msgstr "Alle Footprints entsperren"
 
 #: pcbnew/onrightclick.cpp:171
-#, fuzzy
 msgid "Automatically Place Footprint"
 msgstr "Alle Footprints automatisch platzieren"
 
 #: pcbnew/onrightclick.cpp:178
-#, fuzzy
 msgid "Automatically Route Footprint"
-msgstr "Netz automatisch routen"
+msgstr "Footprint automatisch routen"
 
 #: pcbnew/onrightclick.cpp:199
 msgid "Move Drawing"
@@ -12110,18 +12043,18 @@ msgstr "Nächste Footprints automatisch platzieren"
 msgid "Orient All Footprints"
 msgstr "Alle Footprint ausrichten"
 
+# No translation needed
 #: pcbnew/onrightclick.cpp:470
 msgid "Autoroute"
-msgstr "Autoroute"
+msgstr ""
 
 #: pcbnew/onrightclick.cpp:472
 msgid "Select Layer Pair"
 msgstr "Wähle Lagenpaar"
 
 #: pcbnew/onrightclick.cpp:475
-#, fuzzy
 msgid "Automatically Route All Footprints"
-msgstr "Alle Footprints automatisch platzieren"
+msgstr "Alle Footprints automatisch routen"
 
 #: pcbnew/onrightclick.cpp:477
 msgid "Reset Unrouted"
@@ -12165,7 +12098,7 @@ msgstr "Leiterbahn exakt verschieben"
 
 #: pcbnew/onrightclick.cpp:574
 msgid "Create Track Array"
-msgstr "Leiterbahnarray erstellen "
+msgstr "Leiterbahnarray erstellen"
 
 #: pcbnew/onrightclick.cpp:580
 msgid "Break Track"
@@ -12206,7 +12139,7 @@ msgstr "Micro Durchkontaktierung platzieren"
 
 #: pcbnew/onrightclick.cpp:640
 msgid "Change Via Size and Drill"
-msgstr "Grösse von Durchkontaktierung und Bohrung ändern"
+msgstr "Größe von Durchkontaktierung und Bohrung ändern"
 
 #: pcbnew/onrightclick.cpp:646
 msgid "Change Segment Width"
@@ -12306,9 +12239,8 @@ msgid "Add Cutout Area"
 msgstr "Fläche für Ausschnitt hinzufügen"
 
 #: pcbnew/onrightclick.cpp:763
-#, fuzzy
 msgid "Duplicate Zone Onto Layer"
-msgstr "Fläche duplizieren"
+msgstr "Fläche auf Layer duplizieren"
 
 #: pcbnew/onrightclick.cpp:765
 msgid "Duplicate Zone"
@@ -12381,7 +12313,7 @@ msgstr "Parameter editieren"
 
 #: pcbnew/onrightclick.cpp:868
 msgid "Edit with Footprint Editor"
-msgstr "Editieren mit Footprinteditor"
+msgstr "Editieren mit Footprint Editor"
 
 #: pcbnew/onrightclick.cpp:871
 msgid "Delete Footprint"
@@ -12389,7 +12321,7 @@ msgstr "Footprint entfernen"
 
 #: pcbnew/onrightclick.cpp:923 pcbnew/onrightclick.cpp:1037
 msgid "Reset Size"
-msgstr "Grösse rücksetzen"
+msgstr "Größe rücksetzen"
 
 #: pcbnew/onrightclick.cpp:974
 msgid "Copy Current Settings to this Pad"
@@ -12425,15 +12357,14 @@ msgstr "Kopieren"
 
 #: pcbnew/onrightclick.cpp:1068
 msgid "Auto Width"
-msgstr "Autom. Breite"
+msgstr "Automatische Breite"
 
 #: pcbnew/onrightclick.cpp:1069
 msgid ""
 "Use the track width when starting on a track, otherwise the current track "
 "width"
 msgstr ""
-"Verwende die Leiterbahnbreite der Leiterbahn mit der beginnend, anderenfalls "
-"the aktuelle Leiterbahnbreite"
+"Verwende diese Leiterbahnbreite, anderenfalls die aktuelle Leiterbahnbreite"
 
 #: pcbnew/onrightclick.cpp:1079
 msgid "Use Netclass Values"
@@ -12441,7 +12372,7 @@ msgstr "Verwende Werte der Netznklasse"
 
 #: pcbnew/onrightclick.cpp:1080
 msgid "Use track and via sizes from their Netclass values"
-msgstr "Verwende Leiterbahn- und DuKo-Grösse aus ihrer Netzklasse"
+msgstr "Verwende Leiterbahn- und DuKo-Größe aus deren Netzklasse"
 
 #: pcbnew/onrightclick.cpp:1086
 #, c-format
@@ -12466,7 +12397,8 @@ msgstr "Durchkontaktierung %s, Bohrung %s"
 msgid ""
 "Left click to select, middle click for color change, right click for menu"
 msgstr ""
-"Linksklick zum Selektieren, Mittelklick für Farbwechsel, Rechtsklick für Menü"
+"Links Klick zum Selektieren, Mitteler Klick für Farbwechsel, Rechts Klick "
+"für Menü"
 
 #: pcbnew/layer_widget.cpp:440
 msgid "Enable this for visibility"
@@ -12474,7 +12406,7 @@ msgstr "Für Sichtbarkeit selektieren"
 
 #: pcbnew/layer_widget.cpp:467
 msgid "Middle click for color change"
-msgstr "Mittelklick für Farbwechsel"
+msgstr "Mittel Klick für Farbwechsel"
 
 #: pcbnew/io_mgr.cpp:43
 #, c-format
@@ -12515,14 +12447,12 @@ msgid "Via %s net [%s] (%d) on layers %s/%s"
 msgstr "DuKo %s Netz [%s] (%d) auf Lage %s/%s"
 
 #: pcbnew/class_track.cpp:1037
-#, fuzzy
 msgid "Full Length"
 msgstr "Volle Länge"
 
 #: pcbnew/class_track.cpp:1040
-#, fuzzy
 msgid "Pad To Die Length"
-msgstr "Pad zu Die Länge:"
+msgstr "Pad zu Die Länge"
 
 #: pcbnew/class_track.cpp:1048
 msgid "NC Name"
@@ -12565,7 +12495,7 @@ msgstr "Blinde/Vergrabene Durchkontaktierungen"
 #: pcbnew/dialogs/dialog_plot_base.cpp:71
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:60
 msgid "Layers"
-msgstr "Lagen "
+msgstr "Lagen"
 
 #: pcbnew/class_track.cpp:1226 pcbnew/dialogs/dialog_design_rules_base.cpp:277
 msgid "Diameter"
@@ -12602,13 +12532,15 @@ msgstr "Polarkoordinaten einblenden"
 msgid "Show pads in fill mode"
 msgstr "Pads ausgefüllt darstellen"
 
+# No translation needed
 #: pcbnew/basepcbframe.cpp:839
 msgid "Zoom Auto"
-msgstr "Zoom Auto"
+msgstr ""
 
+# No translation needed
 #: pcbnew/basepcbframe.cpp:844
 msgid "Zoom "
-msgstr "Zoom "
+msgstr ""
 
 #: pcbnew/swap_layers.cpp:94
 msgid "Swap Layers:"
@@ -12619,17 +12551,19 @@ msgstr "Tausche Lagen:"
 msgid "No Change"
 msgstr "Keine Änderung"
 
+# No translation needed
 #: pcbnew/swap_layers.cpp:285
 msgid "&OK"
-msgstr "&OK"
+msgstr ""
 
 #: pcbnew/swap_layers.cpp:289
 msgid "&Cancel"
 msgstr "&Abbrechen"
 
+# No translation needed
 #: pcbnew/class_pad.cpp:620
 msgid "Pad"
-msgstr "Pad"
+msgstr ""
 
 #: pcbnew/class_pad.cpp:623 pcbnew/dialogs/dialog_design_rules.cpp:52
 msgid "Net"
@@ -12639,31 +12573,35 @@ msgstr "Netz"
 msgid "Drill X / Y"
 msgstr "Bohrung X / Y"
 
+# No translation needed
 #: pcbnew/class_pad.cpp:672
 #: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:80
 msgid "Position"
-msgstr "Position"
+msgstr ""
 
 #: pcbnew/class_pad.cpp:677
 msgid "Length in package"
 msgstr "Länge in Package"
 
+# No translation needed
 #: pcbnew/class_pad.cpp:854 pcbnew/dialogs/dialog_pad_properties_base.cpp:68
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:274
 msgid "Oval"
-msgstr "Oval"
+msgstr ""
 
+# No translation needed
 #: pcbnew/class_pad.cpp:860
 msgid "Trap"
-msgstr "Trap"
+msgstr ""
 
 #: pcbnew/class_pad.cpp:873
 msgid "Std"
 msgstr "Std"
 
+# No translation needed
 #: pcbnew/class_pad.cpp:876 pcbnew/dialogs/dialog_pad_properties_base.cpp:58
 msgid "SMD"
-msgstr "SMD"
+msgstr ""
 
 #: pcbnew/class_pad.cpp:879
 msgid "Conn"
@@ -12693,6 +12631,7 @@ msgstr ""
 #: pcbnew/librairi.cpp:60
 msgid "Create New Library Folder (the .pretty folder is the library)"
 msgstr ""
+"Erstelle neuen Ordner für Bibliothek (.pretty ist der Bibliotheksordner)"
 
 #: pcbnew/librairi.cpp:61
 #, c-format
@@ -12706,7 +12645,7 @@ msgstr "Footprint importieren"
 #: pcbnew/librairi.cpp:63
 #, c-format
 msgid "File '%s' not found"
-msgstr "Datei <%s> nicht gefunden."
+msgstr "Datei '%s' nicht gefunden."
 
 #: pcbnew/librairi.cpp:64
 msgid "Not a footprint file"
@@ -12756,7 +12695,7 @@ msgstr "Footprint wurde in die Datei '%s' exportiert."
 #: pcbnew/librairi.cpp:74
 #, c-format
 msgid "Footprint %s deleted from library '%s'"
-msgstr "Footprint '%s' wurde aus der Bibliothek '%s' entfernt."
+msgstr "Footprint %s wurde aus der Bibliothek '%s' entfernt."
 
 #: pcbnew/librairi.cpp:75
 msgid "New Footprint"
@@ -12769,7 +12708,7 @@ msgstr "Keine Footprints zum Archivieren!"
 #: pcbnew/librairi.cpp:78
 #, c-format
 msgid "Footprint %s already exists in library '%s'"
-msgstr "Footprint '%s' existiert bereits in der Bibliothek '%s'."
+msgstr "Footprint %s existiert bereits in der Bibliothek '%s'."
 
 #: pcbnew/librairi.cpp:79
 msgid "No footprint name defined."
@@ -12782,6 +12721,12 @@ msgid ""
 "and update your footprint lib table\n"
 "to save your footprint (a .kicad_mod file) in the .pretty library folder"
 msgstr ""
+"Schreiben/Verändern der im alten Format vorliegende Bibliotheken (.mod "
+"Dateien) ist nicht möglich.\n"
+"Bitte speichern Sie die aktuelle Bibliothek im neuen .pretty Format und "
+"aktualisieren Sie die Footprint Library\n"
+"Tabelle um den Footprint (die .kicad_mod Datei) im Bibliotheksordner "
+"speichern zu können."
 
 #: pcbnew/librairi.cpp:89
 msgid ""
@@ -12790,9 +12735,13 @@ msgid ""
 "and update your footprint lib table\n"
 "before deleting a footprint"
 msgstr ""
+"Verändern der im alten Format vorliegende Bibliotheken (.mod Dateien) ist "
+"nicht möglich.\n"
+"Bitte speichern Sie die aktuelle Bibliothek im neuen .pretty Format und "
+"aktualisieren Sie\n"
+"die Footprint Library Tabelle um den Footprint löschen zu können."
 
 #: pcbnew/librairi.cpp:94
-#, fuzzy
 msgid "Legacy foot print export files (*.emp)|*.emp"
 msgstr "KiCad Footprint Exportdateien (*.emp)|*.emp"
 
@@ -12808,8 +12757,7 @@ msgid ""
 "in '%s'"
 msgstr ""
 "Fehler:\n"
-"Unzulässiges Zeichen '%s' gefunden\n"
-"in '%s'"
+"Unzulässiges Zeichen '%s' in '%s' gefunden."
 
 #: pcbnew/librairi.cpp:700
 #, c-format
@@ -12821,9 +12769,10 @@ msgstr "Bauteil [%s] ersetzt in '%s'."
 msgid "Component [%s] added in  '%s'"
 msgstr "Bauteil [%s] hinzugefügt zu '%s'."
 
+# No translation needed
 #: pcbnew/librairi.cpp:790 pcbnew/dialogs/dialog_fp_lib_table.cpp:204
 msgid "Nickname"
-msgstr "Nickname"
+msgstr ""
 
 #: pcbnew/edit.cpp:693 pcbnew/edit.cpp:715 pcbnew/edit.cpp:741
 #: pcbnew/edit.cpp:769 pcbnew/edit.cpp:797 pcbnew/edit.cpp:825
@@ -12883,7 +12832,7 @@ msgid ""
 msgstr ""
 "Footprint\n"
 "'%s'\n"
-"befindet sich nicht im beschreibbaren Bereich dieser Githubbibliothek\n"
+"befindet sich nicht im beschreibbaren Bereich dieser Github-Bibliothek\n"
 "'%s'"
 
 #: pcbnew/github/github_plugin.cpp:365
@@ -12895,6 +12844,13 @@ msgid ""
 "directory <b>must</b> have a <b>.pretty</b> file extension because the "
 "format of the save is pretty.</p>"
 msgstr ""
+"Setzen Sie diese Eigenschaft auf ein Verzeichnis in dem pretty Footprints "
+"gespeichert werden wenn Daten in dieser Bibliothek gespeichert werden. Alles "
+"was in diesem Verzeichnis gespeichert wird hat Vorrang vor Dateien die mit "
+"dem gleichen Namen im Github Repository vorhanden sind. Diese gespeicherten "
+"Footprints können dann als Update zum Maintainer der Bibliothek geschickt "
+"werden. Das Verzeichnis <b>muss</b> eine Namenserweiterung <b>.pretty</b> "
+"besitzen da die neuen Dateien im pretty Format abgespeichert werden."
 
 #: pcbnew/github/github_plugin.cpp:415
 #, c-format
@@ -12902,7 +12858,7 @@ msgid ""
 "option '%s' for Github library '%s' must point to a writable directory "
 "ending with '.pretty'."
 msgstr ""
-"Die Option '%s' für die Githubbibliothek '%s' muss auf ein beschreibbares "
+"Die Option '%s' für die Github-Bibliothek '%s' muss auf ein beschreibbares "
 "Verzeichnis mit der Endung '.pretty' verweisen."
 
 #: pcbnew/github/github_plugin.cpp:507
@@ -12928,24 +12884,23 @@ msgstr ""
 "Grund: '%s'"
 
 #: pcbnew/github/github_plugin.cpp:585
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "%s\n"
 "Cannot get/download json data from: '%s'\n"
 "Reason: '%s'"
 msgstr ""
 "%s\n"
-"Konnte das Zip-Archiv '%s' nicht herunterladen.\n"
-"Bibliothekspfad: '%s'\n"
+"Konnte die JSON Daten nicht herunterladen von: '%s'.\n"
 "Grund: '%s'"
 
 #: pcbnew/github/github_getliblist.cpp:96
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "malformed URL:\n"
 "'%s'"
 msgstr ""
-"Konnte die folgende URL nicht parsen:\n"
+"Ungültige URL:\n"
 "'%s'"
 
 #: pcbnew/autorouter/move_and_route_event_functions.cpp:133
@@ -12955,16 +12910,14 @@ msgstr ""
 "Möchten Sie dieses durchführen?"
 
 #: pcbnew/autorouter/move_and_route_event_functions.cpp:139
-#, fuzzy
 msgid "No footprint found!"
 msgstr "Kein Footprint gefunden."
 
 #: pcbnew/autorouter/spread_footprints.cpp:181
-#, fuzzy
 msgid "Could not automatically place footprints. No board outlines detected."
 msgstr ""
-"Konnte Bauteil nicht automatisch platzieren, da kein Platinenumriss erkannt "
-"wurde."
+"Konnte Footprint nicht automatisch platzieren, da kein Platinenumriss "
+"erkannt wurde."
 
 #: pcbnew/autorouter/solve.cpp:301
 msgid "Abort routing?"
@@ -12972,20 +12925,20 @@ msgstr "Möchten Sie das Routing abbrechen?"
 
 #: pcbnew/autorouter/auto_place_footprints.cpp:165
 msgid "Footprints NOT LOCKED will be moved"
-msgstr "Alle NICHT GESPERRTEN Anschlussflächen werden verschoben"
+msgstr "Alle NICHT GESPERRTEN Footprints werden verschoben"
 
 #: pcbnew/autorouter/auto_place_footprints.cpp:172
 msgid "Footprints NOT PLACED will be moved"
-msgstr "Alle NICHT PLATZIERTEN Anschlussflächen werden verschoben"
+msgstr "Alle NICHT PLATZIERTEN Footprints werden verschoben"
 
 #: pcbnew/autorouter/auto_place_footprints.cpp:281
-#, fuzzy, c-format
+#, c-format
 msgid "Place footprint %d of %d"
-msgstr "Bauteil %d von %d platzieren"
+msgstr "Footprint %d von %d platzieren"
 
 #: pcbnew/autorouter/auto_place_footprints.cpp:466
 msgid "No PCB edge found, unknown board size!"
-msgstr "Kein Platinenumriss vorhanden, somit unbekannte Platinengrösse!"
+msgstr "Kein Platinenumriss vorhanden, somit unbekannte Platinengröße!"
 
 #: pcbnew/autorouter/auto_place_footprints.cpp:475
 msgid "Cols"
@@ -13009,9 +12962,8 @@ msgid "Net not selected"
 msgstr "Kein Netz ausgewählt"
 
 #: pcbnew/autorouter/autorout.cpp:98
-#, fuzzy
 msgid "Footprint not selected"
-msgstr "Kein Netz ausgewählt"
+msgstr "Kein Footprint ausgewählt"
 
 #: pcbnew/autorouter/autorout.cpp:108
 msgid "Pad not selected"
@@ -13027,7 +12979,7 @@ msgstr "Zellen platzieren"
 
 #: pcbnew/router/router_tool.cpp:110 pcbnew/router/router_menus.h:137
 msgid "Custom size"
-msgstr "Benutzerdefinierte Grösse"
+msgstr "Benutzerdefinierte Größe"
 
 #: pcbnew/router/router_tool.cpp:113 pcbnew/router/router_menus.h:140
 msgid "Use the starting track width"
@@ -13043,7 +12995,7 @@ msgstr "Verwende Werte der Netzklasse"
 
 #: pcbnew/router/router_tool.cpp:117 pcbnew/router/router_menus.h:144
 msgid "Use track and via sizes from the net class"
-msgstr "Verwende Leiterbahn- und DuKo-Grössen aus der Netzklasse"
+msgstr "Verwende Leiterbahn- und DuKo-Größen aus der Netzklasse"
 
 #: pcbnew/router/router_tool.cpp:121 pcbnew/router/router_menus.h:148
 msgid "Track "
@@ -13067,63 +13019,64 @@ msgid ", drill: "
 msgstr ", Bohrung:"
 
 #: pcbnew/router/router_tool.cpp:594 pcbnew/router/router_menus.h:802
-#, fuzzy
 msgid "Route Track"
-msgstr "Keine Leiterbahnen"
+msgstr "Route Leiterbahnen"
 
 #: pcbnew/router/router_tool.cpp:600 pcbnew/router/router_menus.h:809
 msgid "Router Differential Pair"
-msgstr ""
+msgstr "Route Differenzielles Paar"
 
 #: pcbnew/router/pns_meander_placer.cpp:64
 #: pcbnew/router/pns_dp_meander_placer.cpp:73
 msgid "Please select a track whose length you want to tune."
-msgstr ""
+msgstr "Bitte eine Leiterbahn auswählen dessen Länge Sie anpassen wollen."
 
 #: pcbnew/router/pns_meander_placer.cpp:249
 #: pcbnew/router/pns_dp_meander_placer.cpp:436
 msgid "Too long: "
-msgstr ""
+msgstr "Zu lang: "
 
 #: pcbnew/router/pns_meander_placer.cpp:252
 #: pcbnew/router/pns_dp_meander_placer.cpp:439
 msgid "Too short: "
-msgstr ""
+msgstr "Zu kurz: "
 
 #: pcbnew/router/pns_meander_placer.cpp:255
 #: pcbnew/router/pns_dp_meander_placer.cpp:442
 msgid "Tuned: "
-msgstr ""
+msgstr "Angepasst: "
 
+# No translation needed
 #: pcbnew/router/pns_meander_placer.cpp:258
 #: pcbnew/router/pns_dp_meander_placer.cpp:445
 #: pcbnew/router/pns_meander_skew_placer.cpp:151
-#, fuzzy
 msgid "?"
-msgstr "\"?"
+msgstr ""
 
 #: pcbnew/router/pns_diff_pair_placer.cpp:570
 msgid "Can't start a differential pair  in the middle of nowhere."
-msgstr ""
+msgstr "Kann kein differenzielles Paar im Nirgendwo starten."
 
 #: pcbnew/router/pns_diff_pair_placer.cpp:581
 msgid ""
 "Unable to find complementary differential pair net. Make sure the names of "
 "the nets belonging to a differential pair end with either _N/_P or +/-."
 msgstr ""
+"Kann das zugehörige Netz für das differenzielle Signalpaar nicht finden. "
+"Bitte sicherstellen, dass das Netz welches zum differenziellen Signalpaar "
+"gehört mit _N/_P oder +/- endet."
 
 #: pcbnew/router/length_tuner_tool.cpp:269
-#, fuzzy
 msgid "Tune Trace Length"
-msgstr "Leiterbahnlänge"
+msgstr "Anpassen Leiterbahnlänge"
 
 #: pcbnew/router/length_tuner_tool.cpp:276
 msgid "Tune Diff Pair Length"
-msgstr ""
+msgstr "Anpassen Länge differenzielles Signalpaar"
 
 #: pcbnew/router/length_tuner_tool.cpp:283
 msgid "Tune Diff Pair Skew"
-msgstr ""
+msgstr "Anpassen des Versatzes eines differenziellem Signalpaares"
 
 #: pcbnew/router/pns_dp_meander_placer.cpp:90
 msgid ""
@@ -13131,10 +13084,14 @@ msgid ""
 "sure the names of the nets belonging to a differential pair end with either "
 "_N/_P or +/-."
 msgstr ""
+"Kann das zugehörige Netz des differenzielle Signalpaares für die "
+"Längenanpassung nicht finden. Bitte sicherstellen, dass das Netz welches zum "
+"differenziellen Signalpaar gehört mit _N/_P oder +/- endet."
 
 #: pcbnew/router/pns_meander_skew_placer.cpp:53
 msgid "Please select a differential pair trace you want to tune."
 msgstr ""
+"Bitte ein differenzielles Signalpaar auswählen welches angepasst werden soll."
 
 #: pcbnew/router/pns_meander_skew_placer.cpp:73
 msgid ""
@@ -13142,102 +13099,100 @@ msgid ""
 "sure the names of the nets belonging to a differential pair end with either "
 "_N/_P or +/-."
 msgstr ""
+"Kann das zugehörige Netz des differenziellen Signalpaares für die Anpassung "
+"des Versatzes nicht finden. Bitte sicherstellen, dass das Netz welches zum "
+"differenziellen Signalpaar gehört mit _N/_P oder +/- endet."
 
 #: pcbnew/router/pns_meander_skew_placer.cpp:142
 msgid "Too long: skew "
-msgstr ""
+msgstr "Zu lang: Versatz "
 
 #: pcbnew/router/pns_meander_skew_placer.cpp:145
 msgid "Too short: skew "
-msgstr ""
+msgstr "Zu kurz: Versatz "
 
 #: pcbnew/router/pns_meander_skew_placer.cpp:148
 msgid "Tuned: skew "
-msgstr ""
+msgstr "Angepasst: Versatz "
 
 #: pcbnew/dialogs/dialog_select_dirlist_base.cpp:19
 msgid ""
 "The footprint library is a folder.\n"
 "Footprints are files inside this folder."
 msgstr ""
+"Die Footprint Bibliothek ist ein Ordner.\n"
+"Footprints sind die Dateien in diesem Ordner."
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_select_dirlist_base.cpp:25
 msgid "*.pretty|*"
 msgstr ""
 
 #: pcbnew/dialogs/dialog_pns_settings_base.cpp:19
-#, fuzzy
 msgid "Highlight collisions"
-msgstr "Netz hervorheben"
+msgstr "Kollisionen hervorheben"
 
 #: pcbnew/dialogs/dialog_pns_settings_base.cpp:19
 msgid "Shove"
-msgstr ""
+msgstr "Schieben"
 
 #: pcbnew/dialogs/dialog_pns_settings_base.cpp:19
-#, fuzzy
 msgid "Walk around"
-msgstr "Schwarzer Hintergrund"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_pns_settings_base.cpp:19
 msgid "Figure out what's best"
-msgstr ""
+msgstr "Beste Lösung finden"
 
 #: pcbnew/dialogs/dialog_pns_settings_base.cpp:28
-#, fuzzy
 msgid "Shove vias"
-msgstr "Zeige Micro-Durchkontaktierungen"
+msgstr "Zeige Durchkontaktierungen"
 
 #: pcbnew/dialogs/dialog_pns_settings_base.cpp:31
 msgid "Jump over obstacles"
-msgstr ""
+msgstr "Gehe um Hindernisse"
 
 #: pcbnew/dialogs/dialog_pns_settings_base.cpp:34
-#, fuzzy
 msgid "Remove redundant tracks"
-msgstr "Entferne redundante Durchkontaktierungen"
+msgstr "Entferne redundante Leiterbahnen"
 
 #: pcbnew/dialogs/dialog_pns_settings_base.cpp:37
 msgid "Automatic neckdown"
-msgstr ""
+msgstr "Automatisch abwärts"
 
 #: pcbnew/dialogs/dialog_pns_settings_base.cpp:40
 msgid "Smooth dragged segments"
-msgstr ""
+msgstr "Glatt gezogene Segmente"
 
 #: pcbnew/dialogs/dialog_pns_settings_base.cpp:43
-#, fuzzy
 msgid "Allow DRC violations"
-msgstr "Micro-Durchkontaktierungen erlauben"
+msgstr "DRC Fehler erlauben"
 
 #: pcbnew/dialogs/dialog_pns_settings_base.cpp:46
 msgid "Suggest track finish"
-msgstr ""
+msgstr "Vorschlag Beendigung Leiterbahn"
 
 #: pcbnew/dialogs/dialog_pns_settings_base.cpp:57
 msgid "Optimizer effort"
-msgstr ""
+msgstr "Otimierungsergebnis"
 
 #: pcbnew/dialogs/dialog_pns_settings_base.cpp:73
-#, fuzzy
 msgid "low"
-msgstr "Low-Eingang"
+msgstr "Low"
 
 #: pcbnew/dialogs/dialog_pns_settings_base.cpp:82
 msgid "high"
-msgstr ""
+msgstr "High"
 
 #: pcbnew/dialogs/dialog_block_options_base.cpp:25
-#, fuzzy
 msgid "Include footprints"
-msgstr "Inklusive gesperrter Footprints"
+msgstr "Inklusive Footprints"
 
 #: pcbnew/dialogs/dialog_block_options_base.cpp:28
 msgid "Include text items"
-msgstr "Inklusive Textelementen"
+msgstr "Inklusive Textelemente"
 
 #: pcbnew/dialogs/dialog_block_options_base.cpp:32
-#, fuzzy
 msgid "Include locked footprints"
 msgstr "Inklusive gesperrter Footprints"
 
@@ -13266,17 +13221,19 @@ msgid "Include items on invisible layers"
 msgstr "Inklusive Elementen auf unsichtbaren Lagen"
 
 #: pcbnew/dialogs/dialog_edit_module_text_base.cpp:19
-#, fuzzy, c-format
+#, c-format
 msgid "Footprint %s (%s) orientation %.1f"
-msgstr "Footprint Ausrichtung"
+msgstr "Footprint %s (%s) Ausrichtung %.1f"
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_edit_module_text_base.cpp:72
 msgid "Offset X"
-msgstr "Offset X"
+msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_edit_module_text_base.cpp:80
 msgid "Offset Y"
-msgstr "Offset Y"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_edit_module_text_base.cpp:88
 #: pcbnew/dialogs/dialog_graphic_item_properties_base.cpp:129
@@ -13291,19 +13248,19 @@ msgstr "Lage:"
 #: pcbnew/dialogs/dialog_print_for_modedit.cpp:87
 #: gerbview/dialogs/dialog_print_using_printer.cpp:107
 msgid "Error Init Printer info"
-msgstr "Error Init Drucker Info"
+msgstr "Fehler Init Drucker Info"
 
 #: pcbnew/dialogs/dialog_print_using_printer.cpp:369
 #: pcbnew/dialogs/dialog_plot.cpp:774
 #: gerbview/dialogs/dialog_print_using_printer.cpp:297
 msgid "Warning: Scale option set to a very large value"
-msgstr "Warnung: Skalierungsoption ist auf einen sehr kleinen Wert gesetzt"
+msgstr "Warnung: Skalierungsfaktor ist auf einen sehr großen Wert gesetzt"
 
 #: pcbnew/dialogs/dialog_print_using_printer.cpp:377
 #: pcbnew/dialogs/dialog_plot.cpp:770
 #: gerbview/dialogs/dialog_print_using_printer.cpp:305
 msgid "Warning: Scale option set to a very small value"
-msgstr "Warnung: Skalierungsoption ist auf einen sehr kleinen Wert gesetzt"
+msgstr "Warnung: Skalierungsfaktor ist auf einen sehr kleinen Wert gesetzt"
 
 #: pcbnew/dialogs/dialog_print_using_printer.cpp:443
 #: pcbnew/dialogs/dialog_print_using_printer.cpp:484
@@ -13369,9 +13326,10 @@ msgstr "Rechteck"
 msgid "Trapezoidal"
 msgstr "Trapez"
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:83
 msgid "Position X:"
-msgstr "Position X:"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:91
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:103
@@ -13397,25 +13355,27 @@ msgstr "Position X:"
 msgid "Inch"
 msgstr "Zoll"
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:95
 msgid "Position Y:"
-msgstr "Position Y:"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:107
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:284
 #: pcbnew/dialogs/dialog_set_grid_base.cpp:37
 msgid "Size X:"
-msgstr "Grösse X:"
+msgstr "Größe X:"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:119
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:296
 #: pcbnew/dialogs/dialog_set_grid_base.cpp:45
 msgid "Size Y:"
-msgstr "Grösse Y:"
+msgstr "Größe Y:"
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:135
 msgid "90"
-msgstr "90"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:135
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:29
@@ -13443,7 +13403,7 @@ msgid ""
 "Wire length from pad to die on chip ( used to calculate actual track length)"
 msgstr ""
 "Drahtlänge vom Pad zum Die des Chips (wird verwendet um die gegenwärtige "
-"Leiterbahnlänge zu berechnen)"
+"Leiterbahn zu berechnen)"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:195
 msgid "Trap. delta dim:"
@@ -13457,9 +13417,10 @@ msgstr "Trapezausrichtung:"
 msgid "Parent footprint orientation"
 msgstr "Ausrichtung des Footprint-Elternelements"
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:233
 msgid "Rotation:"
-msgstr "Rotation:"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:241
 msgid "Board side:"
@@ -13512,11 +13473,11 @@ msgstr "Rückseitiger Siebdruck"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:354
 msgid "Front solder mask"
-msgstr "Vorderseitige Lötstoppmaske"
+msgstr "Vorderseitige Lötstopmaske"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:357
 msgid "Back solder mask"
-msgstr "Rückseitige Lötstoppmaske"
+msgstr "Rückseitige Lötstopmaske"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:360
 msgid "Drafting notes"
@@ -13552,14 +13513,14 @@ msgstr ""
 #: pcbnew/dialogs/dialog_plot_base.cpp:197
 #: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:247
 msgid "Solder mask clearance:"
-msgstr "Abstand Lötstoppmaske:"
+msgstr "Abstand Lötstopmaske:"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:415
 msgid ""
 "This is the local clearance between this  pad and the solder mask\n"
 "If 0, the footprint local value or the global value is used"
 msgstr ""
-"Dies ist das lokale Abstandsmaß zwischen diesem Pad und der Lötstoppmaske.\n"
+"Dies ist das lokale Abstandsmaß zwischen diesem Pad und der Lötstopmaske.\n"
 "Wenn 0, wird der lokale Wert des Footprints oder der globale Wert verwendet."
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:427
@@ -13582,7 +13543,7 @@ msgstr ""
 "verwendet.\n"
 "Das endgültige Abstandsmaß ist die Summe aus diesem Wert und dem "
 "Abstandsverhältnis.\n"
-"Ein negativer Wert bedeutet, dass die Maskengrösse kleiner als die Padgrösse "
+"Ein negativer Wert bedeutet, dass die Maskengröße kleiner als die Padgröße "
 "ist."
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:441
@@ -13590,7 +13551,7 @@ msgstr ""
 #: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:209
 #: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:275
 msgid "Solder paste ratio clearance:"
-msgstr "Abstandsverhältnis der Lötstoppmaske:"
+msgstr "Abstandsverhältnis der Lötstopmaske:"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:443
 msgid ""
@@ -13603,21 +13564,22 @@ msgid ""
 msgstr ""
 "Dies ist das lokale Abstandsverhältnis in Prozent zwischen diesem Pad und "
 "der Lötpaste.\n"
-"Ein Wert von 10 bedeutet, dass das Abstandsmaß 10 Prozent der Padgrösse "
+"Ein Wert von 10 bedeutet, dass das Abstandsmaß 10 Prozent der Padgröße "
 "entspricht.\n"
 "Wenn 0, wird der lokale Footprintwert oder der globale Wert verwendet.\n"
 "Das endgültige Abstandsmaß ist die Summe aus diesem Wert und dem "
 "Abstandsmaß.\n"
-"Ein negativer Wert bedeutet, dass die Maskengrösse kleiner als die Padgrösse "
+"Ein negativer Wert bedeutet, dass die Maskengröße kleiner als die Padgröße "
 "ist."
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:451
 #: pcbnew/dialogs/dialog_mask_clearance_base.cpp:101
 #: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:219
 #: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:285
 #: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:133
 msgid "%"
-msgstr "%"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:462
 msgid "Copper Zones"
@@ -13629,9 +13591,8 @@ msgid "Pad connection:"
 msgstr "Padverbindung:"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:474
-#, fuzzy
 msgid "From parent footprint"
-msgstr "Aktueller Footprint"
+msgstr "Von Ursprungs Footprint"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:474
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:154
@@ -13656,7 +13617,7 @@ msgstr "Abstand zur thermischen Abführung:"
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:514
 msgid "Set fields to 0 to use parent or global values"
 msgstr ""
-"Setze die Felder auf 0, um übergeordnete oder globale Werten zu verwenden"
+"Setze die Felder auf 0 um übergeordnete oder globale Werten zu verwenden"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:527
 msgid "Local Clearance and Settings"
@@ -13677,6 +13638,8 @@ msgid ""
 "The project path is empty and this option is not valid.\n"
 "Looks like you are running the wizard outside a project."
 msgstr ""
+"Der Projektpfad ist leer und diese Option ist nicht gültig.\n"
+"Es scheint das Sie den Wizard außerhalb des Projektes benutzen."
 
 #: pcbnew/dialogs/wizard_add_fplib.cpp:237
 #, c-format
@@ -13684,18 +13647,25 @@ msgid ""
 "The default path defined by env var \"%s\" is empty.\n"
 "Cannot use it"
 msgstr ""
+"Der Standard Pfad ist leer welcher in den Umgebungsvariablen \"%s\" gesetzt "
+"ist.\n"
+"Dieser kann nicht benutzt werden."
 
 #: pcbnew/dialogs/wizard_add_fplib.cpp:249
 msgid ""
 "Github Plugin uses a valid Internet URL starting by http.\n"
 "Cannot be used as URL"
 msgstr ""
+"Das Github Plugin benutzt eine gültige Internet URL beginnend mit 'http'.\n"
+"Diese kann nicht als URL benutzt werden."
 
 #: pcbnew/dialogs/wizard_add_fplib.cpp:259
 msgid ""
 "This default path looks strange.\n"
 "Cannot be used for a file path"
 msgstr ""
+"Dieser Standard Pfad sieht ungewöhnlich aus.\n"
+"Dieser kann nicht als Datei Pfad benutzt werden."
 
 #: pcbnew/dialogs/wizard_add_fplib.cpp:481
 #, c-format
@@ -13703,93 +13673,91 @@ msgid ""
 "The URL defined by env var \"%s\" is an incorrect URL.\n"
 "Cannot use it"
 msgstr ""
+"Die URL aus der Umgebungsvariable \"%s\" ist keine gültige URL.\n"
+"Diese URL kann nicht benutzt werden."
 
 #: pcbnew/dialogs/wizard_add_fplib.cpp:501
 msgid "Download Github Libs"
-msgstr ""
+msgstr "Github Bibliotheken herunterladen"
 
 #: pcbnew/dialogs/wizard_add_fplib.cpp:506
 #: pcbnew/dialogs/wizard_add_fplib_base.cpp:203
 msgid "Github Libs List"
-msgstr ""
+msgstr "Liste der Github Bibliotheken"
 
 #: pcbnew/dialogs/wizard_add_fplib.cpp:525
 msgid "Add Libs with WebViewer"
-msgstr ""
+msgstr "Hinzufügen der Bibliotheken mit dem WebViewer"
 
 #: pcbnew/dialogs/wizard_add_fplib.cpp:527
-#, fuzzy
 msgid "Add FP Library entry"
-msgstr "Bibliothekseditor"
+msgstr "FP Bibliothekseintrag hinzufügen"
 
 #: pcbnew/dialogs/wizard_add_fplib.cpp:531
 #: pcbnew/dialogs/wizard_add_fplib_base.cpp:206
-#, fuzzy
 msgid "Add FP Libraries"
-msgstr "&Bibliotheken"
+msgstr "FP Bibliotheken hinzufügen"
 
 #: pcbnew/dialogs/wizard_add_fplib.cpp:562
-#, fuzzy
 msgid "Full URL"
-msgstr "Volle Länge"
+msgstr "Volle URL"
 
 #: pcbnew/dialogs/wizard_add_fplib.cpp:564
-#, fuzzy
 msgid "Full filename"
-msgstr "Dateiname:"
+msgstr "Voller Dateiname:"
 
 #: pcbnew/dialogs/wizard_add_fplib.cpp:590
-#, fuzzy
 msgid "Select Library Files"
-msgstr "Wähle Bibliothek"
+msgstr "Wähle Bibliotheksdateien"
 
 #: pcbnew/dialogs/wizard_add_fplib.cpp:869
-#, fuzzy
 msgid ""
 "Urls detected as footprint .pretty libraries.\n"
 "Selected urls will be added to the current footprint library list"
 msgstr ""
-"Es sind keine PCB-Footprintbibliotheken in der gegewärtigen "
-"Footprintbibliothekstabelle aufgeführt."
+"Es wurden Footprint .pretty Bibliotheken URLs gefunden.\n"
+"Ausgewählte URLs werden zur gegenwärtigen Footprintbibliothekstabelle "
+"hinzugefügt."
 
 #: pcbnew/dialogs/wizard_add_fplib.cpp:873
-#, fuzzy
 msgid "Footprint libraries"
-msgstr "Footprint Bibliotheksdateien"
+msgstr "Footprint Bibliotheken"
 
 #: pcbnew/dialogs/wizard_add_fplib.cpp:894
 msgid "Choose Folder to Copy Downloaded '.pretty' Libraries"
-msgstr ""
+msgstr "Auswahl des Ordners für heruntergeladene '.pretty' Bibliotheken"
 
 #: pcbnew/dialogs/wizard_add_fplib.cpp:900
-#, fuzzy
 msgid "Aborted"
-msgstr "Abbruch\n"
+msgstr "Abbruch"
 
 #: pcbnew/dialogs/wizard_add_fplib.cpp:908
-#, fuzzy, c-format
+#, c-format
 msgid "Folder '%s' does not exists"
-msgstr "Footprintbibliothekspfad '%s' existiert nicht."
+msgstr "Ordner '%s' existiert nicht."
 
 #: pcbnew/dialogs/wizard_add_fplib.cpp:915
-#, fuzzy
 msgid "Download libraries"
-msgstr "Globale Bibliotheken"
+msgstr "Bibliotheken herunterladen"
 
 #: pcbnew/dialogs/wizard_add_fplib.cpp:952
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "Error:\n"
 "'%s'\n"
 "while downloading library:\n"
 "'%s'"
 msgstr ""
-"Fehler '%s' ist aufgetreten beim Einlesen der Symbolbibliotheksdatei '%s'."
+"Fehler:\n"
+"'%s'\n"
+"ist aufgetreten beim Herunterladen der Bibliothek:\n"
+"'%s'."
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:25
 #: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:25
 msgid "Polar"
-msgstr "Polar"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:27
 #: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:27
@@ -13802,7 +13770,7 @@ msgid ""
 "the space key)\n"
 "to the cursor, in polar coordinates (angle and distance)"
 msgstr ""
-"Aktiviert das Anzeigen von relativen Koordinaten vom relativen Ursprung "
+"Aktiviert das Anzeigen von relativen Koordinaten mit relativen Ursprung "
 "(gesetzt durch Leertaste)\n"
 "zum Mauszeiger, in Polarkoordinaten (Winkel und Distanz)."
 
@@ -13828,16 +13796,15 @@ msgstr "Kleines Fadenkreuz"
 msgid "Full screen cursor"
 msgstr "Großes Fadenkreuz"
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:43
 #: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:39
 msgid "Cursor"
-msgstr "Cursor"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:45
 msgid "Main cursor shape selection (small cross or large cursor)"
-msgstr ""
-"Auswahl der Mauszeigerform (kleines Kreuz oder großes Kreuz in "
-"Bildschirmgrösse)."
+msgstr "Auswahl der Mauszeigerform (kleines Kreuz oder großes Kreuz)."
 
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:60
 msgid "Maximum Links:"
@@ -13847,7 +13814,7 @@ msgstr "Max. Verbindungen:"
 msgid "Adjust the number of ratsnets shown from cursor to closest pads"
 msgstr ""
 "Stelle die Anzahl von Netzlinien ein, welche vom Mauszeiger\n"
-"zum naheliegendsten Pad angezeigt werden sollen."
+"zum nächstliegendsten Pad angezeigt werden sollen."
 
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:69
 msgid "Auto Save (minutes):"
@@ -13917,7 +13884,7 @@ msgid ""
 "If enabled, force tracks directions to H, V or 45 degrees, when creating a "
 "track."
 msgstr ""
-"Wenn aktiviert, wird eine Leiterbahnausrichtung nach H, V oder 45 Grad "
+"Wenn aktiviert wird eine Leiterbahnausrichtung nach H, V oder 45 Grad "
 "erzwungen, wenn eine Leiterbahn erstellt wird."
 
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:120
@@ -13929,8 +13896,8 @@ msgid ""
 "If enabled, force segments directions to H, V or 45 degrees, when creating a "
 "segment on technical layers."
 msgstr ""
-"Wenn aktiviert, wird eine Segmentausrichtung nach H, V oder 45 Grad "
-"erzwungen, wenn ein Segment erstellt wird."
+"Wenn aktiviert wird eine Segmentausrichtung nach H, V oder 45 Grad "
+"erzwungen, wenn ein Segment auf einer technischen Lage erstellt wird."
 
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:125
 msgid "Use double segmented tracks"
@@ -13941,7 +13908,7 @@ msgid ""
 "If enabled, uses two track segments, with 45 degrees angle between them when "
 "creating a new track "
 msgstr ""
-"Wenn aktiviert, wird eine Leiterbahn bestehend aus zwei Stücken verwendet, "
+"Wenn aktiviert wird eine Leiterbahn bestehend aus zwei Stücken verwendet, "
 "mit einem Winkel von 45 Grad\n"
 "zwischen beiden Stücken, wenn eine neue Leiterbahn erstellt wird."
 
@@ -13981,7 +13948,8 @@ msgstr "Magnetische Leiterbahnen"
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:151
 msgid ""
 "Control the capture of the pcb cursor when the mouse cursor enters a track"
-msgstr "Bestimmt das Fangen des PCB Cursors wenn die Maus über eine Pad fährt"
+msgstr ""
+"Bestimmt das Fangen des PCB Cursors wenn die Maus über eine Leiterbahn fährt"
 
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:158
 #: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:86
@@ -14017,27 +13985,26 @@ msgstr "Linienbreite Kupfertext"
 #: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:49
 #: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:87
 msgid "Text Size V"
-msgstr "Textgrösse V"
+msgstr "Textgröße V"
 
 #: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:57
 #: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:95
 msgid "Text Size H"
-msgstr "Textgrösse H"
+msgstr "Textgröße H"
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:69
 #: pcbnew/dialogs/dialog_display_options_base.cpp:68
 msgid "Footprints:"
-msgstr "Footprints:"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:71
-#, fuzzy
 msgid "Edges Width"
 msgstr "Linienbreite Platinenumriss"
 
 #: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:79
-#, fuzzy
 msgid "Text Width"
-msgstr "Textbreite:"
+msgstr "Textbreite"
 
 #: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:107
 msgid "General:"
@@ -14056,43 +14023,44 @@ msgid ""
 "Pen size used to draw items that have no pen size specified.\n"
 "Used mainly to draw items in sketch mode."
 msgstr ""
-"Stiftgrösse, um Elemente darzustellen, verwendet obwohl keine Stiftgrösse "
-"spezifiziert wurde.\n"
-"Wird hauptsächlich verwendet, um Elemente im Umriss-Modus darzustellen."
+"Stiftgröße die verwendet wird um Elemente darzustellen, obwohl keine "
+"Stiftgröße spezifiziert wurde.\n"
+"Wird hauptsächlich verwendet um Elemente im Umriss-Modus darzustellen."
 
 #: pcbnew/dialogs/dialog_export_vrml_base.cpp:22
-#, fuzzy
 msgid "File Name:"
-msgstr "Dateiname"
+msgstr "Dateiname:"
 
 #: pcbnew/dialogs/dialog_export_vrml_base.cpp:26
 msgid "Save VRML Board File"
 msgstr "Speichere VRML Platinendatei"
 
 #: pcbnew/dialogs/dialog_export_vrml_base.cpp:29
-#, fuzzy
 msgid "Footprint 3D model path:"
-msgstr "Footprint Dokumentation"
+msgstr "Footprint 3D-Modell Pfad:"
 
 #: pcbnew/dialogs/dialog_export_vrml_base.cpp:46
 msgid "Copy 3D model files to 3D model path"
-msgstr ""
+msgstr "3D-Modelle in den 3D-Modell Pfad kopieren"
 
 #: pcbnew/dialogs/dialog_export_vrml_base.cpp:50
 msgid "Use relative paths to model files in board VRML file"
-msgstr ""
+msgstr "Benutze relative Pfade zu den Modell-Dateien in VRML Platinendatei"
 
 #: pcbnew/dialogs/dialog_export_vrml_base.cpp:51
 msgid "Use paths for model files in board VRML file relative to the vrml file"
 msgstr ""
+"Benutze Pfade für die Modell-Dateien in VRML Platinendatei relativ zur VRML "
+"Datei"
 
 #: pcbnew/dialogs/dialog_export_vrml_base.cpp:55
 msgid "Plain PCB (no copper or silk)"
-msgstr ""
+msgstr "Platine ohne Kupfer oder Siebdruck"
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_export_vrml_base.cpp:61
 msgid "Meter"
-msgstr "Meter"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_export_vrml_base.cpp:63
 #: pcbnew/dialogs/dialog_gen_module_position_file_base.cpp:54
@@ -14119,7 +14087,7 @@ msgid ""
 "PC bus connector)"
 msgstr ""
 "Verwende dieses Attribut für die auf der Platine dargestellten \"virtuellen"
-"\" Bauteile (wie z.B. einen alten ISA PC Bus Verbinder)"
+"\" Bauteile (wie z.B. ein alter ISA PC Bus Verbinder)"
 
 #: pcbnew/dialogs/dialog_edit_module_for_Modedit.cpp:163
 msgid "Enable hotkey move commands and Auto Placement"
@@ -14137,9 +14105,9 @@ msgstr "3D Form:"
 
 #: pcbnew/dialogs/dialog_edit_module_for_Modedit.cpp:368
 #: pcbnew/dialogs/dialog_edit_module_for_BoardEditor.cpp:501
-#, fuzzy, c-format
+#, c-format
 msgid "Use a path relative to '%s'?"
-msgstr "Einen relativen Pfad verwenden?"
+msgstr "Einen relativen Pfad für '%s' verwenden?"
 
 #: pcbnew/dialogs/dialog_edit_module_for_Modedit.cpp:414
 #, c-format
@@ -14160,9 +14128,8 @@ msgstr "Konnte die folgende Datei nicht erstellen: "
 
 #: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:143
 #: pcbnew/dialogs/dialog_graphic_item_properties.cpp:132
-#, fuzzy
 msgid "Circle Properties"
-msgstr "Feldeigenschaften"
+msgstr "Kreis Eigenschaften"
 
 #: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:144
 #: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:155
@@ -14190,9 +14157,8 @@ msgstr "Punkt Y"
 
 #: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:154
 #: pcbnew/dialogs/dialog_graphic_item_properties.cpp:143
-#, fuzzy
 msgid "Arc Properties"
-msgstr "Eigenschaften"
+msgstr "Eigenschaften Kreisbogen"
 
 #: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:157
 #: pcbnew/dialogs/dialog_graphic_item_properties.cpp:146
@@ -14206,18 +14172,16 @@ msgstr "Startpunkt Y"
 
 #: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:167
 #: pcbnew/dialogs/dialog_graphic_item_properties.cpp:155
-#, fuzzy
 msgid "Line Segment Properties"
-msgstr "Pin Eigenschaften:"
+msgstr "Linien Segment Eigenschaften:"
 
 #: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:197
-#, fuzzy
 msgid ""
 "This item was on an unknown layer.\n"
 "It has been moved to the front silk screen layer. Please fix it."
 msgstr ""
-"Dieses Element besitzt eine ungültige Lagen Id.\n"
-"und wurde somit auf die vordere Siebdrucklage verschoben.\n"
+"Dieses Element war auf einer ungültigen Lage.\n"
+"Es wurde auf die vordere Siebdrucklage verschoben.\n"
 "Bitte dies entsprechend beheben."
 
 #: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:227
@@ -14231,91 +14195,78 @@ msgstr ""
 
 #: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:298
 #: pcbnew/dialogs/dialog_graphic_item_properties.cpp:291
-#, fuzzy
 msgid "The arc angle must be greater than zero."
-msgstr ""
-"Die Breite der Wärmeabführungsspeiche muß größer als die Mindestbreite sein."
+msgstr "Der Winkel des Bogens muss größer als 0 sein."
 
 #: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:306
 #: pcbnew/dialogs/dialog_graphic_item_properties.cpp:300
-#, fuzzy
 msgid "The radius must be greater than zero."
-msgstr ""
-"Die Breite der Wärmeabführungsspeiche muß größer als die Mindestbreite sein."
+msgstr "Der Radius muss größer als 0 sein."
 
 #: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:314
 #: pcbnew/dialogs/dialog_graphic_item_properties.cpp:310
 msgid "The start and end points cannot be the same."
-msgstr ""
+msgstr "Der Startpunkt und der Endpunkt müssen verschieden sein."
 
 #: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:323
 #: pcbnew/dialogs/dialog_graphic_item_properties.cpp:320
-#, fuzzy
 msgid "The item thickness must be greater than zero."
-msgstr ""
-"Die Breite der Wärmeabführungsspeiche muß größer als die Mindestbreite sein."
+msgstr "Die Breite des Elements muss größer als 0 sein."
 
 #: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:329
 #: pcbnew/dialogs/dialog_graphic_item_properties.cpp:326
-#, fuzzy
 msgid "The default thickness must be greater than zero."
-msgstr ""
-"Die Breite der Wärmeabführungsspeiche muß größer als die Mindestbreite sein."
+msgstr "Die Standard Breite muss größer als 0 sein."
 
 #: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:333
 #: pcbnew/dialogs/dialog_graphic_item_properties.cpp:330
-#, fuzzy
 msgid "Error list"
-msgstr "Fehlerliste:"
+msgstr "Fehlerliste"
 
 #: pcbnew/dialogs/dialog_modedit_options_base.cpp:22
 msgid "On new graphic item creation:"
-msgstr ""
+msgstr "Beim Erstellen neuer Grafikelemente:"
 
 #: pcbnew/dialogs/dialog_modedit_options_base.cpp:34
-#, fuzzy
 msgid "Graphic line width"
 msgstr "Linienbreite grafischer Elemente"
 
 #: pcbnew/dialogs/dialog_modedit_options_base.cpp:46
-#, fuzzy
 msgid "Text width"
-msgstr "Textbreite:"
+msgstr "Textbreite"
 
 #: pcbnew/dialogs/dialog_modedit_options_base.cpp:58
-#, fuzzy
 msgid "Text size V"
-msgstr "Textgrösse V"
+msgstr "Textgröße V"
 
 #: pcbnew/dialogs/dialog_modedit_options_base.cpp:70
-#, fuzzy
 msgid "Text size H"
-msgstr "Textgrösse H"
+msgstr "Textgröße H"
 
 #: pcbnew/dialogs/dialog_modedit_options_base.cpp:88
-#, fuzzy
 msgid "Default values on new footprint creation:"
-msgstr "Falscher Wert für Ausrichtung von Footprints"
+msgstr "Standardwerte beim Erstellen neuer Footprints:"
 
 #: pcbnew/dialogs/dialog_modedit_options_base.cpp:94
 msgid "Leave ref or value blank to use the footprint name as default text"
 msgstr ""
+"Benutze den Footprintnamen als Standard Text bei leerer Referenz oder Wert"
 
 #: pcbnew/dialogs/dialog_modedit_options_base.cpp:111
 msgid ""
 "Default text for reference\n"
 "Leave blank to use the footprint name"
 msgstr ""
+"Referenz Standardtext\n"
+"Leer lassen um den Footprintnamen zu benutzen"
 
 #: pcbnew/dialogs/dialog_modedit_options_base.cpp:119
 #: pcbnew/dialogs/dialog_modedit_options_base.cpp:148
-#, fuzzy
 msgid "SilkScreen"
-msgstr "Siebdruck (BS)"
+msgstr "Siebdruck"
 
 #: pcbnew/dialogs/dialog_modedit_options_base.cpp:119
 #: pcbnew/dialogs/dialog_modedit_options_base.cpp:148
-#, fuzzy
 msgid "Fab. Layer"
 msgstr "Fabrikationslage auswählen"
 
@@ -14324,6 +14275,8 @@ msgid ""
 "Default text for value\n"
 "Leave blank to use the footprint name"
 msgstr ""
+"Werte Standardtext\n"
+"Leer lassen um den Footprintnamen zu benutzen"
 
 #: pcbnew/dialogs/dialog_gendrill.cpp:132
 #: pcbnew/dialogs/dialog_gendrill.cpp:133
@@ -14349,22 +14302,22 @@ msgstr ""
 #: pcbnew/dialogs/dialog_gendrill.cpp:593
 #, c-format
 msgid "** Unable to create %s **\n"
-msgstr "Konnte Datei <%s> nicht erstellen.\n"
+msgstr "** Konnte Datei %s nicht erstellen. **\n"
 
 #: pcbnew/dialogs/dialog_gendrill.cpp:433
 #: pcbnew/dialogs/dialog_gendrill.cpp:599
 #, c-format
 msgid "Plot: %s OK\n"
-msgstr "Plot: %s OK\n"
+msgstr "Plotten: '%s' OK\n"
 
 #: pcbnew/dialogs/dialog_gendrill.cpp:505
 msgid "Save Drill Report File"
-msgstr "Bohrplandatei speichern"
+msgstr "Bohrplan Protokolldatei speichern"
 
 #: pcbnew/dialogs/dialog_gendrill.cpp:530
 #, c-format
 msgid "Report file %s created\n"
-msgstr "Protokolldatei <%s> erstellt\n"
+msgstr "Protokolldatei %s erstellt\n"
 
 #: pcbnew/dialogs/dialog_gendrill.cpp:548
 msgid "HPGL plot files (.plt)|*.plt"
@@ -14384,15 +14337,13 @@ msgstr "Bibliotheken nach Geltungsbereich"
 
 #: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:32
 #: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:84
-#, fuzzy
 msgid "Table:"
-msgstr "Aktiviert"
+msgstr "Tabelle:"
 
 #: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:36
 #: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:88
-#, fuzzy
 msgid "Table Name"
-msgstr "Netz Name"
+msgstr "Tabellen Name"
 
 #: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:74
 msgid "Global Libraries"
@@ -14403,23 +14354,20 @@ msgid "Project Specific Libraries"
 msgstr "Projektspezifische Bibliotheken"
 
 #: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:133
-#, fuzzy
 msgid "Append Library"
-msgstr "Neue Biblliothek"
+msgstr "Bibliothek einfügen"
 
 #: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:134
 msgid "Add a PCB library row to this table"
 msgstr "Der Tabelle eine Zeile mit einer PCB-Bibliothek hinzufügen"
 
 #: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:138
-#, fuzzy
 msgid "Append with Wizard"
-msgstr "Platine &hinzufügen..."
+msgstr "Mit Wizard hinzufügen"
 
 #: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:141
-#, fuzzy
 msgid "Remove Library"
-msgstr "Neue Biblliothek"
+msgstr "Bibliothek entfernen"
 
 #: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:142
 msgid "Remove a PCB library from this library table"
@@ -14438,7 +14386,6 @@ msgid "Options Editor"
 msgstr "Editor für Optionen"
 
 #: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:157
-#, fuzzy
 msgid "Zoom into the options table for current row"
 msgstr "Zoome in die Optionstabelle für die aktuelle Reihe"
 
@@ -14464,17 +14411,15 @@ msgstr ""
 
 #: pcbnew/dialogs/dialog_enum_pads_base.cpp:19
 msgid "Pad names are restricted to 4 characters (including number)."
-msgstr ""
+msgstr "Pad Namen sind begrenzt auf 4 Buchstaben (inklusive Nummern)."
 
 #: pcbnew/dialogs/dialog_enum_pads_base.cpp:32
-#, fuzzy
 msgid "Pad name prefix:"
-msgstr "Padnummer:"
+msgstr "Prefix für Padnamen:"
 
 #: pcbnew/dialogs/dialog_enum_pads_base.cpp:40
-#, fuzzy
 msgid "First pad number:"
-msgstr "Zeige Nummern der Anschlüsse"
+msgstr "Erste Pad Nummer:"
 
 #: pcbnew/dialogs/dialog_mask_clearance_base.cpp:27
 msgid ""
@@ -14483,7 +14428,7 @@ msgid ""
 "- a negative value means a mask smaller than a pad\n"
 msgstr ""
 "Beachte für Abstandswerte:\n"
-"- Ein positiver Wert bedeutet, dass die Maske grösser als das Pad ist\n"
+"- Ein positiver Wert bedeutet, dass die Maske größer als das Pad ist\n"
 "- Ein negativer Wert bedeutet, dass die Maske kleiner als das Pad ist\n"
 
 #: pcbnew/dialogs/dialog_mask_clearance_base.cpp:42
@@ -14491,14 +14436,14 @@ msgid ""
 "This is the global clearance between pads and the solder mask\n"
 "This value can be superseded by local values for a footprint or a pad."
 msgstr ""
-"Dies ist das globale Abstandsmaß zwischen Pads und der Lötstoppmaske.\n"
+"Dies ist das globale Abstandsmaß zwischen Pads und der Lötstopmaske.\n"
 "Dieser Wert kann durch lokale Werte eines Footprints oder Pads ersetzt "
 "werden."
 
 #: pcbnew/dialogs/dialog_mask_clearance_base.cpp:54
 #: pcbnew/dialogs/dialog_plot_base.cpp:207
 msgid "Solder mask min width:"
-msgstr "Min.breite der Lötstoppmaske:"
+msgstr "Minimalbreite der Lötstopmaske:"
 
 #: pcbnew/dialogs/dialog_mask_clearance_base.cpp:56
 msgid ""
@@ -14508,8 +14453,8 @@ msgid ""
 msgstr ""
 "Mindestabstand zwischen zwei Padflächen.\n"
 "Zwei Padflächen, welche sich näher sind als dieser Wert, werden beim Plotten "
-"zusammengefaßt.\n"
-"Dieser Parameter wird nur zum Plotten von Lagen mit Lötstoppmasken verwendet."
+"zusammengefasst.\n"
+"Dieser Parameter wird nur zum Plotten von Lagen mit Lötstopmaske verwendet."
 
 #: pcbnew/dialogs/dialog_mask_clearance_base.cpp:79
 msgid ""
@@ -14534,7 +14479,7 @@ msgid ""
 msgstr ""
 "Dies ist das globale Abstandsverhältnis in Prozent zwischen Pads und der "
 "Lötpaste.\n"
-"Ein Wert von 10 bedeutet, dass das Abstandsmaß 10 Prozent der Padgrösse "
+"Ein Wert von 10 bedeutet, dass das Abstandsmaß 10 Prozent der Padgröße "
 "entspricht.\n"
 "Dieser Wert kann durch lokale Werte eines Footprints oder Pads ersetzt "
 "werden.\n"
@@ -14562,15 +14507,15 @@ msgstr "Der zulässige Mindestwert für eine Leiterbahnbreite"
 
 #: pcbnew/dialogs/dialog_drc_base.cpp:56
 msgid "Min via size"
-msgstr "Mindest-DuKo-Grösse"
+msgstr "Mindestgröße DuKo"
 
 #: pcbnew/dialogs/dialog_drc_base.cpp:58
 msgid "Enter the minimum acceptable diameter for a standard via"
-msgstr "Der zulässige Mindestdurchmesser für eine Standard-Durchkontaktierung"
+msgstr "Der zulässige Mindestdurchmesser für eine Standard Durchkontaktierung"
 
 #: pcbnew/dialogs/dialog_drc_base.cpp:66
 msgid "Min uVia size"
-msgstr "Mindest-MicroDuKo-Grösse"
+msgstr "Mindestgröße MicroDuKo"
 
 #: pcbnew/dialogs/dialog_drc_base.cpp:68
 msgid "Enter the minimum acceptable diameter for a micro via"
@@ -14586,11 +14531,12 @@ msgstr "Das Schreiben des Protokolls in diese Datei ermöglichen"
 
 #: pcbnew/dialogs/dialog_drc_base.cpp:89
 msgid "Enter the report filename"
-msgstr "Dateiname für das zu erstellende Protokoll"
+msgstr "Dateiname für die zu erstellende Protokolldatei"
 
+# No translation needed
 #: pcbnew/dialogs/dialog_drc_base.cpp:94
 msgid "..."
-msgstr "..."
+msgstr ""
 
 #: pcbnew/dialogs/dialog_drc_base.cpp:124
 msgid "Start DRC"
@@ -14633,7 +14579,7 @@ msgid ""
 "MARKERs, double click any to go there in PCB, right click for popup menu"
 msgstr ""
 "Doppelklicke einen Marker, um zur entsprechenden Stelle im PCB zu springen "
-"oder rechtsklick für Pop-up-Menü"
+"oder Rechtsklick für Pop-up-Menü"
 
 #: pcbnew/dialogs/dialog_drc_base.cpp:170
 msgid "Problems / Markers"
@@ -14649,7 +14595,7 @@ msgstr "Suchen nach:"
 
 #: pcbnew/dialogs/dialog_find_base.cpp:29
 msgid "Do not warp mouse pointer"
-msgstr "Mauszeiger springt nicht zu gefundenen Element"
+msgstr "Mauszeiger nicht verändern"
 
 #: pcbnew/dialogs/dialog_find_base.cpp:38
 msgid "Find Item"
@@ -14659,9 +14605,10 @@ msgstr "Suche Element"
 msgid "Find Marker"
 msgstr "Suche Marker"
 
+# No translation needed
 #: pcbnew/dialogs/dialog_global_pads_edition_base.cpp:23
 msgid "Pad Filter :"
-msgstr "Pad Filter:"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_global_pads_edition_base.cpp:25
 msgid "Do not modify pads having a different shape"
@@ -14680,14 +14627,12 @@ msgid "Pad Editor"
 msgstr "Pad-Editor"
 
 #: pcbnew/dialogs/dialog_global_pads_edition_base.cpp:49
-#, fuzzy
 msgid "Change Pads on Footprint"
-msgstr "Ändere Pads am Bauteil"
+msgstr "Ändere Pads im Footprint"
 
 #: pcbnew/dialogs/dialog_global_pads_edition_base.cpp:52
-#, fuzzy
 msgid "Change Pads on Identical Footprints"
-msgstr "Ändere Pads an gleichen Bauteilen"
+msgstr "Ändere Pads an gleichen Footprints"
 
 #: pcbnew/dialogs/dialog_global_deletion_base.cpp:23
 msgid "Items to Delete"
@@ -14727,15 +14672,15 @@ msgstr "Gesperrte Leiterbahnen"
 
 #: pcbnew/dialogs/dialog_global_deletion_base.cpp:64
 msgid "Unlocked tracks"
-msgstr "Leiterbahnen entsperren"
+msgstr "Entsperrte Leiterbahnen"
 
 #: pcbnew/dialogs/dialog_global_deletion_base.cpp:72
 msgid "Locked footprints"
-msgstr "Alle Footprints sperren"
+msgstr "Gesperrte Footprints"
 
 #: pcbnew/dialogs/dialog_global_deletion_base.cpp:75
 msgid "Unlocked footprints"
-msgstr "Alle Footprints entsperren"
+msgstr "Entsperrte Footprints"
 
 #: pcbnew/dialogs/dialog_global_deletion_base.cpp:82
 msgid "All layers"
@@ -14756,7 +14701,7 @@ msgstr "Aktuelle Lage:"
 #: pcbnew/dialogs/dialog_global_edit_tracks_and_vias.cpp:173
 msgid "Set current Net tracks and vias sizes and drill to the current values?"
 msgstr ""
-"DuKo-, Leiterbahngrösse und Bohrdurchmesser innerhalb des gegenwärtigen "
+"Leiterbahngröße, DuKo- und Bohrdurchmesser innerhalb des gegenwärtigen "
 "Netzes auf aktuellen Wert setzen?"
 
 #: pcbnew/dialogs/dialog_global_edit_tracks_and_vias.cpp:183
@@ -14764,8 +14709,8 @@ msgid ""
 "Set current Net tracks and vias sizes and drill to the Netclass default "
 "value?"
 msgstr ""
-"DuKo-, Leiterbahngrössen und Bohrdurchmesser des gegenwärtigen Netzes als "
-"Defaultwert für Netzklasse verwenden?"
+"Leiterbahngröße, DuKo- und Bohrdurchmesser innerhalb des gegenwärtigen "
+"Netzes auf default Wert setzen?"
 
 #: pcbnew/dialogs/dialog_global_edit_tracks_and_vias.cpp:192
 msgid "Set All Tracks and Vias to Netclass value"
@@ -14783,7 +14728,7 @@ msgstr "Alle Leiterbahnen auf Netzklassenwert setzen?"
 #: pcbnew/dialogs/dialog_orient_footprints.cpp:119
 #, c-format
 msgid "OK to set footprints orientation to %.1f degrees ?"
-msgstr "Möchten Sie die Footprintausrichtung auf %.1f Grad setzen?"
+msgstr "Möchten Sie die Footprint Ausrichtung auf %.1f Grad setzen?"
 
 #: pcbnew/dialogs/dialog_orient_footprints.cpp:150
 msgid "Bad value for footprints orientation"
@@ -14863,18 +14808,20 @@ msgstr "Die ausgewählte Netzklasse um eine Position nach oben verschieben"
 msgid "Membership:"
 msgstr "Zugehörigkeit:"
 
+# No translation needed
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:115
 msgid "<<<"
-msgstr "<<<"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:116
 msgid "Move the selected nets in the right list to the left list"
 msgstr ""
 "Die in der rechten Liste ausgewählten Netze in die linke Liste verschieben"
 
+# No translation needed
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:120
 msgid ">>>"
-msgstr ">>>"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:121
 msgid "Move the selected nets in the left list to the right list"
@@ -14923,7 +14870,7 @@ msgid ""
 "Do not allow is the usual selection.\n"
 "Note: micro vias are a special type of blind vias and are not managed here"
 msgstr ""
-"Blinde/Vergrabene Durchkontaktieren zulassen oder verbieten.\n"
+"Blinde/Vergrabene Durchkontaktierungen zulassen oder verbieten.\n"
 "Diese nicht zu erlauben ist die übliche Einstellung.\n"
 "Achtung: Micro-DuKo's sind eine besondere Art von blinden DuKo's und werden "
 "hier nicht verwaltet."
@@ -14982,7 +14929,7 @@ msgstr ""
 
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:258
 msgid "Custom Via Sizes:"
-msgstr "Benutzerdefinierte DuKo-Grössen:"
+msgstr "Benutzerdefinierte DuKo-Größen:"
 
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:260
 msgid "Drill value: a blank or 0 => default Netclass value"
@@ -15094,7 +15041,7 @@ msgstr "Globale Design Regeln"
 
 #: pcbnew/dialogs/dialog_layer_selection_base.cpp:116
 msgid "Top/Front Layer"
-msgstr "Ober-/frontseite"
+msgstr "Ober-/Frontseite"
 
 #: pcbnew/dialogs/dialog_layer_selection_base.cpp:154
 msgid "Bottom/Back Layer"
@@ -15126,7 +15073,7 @@ msgstr "0.1 Grad"
 
 #: pcbnew/dialogs/dialog_graphic_item_properties_base.cpp:105
 msgid "Item thickness:"
-msgstr "Elementenstärke:"
+msgstr "Elementstärke:"
 
 #: pcbnew/dialogs/dialog_graphic_item_properties_base.cpp:117
 msgid "Default thickness:"
@@ -15175,18 +15122,16 @@ msgid "Duplicates:"
 msgstr "Duplikate:"
 
 #: pcbnew/dialogs/dialog_netlist.cpp:271
-#, fuzzy
 msgid "No missing footprints."
-msgstr "Footprint zuweisen"
+msgstr "Keine fehlenden Footprints."
 
 #: pcbnew/dialogs/dialog_netlist.cpp:274
 msgid "Missing:"
 msgstr "Fehlend:"
 
 #: pcbnew/dialogs/dialog_netlist.cpp:290
-#, fuzzy
 msgid "No extra footprints."
-msgstr "Zusätzliche Footprints"
+msgstr "Keine zusätzliche Footprints."
 
 #: pcbnew/dialogs/dialog_netlist.cpp:293
 msgid "Not in Netlist:"
@@ -15197,9 +15142,8 @@ msgid "Too many errors: some are skipped"
 msgstr "Zu viele Fehler: Einige wurden übersprungen"
 
 #: pcbnew/dialogs/dialog_netlist.cpp:322
-#, fuzzy
 msgid "Check footprints"
-msgstr "Alle Footprints sperren"
+msgstr "Footprints prüfen"
 
 #: pcbnew/dialogs/dialog_netlist.cpp:362
 msgid "Save contents of message window"
@@ -15208,7 +15152,7 @@ msgstr "Vorliegende Meldungen speichern"
 #: pcbnew/dialogs/dialog_netlist.cpp:379
 #, c-format
 msgid "Cannot write message contents to file \"%s\"."
-msgstr "Konnte die Datei \"%s\" mit Meldungen erstellen."
+msgstr "Konnte Meldung nicht in Datei \"%s\" schreiben."
 
 #: pcbnew/dialogs/dialog_netlist.cpp:381
 msgid "File Write Error"
@@ -15223,6 +15167,7 @@ msgstr ""
 "Fehler beim Einlesen der Netzliste:\n"
 "%s"
 
+# No translation needed
 #: pcbnew/dialogs/dialog_pns_diff_pair_dimensions_base.cpp:32
 #: pcbnew/dialogs/dialog_pns_diff_pair_dimensions_base.cpp:43
 #: pcbnew/dialogs/dialog_pns_diff_pair_dimensions_base.cpp:60
@@ -15232,18 +15177,16 @@ msgid "u"
 msgstr ""
 
 #: pcbnew/dialogs/dialog_pns_diff_pair_dimensions_base.cpp:36
-#, fuzzy
 msgid "Trace gap:"
-msgstr "Leiterbahn "
+msgstr "Abstand Zwischenraum:"
 
 #: pcbnew/dialogs/dialog_pns_diff_pair_dimensions_base.cpp:49
-#, fuzzy
 msgid "Via gap:"
-msgstr "Durchkontaktierungen:"
+msgstr "Abstand Durchkontaktierung:"
 
 #: pcbnew/dialogs/dialog_pns_diff_pair_dimensions_base.cpp:70
 msgid "Via gap same as trace gap"
-msgstr ""
+msgstr "Abstand DoKu gleich wie Abstand Zwischenraum"
 
 #: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:79
 msgid "Footprint Name in Library"
@@ -15305,7 +15248,7 @@ msgid ""
 "This value can be superseded by a pad local value.\n"
 "If 0, the global value is used"
 msgstr ""
-"Dies ist das lokale Abstandsmaß zwischen Pads und Lötstoppmaske\n"
+"Dies ist das lokale Abstandsmaß zwischen Pads und Lötstopmaske\n"
 "für diesen Footprint.\n"
 "Dieser Wert kann durch den lokalen Wert eines Pads ersetzt werden.\n"
 "Wenn 0, wird der globale Wert verwendet."
@@ -15330,7 +15273,7 @@ msgstr ""
 "Dieser Wert kann durch den lokalen Wert eines Pads ersetzt werden.\n"
 "Das endgültige Abstandsmaß ist die Summe aus diesem Wert und dem "
 "Abstandsmaßverhältnis.\n"
-"Ein negativer Wert bedeutet, dass die Maskengrösse kleiner als die Padgrösse "
+"Ein negativer Wert bedeutet, dass die Maskengröße kleiner als die Padgröße "
 "ist."
 
 #: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:211
@@ -15347,12 +15290,12 @@ msgstr ""
 "Dies ist das lokale Abstandsverhältnis in Prozent zwischen Pads und "
 "Lötpaste\n"
 "für diesen Footprint.\n"
-"Ein Wert von 10 bedeutet, dass das Abstandsmaß 10 Prozent der Padgrösse "
+"Ein Wert von 10 bedeutet, dass das Abstandsmaß 10 Prozent der Padgröße "
 "entspricht.\n"
 "Dieser Wert kann durch den lokalen Wert eines Pads ersetzt werden.\n"
 "Das endgültige Abstandsmaß ist die Summe aus diesem Wert und dem "
 "Abstandsmaß.\n"
-"Ein negativer Wert bedeutet, dass die Maskengrösse kleiner als die Padgrösse "
+"Ein negativer Wert bedeutet, dass die Maskengröße kleiner als die Padgröße "
 "ist."
 
 #: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:236
@@ -15361,7 +15304,6 @@ msgid "Properties"
 msgstr "Eigenschaften"
 
 #: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:241
-#, fuzzy
 msgid "3D Shape Names"
 msgstr "Name der 3D Form"
 
@@ -15383,7 +15325,7 @@ msgstr "Skalierung der Form:"
 #: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:271
 #: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:337
 msgid "Shape Offset (inch):"
-msgstr "Offset der Form (inch):"
+msgstr "Offset der Form (Zoll):"
 
 #: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:280
 #: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:346
@@ -15402,9 +15344,8 @@ msgstr "3D Form entfernen"
 
 #: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:299
 #: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:365
-#, fuzzy
 msgid "Edit Filename"
-msgstr "Dateiname:"
+msgstr "Editiere Dateiname"
 
 #: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:312
 #: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:378
@@ -15434,7 +15375,6 @@ msgid "Show all (alphabetical)"
 msgstr "Zeige alles (alphabetisch)"
 
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:67
-#, fuzzy
 msgid "Show all (pad count)"
 msgstr "Zeige alles (fortlaufend)"
 
@@ -15443,7 +15383,6 @@ msgid "Filtered (alphabetical)"
 msgstr "Gefiltert (alphabetisch)"
 
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:67
-#, fuzzy
 msgid "Filtered (pad count)"
 msgstr "Gefiltert (fortlaufend)"
 
@@ -15463,10 +15402,11 @@ msgstr ""
 msgid "Visible net filter:"
 msgstr "Sichtbare Netzfilter:"
 
+# No translation needed
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:87
 #: pcbnew/dialogs/dialog_orient_footprints_base.cpp:35
 msgid "*"
-msgstr "*"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:89
 msgid ""
@@ -15559,15 +15499,17 @@ msgstr "Füllmodus:"
 msgid "Segments / 360 deg:"
 msgstr "Segmente / 360 Grad:"
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:215
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:45
 msgid "16"
-msgstr "16"
+msgstr ""
 
+# No translation needed
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:215
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:45
 msgid "32"
-msgstr "32"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:227
 msgid "Outline slope:"
@@ -15579,7 +15521,7 @@ msgstr "Beliebig"
 
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:231
 msgid "H, V, and 45 deg only"
-msgstr "H, V und 45 Grad"
+msgstr "H, V und (nur) 45 Grad"
 
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:237
 msgid "Outline style:"
@@ -15602,7 +15544,7 @@ msgid ""
 "Export this zone setup (excluding layer and net selection) to all other "
 "copper zones."
 msgstr ""
-"Exportiere Flächeneinstellungen (ausser Lagen und Netzauswahl) an alle "
+"Exportiere Flächeneinstellungen (außer Lagen und Netzauswahl) an alle "
 "anderen Kupferflächen."
 
 #: pcbnew/dialogs/dialog_SVG_print_base.cpp:28
@@ -15642,7 +15584,7 @@ msgid ""
 "specified."
 msgstr ""
 "Auswahl der Stiftbreite zum Zeichnen von Elementen, welche keine "
-"spezifizierte Stiftgrösse besitzen."
+"spezifizierte Stiftgröße besitzen."
 
 #: pcbnew/dialogs/dialog_SVG_print_base.cpp:73
 msgid "Print mode"
@@ -15678,7 +15620,7 @@ msgstr "Gespiegelt drucken"
 
 #: pcbnew/dialogs/dialog_SVG_print_base.cpp:92
 msgid "Print the layer(s) horizontally mirrored"
-msgstr ""
+msgstr "Die Lage(n) horizontal gespiegelt ausdrucken"
 
 #: pcbnew/dialogs/dialog_SVG_print_base.cpp:102
 msgid "One file per layer"
@@ -15702,10 +15644,11 @@ msgstr "Plotten"
 msgid "Plot format:"
 msgstr "Plotformat:"
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_plot_base.cpp:31
 #: pcbnew/dialogs/dialog_gendrill_base.cpp:74
 msgid "Gerber"
-msgstr "Gerber"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:52
 #: pcbnew/dialogs/dialog_gen_module_position_file_base.cpp:32
@@ -15725,7 +15668,6 @@ msgid "Plot pads on silkscreen"
 msgstr "Drucke Pads des Siebdruckes"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:95
-#, fuzzy
 msgid ""
 "Enable plotting of pads on silkscreen layers\n"
 "When disabled, pads are never plotted on silkscreen layers\n"
@@ -15737,40 +15679,36 @@ msgstr ""
 "erscheinen."
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:99
-#, fuzzy
 msgid "Plot footprint values"
-msgstr "Zeige Footprintwerte"
+msgstr "Plotte Footprintwerte"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:103
-#, fuzzy
 msgid "Plot footprint references"
-msgstr "Zeige Footprintreferenzen"
+msgstr "Plotte Footprintreferenzen"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:106
-#, fuzzy
 msgid "Force plotting of invisible values/references"
-msgstr "Erzwinge das Ploten unsichtbarer Werte/Referenzen"
+msgstr "Erzwinge das Plotten unsichtbarer Werte/Referenzen"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:107
 msgid "Force plot invisible values and/or references"
-msgstr "Erzwinge das Ploten unsichtbarer Werte und/oder Referenzen"
+msgstr "Erzwinge das Plotten unsichtbarer Werte und/oder Referenzen"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:111
 msgid "Do not tent vias"
 msgstr "Durchkontaktierungen nicht umschließen"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:112
-#, fuzzy
 msgid "Remove soldermask on vias"
-msgstr "Entferne Lötstoppmaske an Durchkontaktierungen."
+msgstr "Entferne Lötstopmaske an Durchkontaktierungen."
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:116
 msgid "Exclude PCB edge layer from other layers"
-msgstr "Schliesse Platinenumrisslage von allen anderen Lagen aus"
+msgstr "Schließe Platinenumrisslage von allen anderen Lagen aus"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:117
 msgid "Exclude contents of the pcb edge layer from all other layers"
-msgstr "Schliesse Inhalt von Platinen-Umriss-Lage von allen anderen Lagen aus"
+msgstr "Schließe Inhalt von Platinen-Umriss-Lage von allen anderen Lagen aus"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:121
 msgid "Mirrored plot"
@@ -15785,9 +15723,8 @@ msgid "Use auxiliary axis as origin"
 msgstr "Verwende Hilfsachsen als Ursprungspunkt"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:128
-#, fuzzy
 msgid "Use auxiliary axis as coordinates origin in plot files"
-msgstr "Verwende Hilfsachsen als Koordinatenursprung in Gerberdateien."
+msgstr "Verwende Hilfsachsen als Koordinatenursprung in Plottdateien."
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:138
 msgid "Drill marks:"
@@ -15800,7 +15737,7 @@ msgstr "Klein"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:142
 msgid "Actual size"
-msgstr "Gegenwärtige Grösse"
+msgstr "Gegenwärtige Größe"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:148
 msgid "Scaling:"
@@ -15810,25 +15747,29 @@ msgstr "Skalierung:"
 msgid "Auto"
 msgstr "Autozoom"
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_plot_base.cpp:152
 msgid "1:1"
-msgstr "1:1"
+msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_plot_base.cpp:152
 msgid "3:2"
-msgstr "3:2"
+msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_plot_base.cpp:152
 msgid "2:1"
-msgstr "2:1"
+msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_plot_base.cpp:152
 msgid "3:1"
-msgstr "3:1"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:158
 msgid "Plot mode:"
-msgstr "Plotmodus:"
+msgstr "Plottmodus:"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:162
 #: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:53
@@ -15854,11 +15795,11 @@ msgstr "Linienbreite für z.B. Schaltplanreferenzen."
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:190
 msgid "Current solder mask settings:"
-msgstr "Aktuelle Einstellungen der Lötstoppmaske:"
+msgstr "Aktuelle Einstellungen der Lötstopmaske:"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:199
 msgid "Margin between pads and solder mask"
-msgstr "Abstandsflächen zwischen Pads und Lötstoppmaske"
+msgstr "Abstandsflächen zwischen Pads und Lötstopmaske"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:203
 #: pcbnew/dialogs/dialog_plot_base.cpp:213
@@ -15866,45 +15807,42 @@ msgid "val"
 msgstr "Wert"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:209
-#, fuzzy
 msgid ""
 "Minimum distance between 2 pad areas.\n"
 "Two pad areas nearer than this value will be merged during plotting"
 msgstr ""
 "Mindestabstand zwischen zwei Padflächen.\n"
 "Zwei Padflächen, welche sich näher sind als dieser Wert, werden beim Plotten "
-"zusammengefaßt."
+"zusammengefasst."
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:223
 msgid "Gerber Options"
 msgstr "Gerber Optionen"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:228
-#, fuzzy
 msgid "Use Protel filename extensions"
 msgstr "Verwende geeignete Endung für Dateinamen"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:229
-#, fuzzy
 msgid "Use conventional Protel Gerber extensions - .GBL, .GTL, etc..."
 msgstr "Verwende passende Gerberendung - .GBL, .GTL, etc..."
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:233
-#, fuzzy
 msgid "Include extended attributes"
-msgstr "Inklusive Textelementen"
+msgstr "Inklusive erweiterter Attribute"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:234
 msgid "Include extended attributes (X2 Gerber files format) in the Gerber file"
 msgstr ""
+"Inklusive erweiterter Attribute in der Gerberdatei (X2 Gerber Datei Format)"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:238
 msgid "Subtract soldermask from silkscreen"
-msgstr "Subtrahiere Lötstoppmaske von Siebdruckmaske"
+msgstr "Subtrahiere Lötstopmaske von Siebdruckmaske"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:239
 msgid "Remove silkscreen from areas without soldermask"
-msgstr "Entferne Siebdruck von Bereichen ohne Lötstoppmaske"
+msgstr "Entferne Siebdruck von Bereichen ohne Lötstopmaske"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:246
 msgid "4.5 (unit  mm)"
@@ -15919,10 +15857,12 @@ msgid ""
 "Resolution of coordinates in Gerber files.\n"
 "Use the higher value if possible."
 msgstr ""
+"Auflösung der Koordinaten in Gerberdateien.\n"
+"Höchsten Wert benutzen wenn möglich."
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:265
 msgid "Pen size"
-msgstr "Stiftgrösse"
+msgstr "Stiftgröße"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:279
 msgid "Pen overlay"
@@ -15930,7 +15870,7 @@ msgstr "Stiftabdeckung"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:285
 msgid "Set plot overlay for filling"
-msgstr "Setze Plot Ausfüll-Überlagerung"
+msgstr "Setze Plot für Ausfüll-Überlagerung"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:298
 msgid "Postscript Options"
@@ -15968,8 +15908,8 @@ msgstr ""
 "Breite.\n"
 "Diese Breitenkorrektur ist für eine Kompensation von Fehlern bei "
 "Leiterbahnbreiten, Pads und DuKo-Größen vorgesehen.\n"
-"Eine angemessener Breitenkorrekturwert muß innerhalb eines Bereiches von [-"
-"(Min.Leiterbahnbreite-1), +(MinAbstandswert-1)] Dezimil liegen."
+"Eine angemessener Breitenkorrekturwert muss innerhalb eines Bereiches von [-"
+"(Min.Leiterbahnbreite-1), +(MinAbstandswert-1)] Dezimillimeter liegen."
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:354
 msgid "Force A4 output"
@@ -16009,7 +15949,7 @@ msgstr "Eine Datei für Platine"
 
 #: pcbnew/dialogs/dialog_gen_module_position_file_base.cpp:60
 msgid "Files:"
-msgstr "Datein:"
+msgstr "Dateien:"
 
 #: pcbnew/dialogs/dialog_gen_module_position_file_base.cpp:62
 msgid ""
@@ -16044,25 +15984,21 @@ msgstr ""
 "Achtung: Diese Option wird die Platine modifizieren."
 
 #: pcbnew/dialogs/dialog_move_exact.cpp:135
-#, fuzzy
 msgid "Distance:"
-msgstr "Pin entfernen"
+msgstr "Abstand:"
 
 #: pcbnew/dialogs/dialog_move_exact.cpp:136
 #: pcbnew/dialogs/dialog_create_array_base.cpp:214
-#, fuzzy
 msgid "Angle:"
 msgstr "Winkel"
 
 #: pcbnew/dialogs/dialog_move_exact.cpp:142
-#, fuzzy
 msgid "Move vector X:"
-msgstr "Text verschieben"
+msgstr "Verschiebe Vektor X:"
 
 #: pcbnew/dialogs/dialog_move_exact.cpp:143
-#, fuzzy
 msgid "Move vector Y:"
-msgstr "Text verschieben"
+msgstr "Verschiebe Vektor Y:"
 
 #: pcbnew/dialogs/dialog_layers_setup.cpp:352
 msgid "Enabled"
@@ -16116,7 +16052,7 @@ msgstr "Netzklassenname:"
 
 #: pcbnew/dialogs/dialog_global_edit_tracks_and_vias_base.cpp:82
 msgid "Track size"
-msgstr "Leiterbahngrösse"
+msgstr "Leiterbahngröße"
 
 #: pcbnew/dialogs/dialog_global_edit_tracks_and_vias_base.cpp:83
 msgid "Via diameter"
@@ -16182,9 +16118,8 @@ msgid "Create .dsn File and Launch FreeRouter"
 msgstr "dsn-Datei erstellen und FreeRouter starten"
 
 #: pcbnew/dialogs/dialog_freeroute_exchange.cpp:92
-#, fuzzy
 msgid "Create .dsn File"
-msgstr "Neue Datei erstellen"
+msgstr "Neue .dsn Datei erstellen"
 
 #: pcbnew/dialogs/dialog_freeroute_exchange.cpp:104
 msgid "Freeroute Help"
@@ -16227,14 +16162,14 @@ msgstr ""
 "unterschiedliche Datenträger)!"
 
 #: pcbnew/dialogs/dialog_SVG_print.cpp:274
-#, fuzzy, c-format
+#, c-format
 msgid "Could not write plot files to folder '%s'."
 msgstr "Konnte die Plotdateien nicht in dem Verzeichnis '%s' anlegen."
 
 #: pcbnew/dialogs/dialog_SVG_print.cpp:311
-#, fuzzy, c-format
+#, c-format
 msgid "** Unable to create '%s'**\n"
-msgstr "Konnte Datei <%s> nicht erstellen.\n"
+msgstr "** Konnte Datei '%s' nicht erstellen. **\n"
 
 #: pcbnew/dialogs/dialog_fp_lib_table.cpp:205
 msgid "Library Path"
@@ -16247,7 +16182,7 @@ msgstr "Plugintyp"
 #: pcbnew/dialogs/dialog_fp_lib_table.cpp:427
 #, c-format
 msgid "Illegal character '%s' found in Nickname: '%s' in row %d"
-msgstr "Unzulässiges Zeichen '%s' gefunden im Nicknamen '%s' und Zeile '%d'."
+msgstr "Unzulässiges Zeichen '%s' gefunden im Nicknamen '%s' und Zeile %d."
 
 #: pcbnew/dialogs/dialog_fp_lib_table.cpp:441
 msgid "No Colon in Nicknames"
@@ -16262,21 +16197,22 @@ msgstr "Doppelter Nickname: '%s' in Zeile %d und %d"
 msgid "Please Delete or Modify One"
 msgstr "Bitte einen Nicknamen entfernen oder ändern."
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_dimension_editor_base.cpp:21
 #: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:24
 #: pcbnew/dialogs/dialog_edit_module_text.cpp:128
 msgid "Text:"
-msgstr "Text:"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_dimension_editor_base.cpp:37
 #: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:43
 msgid "Size X"
-msgstr "Grösse X"
+msgstr "Größe X"
 
 #: pcbnew/dialogs/dialog_dimension_editor_base.cpp:45
 #: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:76
 msgid "Size Y"
-msgstr "Grösse Y"
+msgstr "Größe Y"
 
 #: pcbnew/dialogs/dialog_dimension_editor_base.cpp:61
 msgid "Text position X"
@@ -16287,7 +16223,6 @@ msgid "Text position Y"
 msgstr "Textposition Y"
 
 #: pcbnew/dialogs/dialog_netlist_fbp.cpp:33
-#, fuzzy
 msgid "Footprint Selection"
 msgstr "Footprintsauswahl:"
 
@@ -16311,7 +16246,6 @@ msgid "From separate .cmp file"
 msgstr "Von separater cmp-Datei"
 
 #: pcbnew/dialogs/dialog_netlist_fbp.cpp:41
-#, fuzzy
 msgid "Footprint Name Source"
 msgstr "Footprintname in Bibliothek"
 
@@ -16339,9 +16273,8 @@ msgid "Change"
 msgstr "Ändern"
 
 #: pcbnew/dialogs/dialog_netlist_fbp.cpp:49
-#, fuzzy
 msgid "Exchange Footprint"
-msgstr "Zusätzliche Footprints"
+msgstr "Austausch Footprint"
 
 #: pcbnew/dialogs/dialog_netlist_fbp.cpp:51
 msgid ""
@@ -16410,7 +16343,7 @@ msgstr ""
 
 #: pcbnew/dialogs/dialog_netlist_fbp.cpp:114
 msgid "Save Messages to File"
-msgstr "Meldungen speichern"
+msgstr "Meldungen in Datei speichern"
 
 #: pcbnew/dialogs/dialog_netlist_fbp.cpp:129
 msgid "Dry run. Only report changes in message panel"
@@ -16458,17 +16391,20 @@ msgstr "Datei für Netzliste:"
 msgid "Side"
 msgstr "Seite"
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:66
 msgid "+90.0"
-msgstr "+90.0"
+msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:66
 msgid "-90.0"
-msgstr "-90.0"
+msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:66
 msgid "180.0"
-msgstr "180.0"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:66
 msgid "User"
@@ -16483,17 +16419,14 @@ msgid "Sheet path:"
 msgstr "Schaltplanpfad:"
 
 #: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:131
-#, fuzzy
 msgid "Change Footprint(s)"
-msgstr "Footprint speichern"
+msgstr "Footprint(s) ändern"
 
 #: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:146
-#, fuzzy
 msgid "Lock pads"
-msgstr "Gesperrt"
+msgstr "Pad sperren"
 
 #: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:146
-#, fuzzy
 msgid "Lock module"
 msgstr "Bauteil sperren"
 
@@ -16515,7 +16448,7 @@ msgid ""
 "If 0, the Netclass values are used\n"
 "This value can be superseded by a pad local value."
 msgstr ""
-"Dies ist das lokale Netzklassenabstandsmaß für alle Pads diesen Footprints.\n"
+"Dies ist das lokale Netzklassenabstandsmaß für alle Pads dieses Footprints.\n"
 "Wenn 0, werden die Werte der Netzklasse verwendet.\n"
 "Dieser Wert kann durch den lokalen Wert eines Pads ersetzt werden."
 
@@ -16540,13 +16473,12 @@ msgid "Footprint Filter:"
 msgstr "Footprintfilter:"
 
 #: pcbnew/dialogs/dialog_global_modules_fields_edition_base.cpp:42
-#, fuzzy
 msgid ""
 "A string to filter footprints to edit.\n"
 "If not void, footprint names should match this filter.\n"
 "A filter can be something like SM* (case insensitive)"
 msgstr ""
-"Ein Muster, um nach zu editierenden Bauteilen zu filtern.\n"
+"Ein Muster, um nach zu editierenden Footprints zu filtern.\n"
 "Wenn angegeben, sollte der Filter mit Footprintnamen übereinstimmen.\n"
 "Ein Filter kann etwas sein wie SM* (Groß-/Kleinschreibung berücksichtigend)"
 
@@ -16562,9 +16494,10 @@ msgstr "Stärke:"
 msgid "Plugin Options:"
 msgstr "Pluginoptionen:"
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_fp_plugin_options_base.cpp:39
 msgid "Option"
-msgstr "Option"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_fp_plugin_options_base.cpp:57
 msgid "Append"
@@ -16610,12 +16543,12 @@ msgstr "Abstandsfläche muss kleiner sein als %f\" / %f mm."
 #: pcbnew/dialogs/dialog_copper_zones.cpp:419
 #, c-format
 msgid "Minimum width must be larger than %f\" / %f mm."
-msgstr "Mindestbreite muss grösser sein als %f\" / %f mm."
+msgstr "Mindestbreite muss größer sein als %f\" / %f mm."
 
 #: pcbnew/dialogs/dialog_copper_zones.cpp:457
 msgid "Thermal relief spoke must be greater than the minimum width."
 msgstr ""
-"Die Breite der Wärmeabführungsspeiche muß größer als die Mindestbreite sein."
+"Die Breite der Wärmeabführungsspeiche muss größer als die Mindestbreite sein."
 
 #: pcbnew/dialogs/dialog_copper_zones.cpp:470
 #: pcbnew/dialogs/dialog_keepout_area_properties.cpp:223
@@ -16643,95 +16576,86 @@ msgid "Fillet radius"
 msgstr "Auskehlungsradius"
 
 #: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:20
-#, fuzzy
 msgid "Length/skew"
-msgstr "Länge"
+msgstr "Länge/Versatz"
 
 #: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:28
 msgid "Tune from:"
-msgstr ""
+msgstr "Anpassen von:"
 
 #: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:37
 msgid "Tune to:"
-msgstr ""
+msgstr "Anpassen nach:"
 
 #: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:46
-#, fuzzy
 msgid "Constraint:"
-msgstr "Hochformat"
+msgstr "Bedingung:"
 
 #: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:50
-#, fuzzy
 msgid "from Design Rules"
-msgstr "Design Regeln"
+msgstr "aus Design Regeln"
 
 #: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:50
 msgid "manual"
-msgstr ""
+msgstr "manuell"
 
 #: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:58
-#, fuzzy
 msgid "Target length:"
-msgstr "Netzlänge:"
+msgstr "Ziellänge:"
 
 #: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:82
-#, fuzzy
 msgid "Meandering"
-msgstr "Elemente"
+msgstr "Mäandrierung"
 
 #: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:93
 msgid "Min amplitude (Amin):"
-msgstr ""
+msgstr "Minimale Amplitude (Amin):"
 
 #: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:104
 msgid "Max amplitude (Amax):"
-msgstr ""
+msgstr "Maximale Amplitude (Amax):"
 
 #: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:115
 msgid "Spacing (s):"
-msgstr ""
+msgstr "Zwischenraum (s):"
 
 #: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:126
-#, fuzzy
 msgid "Miter radius (r):"
-msgstr "Auskehlungsradius"
+msgstr "Auskehlungsradius (r):"
 
 #: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:137
-#, fuzzy
 msgid "Miter style:"
-msgstr "Flächendarstellung:"
+msgstr "Auskehlungsdarstellung:"
 
 #: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:143
-#, fuzzy
 msgid "45 degree"
-msgstr "0.1 Grad"
+msgstr "45 Grad"
 
 #: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:143
-#, fuzzy
 msgid "arc"
 msgstr "Kreisbogen"
 
 #: pcbnew/dialogs/dialog_move_exact_base.cpp:19
-#, fuzzy
 msgid "Use polar coordinates"
-msgstr "Polarkoordinaten einblenden"
+msgstr "Polarkoordinaten benutzen"
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_move_exact_base.cpp:28
 msgid "x:"
 msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_move_exact_base.cpp:42
 msgid "y:"
 msgstr ""
 
 #: pcbnew/dialogs/dialog_move_exact_base.cpp:56
-#, fuzzy
 msgid "Item rotation:"
-msgstr "Fläche Rotation"
+msgstr "Element Rotation:"
 
 #: pcbnew/dialogs/dialog_plot.cpp:593
 msgid "HPGL pen size constrained!\n"
-msgstr "HPGL Stiftgrösse eingeschränkt!\n"
+msgstr "HPGL Stiftgröße eingeschränkt!\n"
 
 #: pcbnew/dialogs/dialog_plot.cpp:606
 msgid "HPGL pen overlay constrained!\n"
@@ -16757,7 +16681,7 @@ msgid ""
 " [%+f; %+f] (%s) for current design rules!\n"
 msgstr ""
 "Korrektur für die Breite wurde eingeschränkt!\n"
-"Ein angemessener Breitenkorrekturwert muß sich in einem Bereich von\n"
+"Ein angemessener Breitenkorrekturwert muss sich in einem Bereich von\n"
 " [%+f; %+f] (%s) für die aktuellen Designregeln befinden!\n"
 
 #: pcbnew/dialogs/dialog_plot.cpp:812
@@ -16775,19 +16699,14 @@ msgid "Current footprint"
 msgstr "Aktueller Footprint"
 
 #: pcbnew/dialogs/dialog_exchange_modules_base.cpp:55
-#, fuzzy
 msgid "Change footprint"
-msgstr "Neuer Footprint"
+msgstr "Ändere Footprint"
 
 #: pcbnew/dialogs/dialog_exchange_modules_base.cpp:55
-#, fuzzy
 msgid "Change same footprint"
-msgstr ""
-"\n"
-"Kann den Footprint nicht aktualisieren"
+msgstr "Gleichen Footprint ändern"
 
 #: pcbnew/dialogs/dialog_exchange_modules_base.cpp:55
-#, fuzzy
 msgid "Ch. same footprint+value"
 msgstr "Gleiche Bauteile+Wert ändern"
 
@@ -16824,13 +16743,12 @@ msgid "delete track segment having a dangling end"
 msgstr "Entferne baumelnde Leiterbahnsegmente"
 
 #: pcbnew/dialogs/dialog_graphic_item_properties.cpp:192
-#, fuzzy
 msgid ""
 "This item was on an unknown layer.\n"
 "It has been moved to the drawings layer. Please fix it."
 msgstr ""
-"Dieses Element besitzt eine ungültige Id und wurde deshalb\n"
-"auf der Lage für Symbole und Zeichnungen platziert.\n"
+"Dieses Element war auf einer ungültigen Lage.\n"
+"Es wurde auf der Lage für Symbole und Zeichnungen platziert.\n"
 "Bitte korrigieren Sie dies ggfs."
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:23
@@ -16838,12 +16756,10 @@ msgid "Tracks and vias:"
 msgstr "Leiterbahnen und Durchkontaktierungen:"
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:25
-#, fuzzy
 msgid "Tracks sketch mode"
 msgstr "Leiterbahnen als Umrisse darstellen"
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:28
-#, fuzzy
 msgid "Vias sketch mode"
 msgstr "DuKo's als Umrisse darstellen"
 
@@ -16853,7 +16769,7 @@ msgstr "Definierte Bohrdurchmesser"
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:33
 msgid "Show Via Holes:"
-msgstr "Durchkontaktierungsbohrungen:"
+msgstr "Zeige Durchkontaktierungsbohrungen:"
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:35
 msgid ""
@@ -16862,7 +16778,7 @@ msgid ""
 msgstr ""
 "Anzeige von Durchkontaktierungsbohrungen.\n"
 "Wenn 'Definierte Bohrdurchmesser' ausgewählt wurde,\n"
-"werden nur Bohrungen ohne Grössenvoreinstellung angezeigt."
+"werden nur Bohrungen ohne Größenvoreinstellung angezeigt."
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:43
 msgid "Routing help:"
@@ -16894,19 +16810,19 @@ msgstr "Anzeige von Netznamen an Pads und/oder Leiterbahnen"
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:53
 msgid "New track"
-msgstr "An neuen Leiterbahnen"
+msgstr "Neue Leiterbahn"
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:53
 msgid "New track with via area"
-msgstr "An neuen Leiterbahnen mit DuKo-Bereich"
+msgstr "Neue Leiterbahn mit DuKo-Bereich"
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:53
 msgid "New and edited tracks with via area"
-msgstr "An neuen und editierten Leiterbahnen mit DuKo-Bereich"
+msgstr "Neue und editierte Leiterbahnen mit DuKo-Bereich"
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:55
 msgid "Show Tracks Clearance:"
-msgstr "Leiterbahnabstandsflächen:"
+msgstr "Anzeige Leiterbahnabstandsfläche:"
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:57
 msgid ""
@@ -16919,22 +16835,20 @@ msgstr ""
 "nur während des Erstellens der Leiterbahn angezeigt."
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:70
-#, fuzzy
 msgid "Outlines sketch mode"
 msgstr "Silhouette als Umriss darstellen"
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:78
-#, fuzzy
 msgid "Pads sketch mode"
-msgstr "Pads als Umrisse darstellen"
+msgstr "Pads als Umriss darstellen"
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:81
 msgid "Show pad clearance"
-msgstr "Padabstandsflächen anzeigen"
+msgstr "Anzeige Padabstandsflächen"
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:84
 msgid "Show pad number"
-msgstr "Padnummerierungen anzeigen"
+msgstr "Anzeige Padnummerierungen"
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:88
 msgid "Show pad NoConnect"
@@ -17000,20 +16914,19 @@ msgstr "Kein Auffüllen von Kupferflächen"
 
 #: pcbnew/dialogs/dialog_pns_length_tuning_settings.cpp:52
 msgid "Single track length tuning"
-msgstr ""
+msgstr "Anpassen einzelner Leiterbahnlänge"
 
 #: pcbnew/dialogs/dialog_pns_length_tuning_settings.cpp:58
 msgid "Differential pair length tuning"
-msgstr ""
+msgstr "Anpassen der Länge von Differenziellem Paar"
 
 #: pcbnew/dialogs/dialog_pns_length_tuning_settings.cpp:64
 msgid "Differential pair skew tuning"
-msgstr ""
+msgstr "Anpassen derAbstimmung eines differenziellem Signalpaares"
 
 #: pcbnew/dialogs/dialog_pns_length_tuning_settings.cpp:66
-#, fuzzy
 msgid "Target skew: "
-msgstr "Zielgrösse %s"
+msgstr "Ziel Versatz:"
 
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:25
 msgid "Preset Layer Groupings"
@@ -17047,81 +16960,90 @@ msgstr "Alle Lagen ein"
 msgid "Copper Layers"
 msgstr "Kupferlagen"
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:45
 #: pcbnew/dialogs/dialog_create_array_base.cpp:231
 msgid "4"
-msgstr "4"
+msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:45
 msgid "6"
-msgstr "6"
+msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:45
 msgid "8"
-msgstr "8"
+msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:45
 msgid "12"
-msgstr "12"
+msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:45
 msgid "14"
-msgstr "14"
+msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:45
 msgid "18"
-msgstr "18"
+msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:45
 msgid "20"
-msgstr "20"
+msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:45
 msgid "22"
-msgstr "22"
+msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:45
 msgid "24"
-msgstr "24"
+msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:45
 msgid "26"
-msgstr "26"
+msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:45
-#, fuzzy
 msgid "28"
-msgstr "2"
+msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:45
-#, fuzzy
 msgid "30"
-msgstr "3"
+msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:84
 msgid "CrtYd_Front_later"
 msgstr ""
 
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:95
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:1242
-#, fuzzy
 msgid "If you want a courtyard layer for the front side of the board"
-msgstr "Wenn eine Lage für Siebdruck auf der Platinenvorderseite benötigt wird"
+msgstr "Wenn eine Courtyard Lage für die Platinenvorderseite benötigt wird"
 
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:105
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:1252
-#, fuzzy
 msgid "Off-board, testing"
-msgstr "Off-board, Fertigung"
+msgstr "Off-board, Test"
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:109
 msgid "Fab_Front_later"
 msgstr ""
 
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:120
-#, fuzzy
 msgid "If you want a fabrication layer for the front side of the board"
-msgstr "Wenn eine Lage für Siebdruck auf der Platinenvorderseite benötigt wird"
+msgstr "Wenn eine Fabrikationslage für die Platinenvorderseite benötigt wird"
 
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:130
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:155
@@ -17174,7 +17096,7 @@ msgstr ""
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:220
 msgid "If you want a solder mask layer for the front of the board"
 msgstr ""
-"Wenn eine Lage für Lötstoppmaske auf der Platinenvorderseite benötigt wird"
+"Wenn eine Lage für Lötstopmaske auf der Platinenvorderseite benötigt wird"
 
 # No translation needed
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:234
@@ -17368,131 +17290,152 @@ msgstr ""
 "Kupferlagentyp für Freerouter.\n"
 "Spannungs-/Stromlagen werden aus Freerouter's Lagenmenüs entfernt."
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:265
-#, fuzzy
 msgid "In1"
-msgstr "Innen1"
+msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:292
-#, fuzzy
 msgid "In2"
-msgstr "Innen2"
+msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:319
-#, fuzzy
 msgid "In3"
-msgstr "Innen3"
+msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:346
-#, fuzzy
 msgid "In4"
-msgstr "Innen4"
+msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:373
-#, fuzzy
 msgid "In5"
-msgstr "Innen5"
+msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:400
-#, fuzzy
 msgid "In6"
-msgstr "Innen6"
+msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:427
-#, fuzzy
 msgid "In7"
-msgstr "Innen7"
+msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:454
-#, fuzzy
 msgid "In8"
-msgstr "Innen8"
+msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:481
-#, fuzzy
 msgid "In9"
-msgstr "Innen9"
+msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:508
 msgid "In10"
 msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:535
 msgid "In11"
 msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:562
 msgid "In12"
 msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:589
 msgid "In13"
 msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:616
 msgid "In14"
 msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:643
 msgid "In15"
 msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:670
 msgid "In16"
 msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:697
 msgid "In17"
 msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:724
 msgid "In18"
 msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:751
 msgid "In19"
 msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:778
 msgid "In20"
 msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:805
 msgid "In21"
 msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:832
 msgid "In22"
 msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:859
 msgid "In23"
 msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:886
 msgid "In24"
 msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:913
 msgid "In25"
 msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:940
 msgid "In26"
 msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:967
 msgid "In27"
 msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:994
 msgid "In28"
 msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:1021
 msgid "In29"
 msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:1048
 msgid "In30"
 msgstr ""
@@ -17513,7 +17456,7 @@ msgstr ""
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:1117
 msgid "If you want a solder mask layer for the back side of the board"
 msgstr ""
-"Wenn eine Lage für Lötstoppmaske auf der Platinenrückseite benötigt wird"
+"Wenn eine Lage für Lötstopmaske auf der Platinenrückseite benötigt wird"
 
 # No translation needed
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:1131
@@ -17542,20 +17485,19 @@ msgstr ""
 msgid "If you want an adhesive layer for the back side of the board"
 msgstr "Wenn eine Lage für Kleber auf der Platinenrückseite benötigt wird"
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:1206
-#, fuzzy
 msgid "Fab_Back_later"
-msgstr "Rückseite"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:1217
-#, fuzzy
 msgid "If you want a fabrication layer for the back side of the board"
-msgstr "Wenn eine Lage für Siebdruck auf der Platinenrückseite benötigt wird"
+msgstr "Wenn eine Fabrikationslage für die Platinenrückseite benötigt wird"
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:1231
-#, fuzzy
 msgid "CrtYd_Back_later"
-msgstr "Rückseite"
+msgstr ""
 
 # No translation needed
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:1256
@@ -17570,10 +17512,12 @@ msgstr "Wenn eine Lage für den Platinenumfang benötigt wird"
 msgid "Board contour"
 msgstr "Platinenumriss"
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:1281
 msgid "Margin_later"
 msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:1300
 msgid "Edge_Cuts setback"
 msgstr ""
@@ -17611,7 +17555,7 @@ msgstr ""
 
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:1386
 msgid "If you want a layer for documentation drawings"
-msgstr "Wenn eine Lage für dokumentative Zeichnungen benötigt wird"
+msgstr "Wenn eine Lage für Dokumentationszeichnungen benötigt wird"
 
 #: pcbnew/dialogs/dialog_keepout_area_properties.cpp:214
 msgid "Tracks, vias and pads are allowed. The keepout is useless"
@@ -17624,11 +17568,13 @@ msgid ""
 "The footprint library is a folder with a name ending by .pretty\n"
 "Footprints are .kicad_mod files inside this folder."
 msgstr ""
+"Die Footprint Bibliothek ist ein Ordner dessen Name auf .pretty endet.\n"
+"Footprints sind Dateien mit der Erweiterung .kicad_mod innerhalb dieses "
+"Ordners."
 
 #: pcbnew/dialogs/dialog_select_pretty_lib_base.cpp:32
-#, fuzzy
 msgid "Library (.pretty folder)"
-msgstr "Bibliothekseinstellungen"
+msgstr "Bibliothek (.pretty Ordner)"
 
 #: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:22
 #: pcbnew/dialogs/dialog_print_using_printer_base.cpp:49
@@ -17688,7 +17634,7 @@ msgstr "16 fach"
 #: pcbnew/dialogs/dialog_print_using_printer_base.cpp:51
 #: gerbview/dialogs/dialog_print_using_printer_base.cpp:46
 msgid "Approx. Scale:"
-msgstr "Angenäherter Massstab:"
+msgstr "Angenäherter Maßstab:"
 
 #: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:36
 #: pcbnew/dialogs/dialog_print_using_printer_base.cpp:111
@@ -17724,7 +17670,7 @@ msgid ""
 "you must choose a min thickness value bigger than 0.001 inch (or 0.0254 mm)"
 msgstr ""
 "Fehler :\n"
-"Es muß eine Mindeststärke gewählt werden, welche grösser ist als 0.001 Zoll "
+"Es muss eine Mindeststärke gewählt werden, welche größer ist als 0.001 Zoll "
 "(oder 0.0254 mm)"
 
 #: pcbnew/dialogs/dialog_non_copper_zones_properties.cpp:232
@@ -17732,38 +17678,32 @@ msgid "Error : you must choose a layer"
 msgstr "Fehler : Sie müssen eine Lage wählen"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:29
-#, fuzzy
 msgid "x Count:"
-msgstr "Anzahl Löcher"
+msgstr "x Anzahl:"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:36
-#, fuzzy
 msgid "y Count:"
-msgstr "Anzahl Löcher"
+msgstr "y Anzahl:"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:43
-#, fuzzy
 msgid "x Spacing:"
-msgstr "Skalierung:"
+msgstr "x Zwischenraum:"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:54
-#, fuzzy
 msgid "y Spacing:"
-msgstr "Skalierung:"
+msgstr "y Zwischenraum:"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:65
-#, fuzzy
 msgid "x Offset:"
-msgstr "Offset"
+msgstr "x Offset:"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:76
-#, fuzzy
 msgid "y Offset:"
-msgstr "Offset"
+msgstr "y Offset:"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:87
 msgid "Stagger:"
-msgstr ""
+msgstr "Staffelung:"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:94
 msgid "Rows"
@@ -17774,77 +17714,73 @@ msgid "Columns"
 msgstr "Spalten"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:100
-#, fuzzy
 msgid "Stagger type:"
-msgstr "Padtyp:"
+msgstr "Staffelungstyp:"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:110
-#, fuzzy
 msgid "Horizontal, then vertical"
-msgstr "horizontal invertiert"
+msgstr "Horizontal, dann Vertikal"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:110
 msgid "Vertical, then horizontal"
-msgstr "Vertikal, dann horizontal"
+msgstr "Vertikal, dann Horizontal"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:112
-#, fuzzy
 msgid "Numbering direction:"
-msgstr "Trapezausrichtung:"
+msgstr "Nummerierungs Ausrichtung:"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:116
 msgid ""
 "Reverse numbering on \n"
 "alternate rows/columns"
 msgstr ""
+"Umgekehrte Nummerierung nach \n"
+"abwechselnder Reihe/Zeile"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:119
 #: pcbnew/dialogs/dialog_create_array_base.cpp:252
 msgid "Restart numbering"
-msgstr ""
+msgstr "Nummerierung neustarten"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:123
 msgid "Continuous (1, 2, 3...)"
-msgstr ""
+msgstr "Kontinuierlich (1, 2, 3 ...)"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:123
 msgid "Co-ordinate (A1, A2, ... B1, ...)"
-msgstr ""
+msgstr "Koordiniert (A1, A2, ... B1, ...)"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:125
-#, fuzzy
 msgid "Numbering scheme:"
-msgstr "Anzahl der Schaltpläne: %d"
+msgstr "Nummerierungsschema:"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:129
 msgid "Primary axis numbering:"
-msgstr ""
+msgstr "Primäre Achsen Nummerierung:"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:138
 msgid "Secondary axis numbering:"
-msgstr ""
+msgstr "Sekundäre Achsen Nummerierung:"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:154
 #: pcbnew/dialogs/dialog_create_array_base.cpp:268
-#, fuzzy
 msgid "Numbering start:"
-msgstr "Nummer:"
+msgstr "Start Nummerierung:"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:184
-#, fuzzy
 msgid "x Centre:"
-msgstr "In Bildmitte"
+msgstr "x Bildmitte"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:195
-#, fuzzy
 msgid "y Centre:"
-msgstr "In Bildmitte"
+msgstr "y Bildmitte:"
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_create_array_base.cpp:206
-#, fuzzy
 msgid "Radius:"
-msgstr "Radius"
+msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_create_array_base.cpp:210
 msgid "0 mm"
 msgstr ""
@@ -17854,31 +17790,32 @@ msgid ""
 "Positive angles represent an anti-clockwise rotation. An angle of 0 will "
 "produce a full circle divided evenly into \"Count\" portions."
 msgstr ""
+"Positive Winkel repräsentieren ein Rotation entgegen dem Uhrzeigersinn.\n"
+"Ein Winkel von 0 erstellt einen vollen Kreis geteilt in \"Teil\" Anteile"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:227
-#, fuzzy
 msgid "Count:"
-msgstr "Anzahl Löcher"
+msgstr "Anzahl:"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:232
 msgid "How many items in the array."
-msgstr ""
+msgstr "Wie viele Elemente sind im Array."
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:236
-#, fuzzy
 msgid "Rotate:"
-msgstr "Rotieren"
+msgstr "Rotieren:"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:242
 msgid ""
 "Rotate the item as well as move it - multi-selections will be rotated "
 "together"
 msgstr ""
+"Rotiere das Element auch beim bewegen, Multi-Selektionen werden zusammen "
+"rotiert"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:256
-#, fuzzy
 msgid "Numbering type:"
-msgstr "Nummer:"
+msgstr "Nummerierungstyp:"
 
 #: pcbnew/dialogs/dialog_freeroute_exchange_base.cpp:25
 msgid "Export/Import to/from FreeRoute:"
@@ -17893,14 +17830,15 @@ msgid "Export a Specctra DSN file (to FreeRouter)"
 msgstr "Exportiere eine Specctra DSN Datei (nach FreeRouter)"
 
 #: pcbnew/dialogs/dialog_freeroute_exchange_base.cpp:45
-#, fuzzy
 msgid "Export a Specctra Design and Launch FreeRoute"
-msgstr "Exportiere eine Specctra Design Datei (*.dsn)"
+msgstr "Exportiere eine Specctra Design Datei und starte FreeRouter"
 
 #: pcbnew/dialogs/dialog_freeroute_exchange_base.cpp:46
 msgid ""
 "FreeRouter can be run only if freeroute.jar is found in Kicad binaries folder"
 msgstr ""
+"Die Datei freeroute.jar muss im Ordner der KiCad Binarys gefunden werden "
+"damit FreeRouter ausgeführt werden kann."
 
 #: pcbnew/dialogs/dialog_freeroute_exchange_base.cpp:50
 msgid "Back Import the Specctra Session (*.ses) File"
@@ -17951,13 +17889,15 @@ msgstr ""
 msgid "User Defined Grid"
 msgstr "Benutzerdef. Raster"
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_set_grid_base.cpp:71
 msgid "X:"
-msgstr "X:"
+msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_set_grid_base.cpp:83
 msgid "Y:"
-msgstr "Y:"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_set_grid_base.cpp:98
 msgid "Reset Grid Origin"
@@ -17994,14 +17934,12 @@ msgid "No marker found"
 msgstr "Keine Marker gefunden"
 
 #: pcbnew/dialogs/dialog_export_idf_base.cpp:19
-#, fuzzy
 msgid "File name:"
-msgstr "&Dateiname:"
+msgstr "Dateiname:"
 
 #: pcbnew/dialogs/dialog_export_idf_base.cpp:23
-#, fuzzy
 msgid "Select an IDF export filename"
-msgstr "Dateiname für das zu erstellende Protokoll"
+msgstr "Wähle einen IDF-Export Dateinamen"
 
 #: pcbnew/dialogs/dialog_export_idf_base.cpp:26
 msgid "Mils"
@@ -18156,11 +18094,11 @@ msgstr "KiCad (*.Pretty Verzeichnis, enthält .kicad_mod Dateien)"
 
 #: pcbnew/dialogs/wizard_add_fplib_base.cpp:25
 msgid "GitHub (.Pretty lib stored on GitHub repos)"
-msgstr "GitHub (.Pretty Bibliothek im GitHub repos gespeichert)"
+msgstr "GitHub (.Pretty Bibliothek im GitHub Repos gespeichert)"
 
 #: pcbnew/dialogs/wizard_add_fplib_base.cpp:25
 msgid "Legacy ( old *.mod lib file)"
-msgstr "Legacy ( alte *.mod Bibliotheksdatei)"
+msgstr "Legacy (alte *.mod Bibliotheksdatei)"
 
 #: pcbnew/dialogs/wizard_add_fplib_base.cpp:25
 msgid "Eagle V6 xml library file"
@@ -18171,101 +18109,84 @@ msgid "Geda footprint folder (folder containing *.fp files)"
 msgstr "Geda Footprint Verzeichnis (Verzeichnis enthält *.fp Dateien)"
 
 #: pcbnew/dialogs/wizard_add_fplib_base.cpp:27
-#, fuzzy
 msgid "Library Format:"
-msgstr "Bibliothekspfad"
+msgstr "Bibliotheksformat:"
 
 #: pcbnew/dialogs/wizard_add_fplib_base.cpp:37
-#, fuzzy
 msgid "Default URL for KiCad libraries on Github:"
-msgstr "Voreingestellter Pfad für Bibliotheken"
+msgstr "Voreingestellte URL für KiCad Bibliotheken auf Github"
 
 #: pcbnew/dialogs/wizard_add_fplib_base.cpp:56
-#, fuzzy
 msgid "Use  path relative to the project"
-msgstr "Einen relativen Pfad verwenden?"
+msgstr "Relativen Pfad zum Projekt verwenden"
 
 #: pcbnew/dialogs/wizard_add_fplib_base.cpp:56
-#, fuzzy
 msgid "Use environment variable in path"
-msgstr "Umgebungsvariable"
+msgstr "Umgebungsvariable im Pfad benutzen"
 
 #: pcbnew/dialogs/wizard_add_fplib_base.cpp:56
-#, fuzzy
 msgid "Use absolute path"
-msgstr "Einen relativen Pfad verwenden?"
+msgstr "Absoluten Pfad verwenden"
 
 #: pcbnew/dialogs/wizard_add_fplib_base.cpp:58
-#, fuzzy
 msgid "Path management:"
-msgstr "Pfadabschnitt"
+msgstr "Pfadverwaltung:"
 
 #: pcbnew/dialogs/wizard_add_fplib_base.cpp:62
-#, fuzzy
 msgid "Environment variables:"
-msgstr "Umgebungsvariable"
+msgstr "Umgebungsvariablen:"
 
 #: pcbnew/dialogs/wizard_add_fplib_base.cpp:101
-#, fuzzy
 msgid "Add Environment Variable"
-msgstr "Umgebungsvariable"
+msgstr "Umgebungsvariable hinzufügen"
 
 #: pcbnew/dialogs/wizard_add_fplib_base.cpp:104
-#, fuzzy
 msgid "Remove Environment Variable"
-msgstr "Umgebungsvariable"
+msgstr "Umgebungsvariable entfernen"
 
 #: pcbnew/dialogs/wizard_add_fplib_base.cpp:131
-#, fuzzy
 msgid "Plugin type:"
-msgstr "Plugintyp"
+msgstr "Plugintyp:"
 
+# No translation needed.
 #: pcbnew/dialogs/wizard_add_fplib_base.cpp:135
-#, fuzzy
 msgid "KiCad"
-msgstr "KiCad beenden"
+msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/wizard_add_fplib_base.cpp:139
-#, fuzzy
 msgid "Option:"
-msgstr "Optionen:"
+msgstr ""
 
 #: pcbnew/dialogs/wizard_add_fplib_base.cpp:143
 #: pcbnew/dialogs/wizard_add_fplib_base.cpp:151
-#, fuzzy
 msgid "dummy"
 msgstr "Dummytext"
 
 #: pcbnew/dialogs/wizard_add_fplib_base.cpp:147
-#, fuzzy
 msgid "Path:"
-msgstr "Benutzerpfad:"
+msgstr "Pfad:"
 
 #: pcbnew/dialogs/wizard_add_fplib_base.cpp:161
-#, fuzzy
 msgid "Library list to add in Fp table:"
-msgstr ""
-"Auf die Bibliothek '%s' kann nur lesend und nicht schreibend zugegriffen "
-"werden."
+msgstr "Bibliotheksliste zum hinzufügen in der Fp Tabelle"
 
 #: pcbnew/dialogs/wizard_add_fplib_base.cpp:181
-#, fuzzy
 msgid "NickName"
 msgstr "Nickname"
 
 #: pcbnew/dialogs/wizard_add_fplib_base.cpp:182
-#, fuzzy
 msgid "Path"
 msgstr "Pfadvariante"
 
+# No translation needed.
 #: pcbnew/dialogs/wizard_add_fplib_base.cpp:183
 msgid "Plugin"
-msgstr "Plugin"
+msgstr ""
 
 #: pcbnew/dialogs/wizard_add_fplib_base.cpp:209
-#, fuzzy
 msgid "Remove FP Libraries"
-msgstr "Felder entfernen"
+msgstr "FP Bibliotheken entfernen"
 
 #: pcbnew/dialogs/dialog_pad_properties.cpp:343
 msgid "Back side (footprint is mirrored)"
@@ -18278,8 +18199,7 @@ msgstr "Padgröße muß größer als Null sein"
 #: pcbnew/dialogs/dialog_pad_properties.cpp:750
 msgid "Incorrect value for pad drill: pad drill bigger than pad size"
 msgstr ""
-"Inkorrekter Wert für Pad Bohrdurchmesser. Bohrdurchmesser ist grösser als "
-"Pad."
+"Inkorrekter Wert für Pad Bohrdurchmesser: Bohrdurchmesser ist größer als Pad."
 
 #: pcbnew/dialogs/dialog_pad_properties.cpp:756
 msgid "Error: pad has no layer"
@@ -18296,7 +18216,7 @@ msgid ""
 "For NPTH pad, set pad size value to pad drill value, if you do not want this "
 "pad plotted in gerber files"
 msgstr ""
-"Setze für ein NPTH-Pad die Padgrösse auf den Padbohrdurchmesser,\n"
+"Setze für ein NPTH-Pad die Padgröße auf den Padbohrdurchmesser,\n"
 "wenn dieses Pad nicht in Gerberdateien geplottet werden soll."
 
 #: pcbnew/dialogs/dialog_pad_properties.cpp:786
@@ -18316,7 +18236,7 @@ msgid ""
 "Error: Connector pads are not on the solder paste layer\n"
 "Use SMD pads instead"
 msgstr ""
-"Fehler: Anschlußpads befinden sich nicht auf der Lage der Lötstopppaste\n"
+"Fehler: Anschlusspads befinden sich nicht auf der Lage der Lötstoppaste\n"
 "Verwende stattdessen SMD-Pads"
 
 #: pcbnew/dialogs/dialog_pad_properties.cpp:817
@@ -18331,10 +18251,12 @@ msgstr "Unbekannter Netzname. Keine Änderung durchgeführt."
 msgid "Enter the text placed on selected layer."
 msgstr "Zu platzierenden Text für gewählte Lage eingeben."
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:47
 msgid "Position X"
-msgstr "Position X"
+msgstr ""
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:80
 msgid "Position Y"
 msgstr "Position Y"
@@ -18353,7 +18275,7 @@ msgstr "Exklusive Umriss-Lage"
 
 #: pcbnew/dialogs/dialog_print_using_printer_base.cpp:39
 msgid "Exclude contents of Edges_Pcb layer from all other layers"
-msgstr "Schliesse Inhalt von Platinen-Umriss Lage von allen anderen Lagen aus"
+msgstr "Schließe Inhalt von Platinen-Umriss Lage von allen anderen Lagen aus"
 
 #: pcbnew/dialogs/dialog_print_using_printer_base.cpp:49
 #: gerbview/dialogs/dialog_print_using_printer_base.cpp:44
@@ -18456,7 +18378,7 @@ msgstr "Neuer Netzklassenname:"
 msgid "This NetClass is already existing, cannot add it; Aborted"
 msgstr ""
 "Diese Netzklasse existiert bereits und kann somit nicht hinzugefügt werden. "
-"Abbruch.\""
+"Abbruch."
 
 #: pcbnew/dialogs/dialog_design_rules.cpp:748
 msgid "The default Netclass cannot be removed"
@@ -18465,86 +18387,84 @@ msgstr "Die Default-Netzklasse kann nicht entfernt werden."
 #: pcbnew/dialogs/dialog_design_rules.cpp:930
 #, c-format
 msgid "%s: <b>Track Size</b> &lt; <b>Min Track Size</b><br>"
-msgstr "%s: <b>Leiterbahngrösse</b> &lt; <b>Mindest Leiterbahngrösse</b><br>"
+msgstr "%s: <b>Leiterbahngröße</b> &lt; <b>Mindest Leiterbahngröße</b><br>"
 
 #: pcbnew/dialogs/dialog_design_rules.cpp:943
 #, c-format
 msgid "%s: <b>Via Diameter</b> &lt; <b>Minimun Via Diameter</b><br>"
 msgstr ""
-"%s: <b>Durchkontaktierungs Durchmesser</b> &lt; <b>Mindest "
-"Durchkontaktierungs Durchmesser</b><br>"
+"%s: <b>Durchkontaktierung Durchmesser</b> &lt; <b>Mindest Durchkontaktierung "
+"Durchmesser</b><br>"
 
 #: pcbnew/dialogs/dialog_design_rules.cpp:955
 #, c-format
 msgid "%s: <b>Via Drill</b> &ge; <b>Via Dia</b><br>"
 msgstr ""
-"%s: <b>Durchkontaktierungs Bohrdurchmesser</b> &ge; <b>Durchkontaktierungs "
+"%s: <b>Durchkontaktierung Bohrdurchmesser</b> &ge; <b>Durchkontaktierung "
 "Durchmesser</b><br>"
 
 #: pcbnew/dialogs/dialog_design_rules.cpp:964
 #, c-format
 msgid "%s: <b>Via Drill</b> &lt; <b>Min Via Drill</b><br>"
 msgstr ""
-"%s: <b>Durchkontaktierungs Bohrdurchmesser</b> &lt; <b>Mindest "
-"Durchkontaktierungs Bohrdurchmesser</b><br>"
+"%s: <b>Durchkontaktierung Bohrdurchmesser</b> &lt; <b>Mindest-"
+"Durchkontaktierung Bohrdurchmesser</b><br>"
 
 #: pcbnew/dialogs/dialog_design_rules.cpp:977
 #, c-format
 msgid "%s: <b>MicroVia Diameter</b> &lt; <b>MicroVia Min Diameter</b><br>"
 msgstr ""
-"%s: <b>Micro Durchkontaktierungs Durchmesser</b> &lt; <b>Mindest Micro "
-"Durchkontaktierungs Durchmesser</b><br>"
+"%s: <b>Micro-Durchkontaktierung Durchmesser</b> &lt; <b>Mindest Micro-"
+"Durchkontaktierung Durchmesser</b><br>"
 
 #: pcbnew/dialogs/dialog_design_rules.cpp:989
 #, c-format
 msgid "%s: <b>MicroVia Drill</b> &ge; <b>MicroVia Dia</b><br>"
 msgstr ""
-"%s: <b>Micro Durchkontaktierungs Bohrdurchmesser</b> &ge; <b>Micro "
-"Durchkontaktierungs Durchmesser</b><br>"
+"%s: <b>Micro-Durchkontaktierung Bohrdurchmesser</b> &ge; <b>Micro-"
+"Durchkontaktierung Durchmesser</b><br>"
 
 #: pcbnew/dialogs/dialog_design_rules.cpp:998
 #, c-format
 msgid "%s: <b>MicroVia Drill</b> &lt; <b>MicroVia Min Drill</b><br>"
 msgstr ""
-"%s: <b>Micro Durchkontaktierungs Bohrdurchmesser</b> &lt; <b>Micro "
-"Durchkontaktierungs Bohrdurchmesser</b><br>"
+"%s: <b>Micro-Durchkontaktierung Bohrdurchmesser</b> &lt; <b>Micro-"
+"Durchkontaktierung Bohrdurchmesser</b><br>"
 
 #: pcbnew/dialogs/dialog_design_rules.cpp:1019
 #, c-format
 msgid "<b>Extra Track %d Size</b> %s &lt; <b>Min Track Size</b><br>"
 msgstr ""
-"<b>Extra Leiterbahn %d Grösse</b> %s &lt; <b>Mindest Leiterbahngrösse</b><br>"
+"<b>Extra Leiterbahn %d Größe</b> %s &lt; <b>Mindest Leiterbahngröße</b><br>"
 
 #: pcbnew/dialogs/dialog_design_rules.cpp:1028
 #, c-format
 msgid "<b>Extra Track %d Size</b> %s &gt; <b>1 inch!</b><br>"
-msgstr "<b>Extra Leiterbahn %d Grösse</b> %s &gt; <b>1 Zoll!</b><br>"
+msgstr "<b>Extra Leiterbahn %d Größe</b> %s &gt; <b>1 Zoll!</b><br>"
 
 #: pcbnew/dialogs/dialog_design_rules.cpp:1053
 #, c-format
 msgid "<b>Extra Via %d Size</b> %s &lt; <b>Min Via Size</b><br>"
 msgstr ""
-"<b>Extra Durchkontaktierung %d Grösse</b> %s &lt; <b>Mindest "
-"Durchkontaktierungsgrösse</b><br>"
+"<b>Extra Durchkontaktierung %d Größe</b> %s &lt; <b>Mindest "
+"Durchkontaktierungsgröße</b><br>"
 
 #: pcbnew/dialogs/dialog_design_rules.cpp:1062
 #, c-format
 msgid "<b>Extra Via %d Size</b> %s &le; <b> Drill Size</b> %s<br>"
 msgstr ""
-"<b>Extra Durchkontaktierung %d Grösse</b> %s &le; <b>Bohrlochgrösse</b> "
-"%s<br>"
+"<b>Extra Durchkontaktierung %d Größe</b> %s &le; <b>Bohrlochgröße</b> %s<br>"
 
 #: pcbnew/dialogs/dialog_design_rules.cpp:1072
 #, c-format
 msgid "<b>Extra Via %d Size</b>%s &gt; <b>1 inch!</b><br>"
-msgstr "<b>Extra Durchkontaktierung %d Grösse</b>%s &gt; <b>1 Zoll!</b><br>"
+msgstr "<b>Extra Durchkontaktierung %d Größe</b>%s &gt; <b>1 Zoll!</b><br>"
 
 #: pcbnew/dialogs/dialog_track_via_size.cpp:91
 msgid "Settings are incorrect"
 msgstr "Die Einstellungen sind fehlerhaft"
 
 #: pcbnew/dialogs/dialog_global_deletion.cpp:103
-#, fuzzy
 msgid "Are you sure you want to delete the selected items?"
 msgstr "Möchten Sie die ausgewählten Elemente entfernen?"
 
@@ -18557,7 +18477,7 @@ msgid ""
 "This item has an illegal layer id.\n"
 "Now, forced on the front silk screen layer. Please, fix it"
 msgstr ""
-"Dieses Element besitzt eine ungültige Lagen Id.\n"
+"Dieses Element besitzt eine ungültige Lagen ID.\n"
 "und wurde somit auf die vordere Siebdrucklage verschoben.\n"
 "Bitte dies entsprechend beheben."
 
@@ -18592,19 +18512,19 @@ msgstr "Keine Bauteile für automatische Platzierung vorhanden."
 #: pcbnew/exporters/gen_modules_placefile.cpp:265
 #: pcbnew/exporters/gen_modules_placefile.cpp:297
 #: pcbnew/exporters/gen_modules_placefile.cpp:570
-#, fuzzy, c-format
+#, c-format
 msgid "Unable to create '%s'"
-msgstr "Konnte <%s> nicht erstellen"
+msgstr "Konnte '%s' nicht erstellen"
 
 #: pcbnew/exporters/gen_modules_placefile.cpp:272
-#, fuzzy, c-format
+#, c-format
 msgid "Place file: '%s'\n"
-msgstr "Platzierungsdatei: <%s>\n"
+msgstr "Platzierungsdatei: '%s'\n"
 
 #: pcbnew/exporters/gen_modules_placefile.cpp:274
-#, fuzzy, c-format
+#, c-format
 msgid "Front side (top side) place file: '%s'\n"
-msgstr "Platzierungsdatei der Vorderseite (Oberseite): <%s>\n"
+msgstr "Platzierungsdatei der Vorderseite (Oberseite): '%s'\n"
 
 #: pcbnew/exporters/gen_modules_placefile.cpp:278
 #: pcbnew/exporters/gen_modules_placefile.cpp:308
@@ -18613,9 +18533,9 @@ msgid "Footprint count %d\n"
 msgstr "Anzahl Footprints: %d\n"
 
 #: pcbnew/exporters/gen_modules_placefile.cpp:306
-#, fuzzy, c-format
+#, c-format
 msgid "Back side (bottom side) place file: '%s'\n"
-msgstr "Platzierungsdatei der Rückseite (Unterseite): <%s>\n"
+msgstr "Platzierungsdatei der Rückseite (Unterseite): '%s'\n"
 
 #: pcbnew/exporters/gen_modules_placefile.cpp:315
 #, c-format
@@ -18623,16 +18543,17 @@ msgid "Full footprint count %d\n"
 msgstr "Gesamte Anzahl Footprints %d\n"
 
 #: pcbnew/exporters/gen_modules_placefile.cpp:563
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "Footprint report file created:\n"
 "'%s'"
-msgstr "Footprint wurde in die Datei '%s' exportiert."
+msgstr ""
+"Footprint Protokolldatei erstellt:\n"
+"'%s'"
 
 #: pcbnew/exporters/gen_modules_placefile.cpp:565
-#, fuzzy
 msgid "Footprint Report"
-msgstr "Footprinttest"
+msgstr "Footprint Protokolldatei"
 
 #: pcbnew/exporters/export_idf.cpp:571 pcbnew/exporters/export_idf.cpp:580
 #: pcbnew/exporters/export_idf.cpp:588 pcbnew/exporters/export_vrml.cpp:1442
@@ -18680,20 +18601,17 @@ msgid "Save GenCAD Board File"
 msgstr "Speichere GenCAD Platine"
 
 #: pcbnew/tools/placement_tool.cpp:66
-#, fuzzy
 msgid "Align/distribute"
-msgstr "Attribute"
+msgstr "Ausrichtung/Verteilung"
 
 #: pcbnew/tools/drawing_tool.cpp:835
-#, fuzzy
 msgid "Place the footprint anchor"
-msgstr "Referenzpunkt für Bauteilfootprint setzen"
+msgstr "Anker vom Footprint setzen"
 
 #: pcbnew/tools/selection_tool.cpp:448
-#, fuzzy
 msgid "Selection contains locked items. Do you want to continue?"
 msgstr ""
-"Ändern der Dateiendung ändert den Dateityp.\n"
+"Die Auswahl enthält gesperrte Elemente.\n"
 "Möchten Sie trotzdem fortfahren?"
 
 #: pcbnew/tools/selection_tool.cpp:604
@@ -18703,49 +18621,51 @@ msgstr "Auswahl klarstellen"
 #: pcbnew/tools/module_tools.cpp:214
 msgid "Hold left mouse button and move cursor over pads to enumerate them"
 msgstr ""
+"Linken Mouse Button halten und Cursor über das Pad bewegen um diesen zu "
+"enummerieren"
 
 #: pcbnew/tools/module_tools.cpp:333
-#, fuzzy
 msgid "Select reference point"
-msgstr "Auswahl des bevorzugten Editors"
+msgstr "Auswahl des Referenszpunktes"
 
 #: pcbnew/tools/module_tools.cpp:384
-#, fuzzy, c-format
+#, c-format
 msgid "Copied %d item(s)"
-msgstr "Bauteile [%d Elemente]"
+msgstr "%d Element(e) kopiert"
 
 #: pcbnew/tools/module_tools.cpp:410
 msgid "Invalid clipboard contents"
-msgstr ""
+msgstr "Ungültiger Inhalt Zwischenspeicher"
 
 #: pcbnew/tools/pcbnew_control.cpp:534 pcbnew/tools/pcbnew_control.cpp:543
 msgid "Not implemented yet."
 msgstr "Gegenwärtig nicht implementiert"
 
 #: pcbnew/tools/edit_tool.cpp:581
-#, fuzzy
 msgid "Cannot delete component reference."
-msgstr "Bauteilreferenz"
+msgstr "Bauteilreferenz kann nicht gelöscht werden."
 
 #: pcbnew/tools/edit_tool.cpp:585
-#, fuzzy
 msgid "Cannot delete component value."
-msgstr "Entfernen von Bauteil \""
+msgstr "Bauteilwert kann nicht gelöscht werden."
 
 #: pcbnew/tools/edit_tool.cpp:616
 msgid ""
 "Cannot delete the only remaining pad of the module (modules on PCB must have "
 "at least one pad)."
 msgstr ""
+"Kann das einzig übrig gebliebene Pad des Bauteils entfernen (Bauteile auf "
+"der Platine müssen mindestens ein Pad besitzen)."
 
 #: pcbnew/tools/edit_tool.cpp:783
-#, fuzzy, c-format
+#, c-format
 msgid "Duplicated %d item(s)"
-msgstr "Fläche duplizieren"
+msgstr "%d doppelte(s) Element(e)"
 
+# No translation needed.
 #: gerbview/gerbview_frame.cpp:456 gerbview/gerbview_frame.cpp:459
 msgid "D Codes"
-msgstr "D-Codes"
+msgstr ""
 
 #: gerbview/gerbview_frame.cpp:487
 #, c-format
@@ -18757,9 +18677,8 @@ msgid "File:"
 msgstr "Datei:"
 
 #: gerbview/gerbview_frame.cpp:496
-#, fuzzy
 msgid "(with X2 Attributes)"
-msgstr "Attribute"
+msgstr "(mit X2 Attributen)"
 
 #: gerbview/gerbview_frame.cpp:502
 #, c-format
@@ -18768,7 +18687,7 @@ msgstr "Bildname: '%s',  Lagenname: '%s'"
 
 #: gerbview/gerbview_frame.cpp:515
 msgid "X2 attr"
-msgstr ""
+msgstr "X2 Attribut"
 
 #: gerbview/class_GERBER.cpp:347
 msgid "Image name"
@@ -18803,14 +18722,14 @@ msgid "Image Justify Offset"
 msgstr "Bildausrichtungsoffset"
 
 #: gerbview/class_GERBER.cpp:466
-#, fuzzy, c-format
+#, c-format
 msgid "Layer %d (%s, %s)"
-msgstr "Lage %d"
+msgstr "Lage %d (%s, %s)"
 
 #: gerbview/class_GERBER.cpp:470
-#, fuzzy, c-format
+#, c-format
 msgid "Layer %d *"
-msgstr "Lage %d"
+msgstr "Lage %d *"
 
 #: gerbview/class_GERBER.cpp:473 gerbview/select_layers_to_pcb.cpp:183
 #, c-format
@@ -18836,13 +18755,13 @@ msgid "D Code"
 msgstr "D-Codes"
 
 #: gerbview/class_gerber_draw_item.cpp:558
-#, fuzzy
 msgid "Graphic Layer"
 msgstr "Lage für Grafiken"
 
+# No translation needed.
 #: gerbview/class_gerber_draw_item.cpp:565
 msgid "Rotation"
-msgstr "Rotation"
+msgstr ""
 
 #: gerbview/class_gerber_draw_item.cpp:568
 msgid "Clear"
@@ -18878,11 +18797,11 @@ msgstr "Unterseite (*.GBL)|*.GBL;*.gbl|"
 
 #: gerbview/files.cpp:129
 msgid "Bottom solder resist (*.GBS)|*.GBS;*.gbs|"
-msgstr "Maske für Lötstopplack unten (*.GBS)|*.GBS;*.gbs|"
+msgstr "Maske für Lötstoplack unten (*.GBS)|*.GBS;*.gbs|"
 
 #: gerbview/files.cpp:130
 msgid "Top solder resist (*.GTS)|*.GTS;*.gts|"
-msgstr "Maske für Lötstopplack oben (*.GTS)|*.GTS;*.gts|"
+msgstr "Maske für Lötstoplack oben (*.GTS)|*.GTS;*.gts|"
 
 #: gerbview/files.cpp:131
 msgid "Bottom overlay (*.GBO)|*.GBO;*.gbo|"
@@ -18932,21 +18851,21 @@ msgstr "Alle Lagen löschen"
 msgid ""
 "Load a new Gerber file on the current layer. Previous data will be deleted"
 msgstr ""
-"Der aktuellen Lage eine neue Gerberdatei hinzufügen. Vorhergehende Daten "
-"werden gelöscht."
+"Der aktuellen Lage eine neue Gerberdatei hinzufügen. Vorherige Daten werden "
+"gelöscht."
 
 #: gerbview/toolbars_gerber.cpp:66
 msgid ""
 "Load an excellon drill file on the current layer. Previous data will be "
 "deleted"
 msgstr ""
-"Der aktuellen Lage eine neue Excellonbohrdatei hinzufügen. Vorhergehende "
-"Daten werden gelöscht."
+"Der aktuellen Lage eine neue Excellonbohrdatei hinzufügen. Vorherige Daten "
+"werden gelöscht."
 
 #: gerbview/toolbars_gerber.cpp:70
 msgid "Show/hide frame reference and select paper size for printing"
 msgstr ""
-"Ein-/Ausblenden der Rahmenreferenz und Auswahl der Papiergrösse für einen "
+"Ein-/Ausblenden der Rahmenreferenz und Auswahl der Papiergröße für einen "
 "Ausdruck"
 
 #: gerbview/toolbars_gerber.cpp:74
@@ -19058,7 +18977,7 @@ msgstr "&Zuletzt verwendete Gerberdatei öffnen"
 
 #: gerbview/menubar.cpp:91
 msgid "Open a recent opened Gerber file"
-msgstr "Eine vorhergehenden Gerberdatei öffnen"
+msgstr "Eine vorherige Gerberdatei öffnen"
 
 #: gerbview/menubar.cpp:105
 msgid "Open Recent Dri&ll File"
@@ -19130,7 +19049,7 @@ msgstr "Aktuelle Lage entfernen"
 
 #: gerbview/menubar.cpp:211
 msgid "&Text Editor"
-msgstr "&Texteditor auswählen"
+msgstr "&Texteditor"
 
 #: gerbview/menubar.cpp:212
 msgid "Select your preferred text editor"
@@ -19193,9 +19112,9 @@ msgid "OK to change the existing file ?"
 msgstr "Möchten Sie die bestehende Datei ändern?"
 
 #: gerbview/export_to_pcbnew.cpp:220
-#, fuzzy, c-format
+#, c-format
 msgid "Cannot create file '%s'"
-msgstr "Konnte Datei <%s> nicht erstellen."
+msgstr "Konnte Datei '%s' nicht erstellen."
 
 #: gerbview/class_gerbview_layer_widget.cpp:111
 msgid "DCodes"
@@ -19219,11 +19138,11 @@ msgstr "Alle Lagen einblenden"
 
 #: gerbview/class_gerbview_layer_widget.cpp:155
 msgid "Hide All Layers But Active"
-msgstr "Alle Lagen, ausser der aktiven, ausblenden"
+msgstr "Alle Lagen, außer der Aktiven, ausblenden"
 
 #: gerbview/class_gerbview_layer_widget.cpp:158
 msgid "Always Hide All Layers But Active"
-msgstr "Alle Lagen, ausser der aktiven, ausblenden"
+msgstr "Alle Lagen, außer der Aktiven, ausblenden"
 
 #: gerbview/class_gerbview_layer_widget.cpp:161
 msgid "Hide All Layers"
@@ -19231,12 +19150,11 @@ msgstr "Alle Lagen ausblenden"
 
 #: gerbview/class_gerbview_layer_widget.cpp:165
 msgid "Sort Layers if X2 Mode"
-msgstr ""
+msgstr "Lagen sortieren wenn im X2 Modus"
 
 #: gerbview/excellon_read_drill_file.cpp:189
-#, fuzzy
 msgid "No room to load file"
-msgstr "Platinendatei geschrieben:"
+msgstr "Kein Platz um Datei zu laden"
 
 #: gerbview/excellon_read_drill_file.cpp:214
 msgid "Files not found"
@@ -19295,12 +19213,12 @@ msgstr "D-Codes einblenden"
 
 #: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:77
 msgid "Full size without limits"
-msgstr "Grossformat ohne Seitenränder"
+msgstr "Großformat ohne Seitenränder"
 
 #: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:77
 #: gerbview/dialogs/dialog_show_page_borders_base.cpp:25
 msgid "Full size"
-msgstr "Grossformat mit Seitenrändern"
+msgstr "Großformat mit Seitenrändern"
 
 #: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:77
 #: gerbview/dialogs/dialog_show_page_borders_base.cpp:25
@@ -19338,11 +19256,11 @@ msgstr "Seite"
 
 #: gerbview/dialogs/dialog_show_page_borders_base.cpp:25
 msgid "Full size. Do not show page limits"
-msgstr "Grossformat ohne Seitenränder"
+msgstr "Großformat ohne Seitenränder. Zeigt keine Seitenbegrenzungen."
 
 #: gerbview/dialogs/dialog_show_page_borders_base.cpp:27
 msgid "Show Page Limits:"
-msgstr "Seitenformat:"
+msgstr "Zeige Seitenbegrenzungen:"
 
 #: gerbview/dialogs/dialog_layers_select_to_pcb_base.cpp:31
 msgid "Layers selection:"
@@ -19403,7 +19321,7 @@ msgid ""
 "Choose if you want to print sheets in color, or force the black and white "
 "mode."
 msgstr ""
-"Wähle, ob der Schaltplan in farbe oder schwarz-weiß gedruckt werden soll."
+"Wähle, ob der Schaltplan in Farbe oder Schwarz-Weiß gedruckt werden soll."
 
 #: 3d-viewer/dialogs/dialog_3D_view_option_base.h:77
 msgid "3D Display Options"
@@ -19423,7 +19341,7 @@ msgstr "Seite einrichten"
 
 #: common/dialog_about/dialog_about_base.h:55
 msgid "About..."
-msgstr "Über..."
+msgstr "Über ..."
 
 #: cvpcb/common_help_msg.h:28
 msgid "Open netlist file"
@@ -19442,9 +19360,10 @@ msgstr ""
 msgid "Display Options"
 msgstr "Anzeigeoptionen"
 
+# No translation needed.
 #: eeschema/sch_marker.h:107
 msgid "ERC Marker"
-msgstr "ERC Marker"
+msgstr ""
 
 #: eeschema/help_common_strings.h:41
 msgid "Redo last command"
@@ -19476,7 +19395,7 @@ msgstr "Spannungsquelle hinzufügen"
 
 #: eeschema/help_common_strings.h:55
 msgid "Place wire"
-msgstr "Elektr. Verbindung herstellen"
+msgstr "Elektr. Verbindung hinzufügen"
 
 #: eeschema/help_common_strings.h:56
 msgid "Place bus"
@@ -19560,9 +19479,8 @@ msgid "Generate bill of materials and/or cross references"
 msgstr "Stückliste und/oder Querbezüge erstellen"
 
 #: eeschema/help_common_strings.h:81
-#, fuzzy
 msgid "Back-import component footprint fields via CvPcb .cmp file"
-msgstr "Bauteile/Footprint-Zuordnungsdatei (.cmp Datei)"
+msgstr "Rückimport Bauteil Footprintfelder durch CvPvb .cmp Datei"
 
 #: eeschema/help_common_strings.h:84
 msgid "Add pins to component"
@@ -19594,7 +19512,7 @@ msgstr "Keine-Verbindung"
 
 #: eeschema/dialogs/dialog_bom_base.h:93
 msgid "Bill of Material"
-msgstr "Stückliste"
+msgstr "Stückliste (BOM)"
 
 #: eeschema/dialogs/dialog_lib_edit_draw_item_base.h:59
 msgid "Drawing Properties"
@@ -19628,9 +19546,10 @@ msgstr "Annotation des Schaltplans"
 msgid "Field Properties"
 msgstr "Feldeigenschaften"
 
+# No translation needed
 #: eeschema/dialogs/dialog_netlist_base.h:119
 msgid "Plugins:"
-msgstr "Plugins:"
+msgstr ""
 
 #: eeschema/dialogs/dialog_libedit_options_base.h:66
 #: eeschema/dialogs/dialog_libedit_dimensions_base.h:84
@@ -19642,10 +19561,10 @@ msgstr "Bibliothekseditor Optionen"
 msgid "Component Properties"
 msgstr "Bauteil Eigenschaften"
 
+# No translation needed
 #: eeschema/dialogs/dialog_erc_base.h:98
-#, fuzzy
 msgid "Electrical Rules Checker"
-msgstr "Electric Rules &Checker"
+msgstr ""
 
 #: eeschema/dialogs/dialog_lib_edit_text_base.h:68
 msgid "Library Text Properties"
@@ -19673,8 +19592,8 @@ msgid ""
 "This is a experimental feature (under development)"
 msgstr ""
 "Werkzeugleiste für Mikrowellen-Applikationen ein-/ausblenden.\n"
-"Dies ist ein experimentielles Feature, welches sich noch in der Entwicklung "
-"befinden."
+"Dies ist ein experimentelles Feature, welches sich noch in der Entwicklung "
+"befindet."
 
 #: pcbnew/dialogs/dialog_orient_footprints_base.h:53
 msgid "Footprints Orientation"
@@ -19689,9 +19608,8 @@ msgid "Global Pads Edition"
 msgstr "Globale Pad Einstellungen"
 
 #: pcbnew/dialogs/wizard_add_fplib_base.h:84
-#, fuzzy
 msgid "Footprint Library Wizard"
-msgstr "Footprintwizard"
+msgstr "Footprint Bibliothekswizard"
 
 #: pcbnew/dialogs/dialog_layers_setup_base.h:414
 msgid "Layer Setup"
@@ -19703,59 +19621,51 @@ msgstr "Eigenschaften grafischer Elemente"
 
 #: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.h:140
 #: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.h:122
-#, fuzzy
 msgid "Footprint Properties"
-msgstr "Footprint Texteigenschaften"
+msgstr "Footprint Eigenschaften"
 
 #: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.h:81
-#, fuzzy
 msgid "Trace length tuning"
-msgstr "Leiterbahnlänge"
+msgstr "Anpassen Leiterbahnlänge"
 
 #: pcbnew/dialogs/dialog_select_pretty_lib_base.h:57
 #: pcbnew/dialogs/dialog_select_dirlist_base.h:55
-#, fuzzy
 msgid "Select Footprint Library Folder"
-msgstr "Footprint Bibliotheksbrowser"
+msgstr "Auswahl Footprint Bibliotheksordner"
 
 #: pcbnew/dialogs/dialog_global_modules_fields_edition_base.h:68
 msgid "Set Text Size"
-msgstr "Einstellungen der Textgrösse"
+msgstr "Einstellungen der Textgröße"
 
 #: pcbnew/dialogs/dialog_global_deletion_base.h:75
 msgid "Delete Items"
 msgstr "Elemente entfernen"
 
 #: pcbnew/dialogs/dialog_modedit_options_base.h:81
-#, fuzzy
 msgid "Footprint Editor Options"
-msgstr "Footprinteditor"
+msgstr "Footprinteditor Optionen"
 
 #: pcbnew/dialogs/dialog_set_grid_base.h:70
 msgid "Grid Properties"
 msgstr "Raster Eigenschaften"
 
 #: pcbnew/dialogs/dialog_pns_diff_pair_dimensions_base.h:63
-#, fuzzy
 msgid "Differential Pair Dimensions"
-msgstr "Bemaßung entfernen"
+msgstr "Bemaßung differenzielles Signalpaar"
 
 #: pcbnew/dialogs/dialog_non_copper_zones_properties_base.h:67
 msgid "Non Copper Zones Properties"
 msgstr "Eigenschaften für Zonen ohne Kupfer"
 
 #: pcbnew/dialogs/dialog_exchange_modules_base.h:65
-#, fuzzy
 msgid "Exchange Footprints"
-msgstr "Zusätzliche Footprints"
+msgstr "Austausch Footprints"
 
 #: pcbnew/dialogs/dialog_enum_pads_base.h:53
-#, fuzzy
 msgid "Pad enumeration settings"
-msgstr "Allgemeine Einstellungen"
+msgstr "Pad Enummerierungseinstellungen"
 
 #: pcbnew/dialogs/dialog_edit_module_text_base.h:70
-#, fuzzy
 msgid "Footprint Text Properties"
 msgstr "Footprint Texteigenschaften"
 
@@ -19784,14 +19694,12 @@ msgid "Design Rules Editor"
 msgstr "Design Regeln Editor"
 
 #: pcbnew/dialogs/dialog_export_vrml_base.h:67
-#, fuzzy
 msgid "VRML Export Options"
-msgstr "Optionen für den Export von VRML Platinen:"
+msgstr "Export Optionen VRML"
 
 #: pcbnew/dialogs/dialog_move_exact_base.h:74
-#, fuzzy
 msgid "Move item"
-msgstr "Linie verschieben"
+msgstr "Element verschieben"
 
 #: pcbnew/dialogs/dialog_gen_module_position_file_base.h:60
 msgid "Position Files:"
@@ -19841,9 +19749,10 @@ msgstr "Texte und Zeichnungen"
 msgid "Global Edition of Tracks and Vias"
 msgstr "Globale Einstellung für Leiterbahnen und Durchkontaktierungen"
 
+# No translation needed.
 #: pcbnew/dialogs/dialog_export_idf_base.h:50
 msgid "Export IDFv3"
-msgstr "IDFv3"
+msgstr ""
 
 #: pcbnew/import_dxf/dialog_dxf_import_base.h:62
 msgid "Import DXF file"


### PR DESCRIPTION
I'm using KiCad from the current Debian unstable repository. The version in the Debian archive is 4.0.0-rc1and not the recent upstream version 4.0.1. But the translation for German isn't working that much now. This depends on the state of the de/kicad.po as there are most of the string are fuzzy, unclear or not translated, there are only a few strings working.

I updated the kicad.po file as most as possible and it's working locally fine as I could see. Please pull my changes so the translation will be up to over 95% I would say.