### PR TITLE
fix: compile fail with -DCMAKE_INSTALL_PREFIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,11 +17,11 @@ option( KICAD_I18N_UNIX_STRICT_PATH
     )
 
 if( UNIX AND KICAD_I18N_UNIX_STRICT_PATH )
-    set( KICAD_I18N_PATH ${CMAKE_INSTALL_PREFIX}/share/locale
+    set( KICAD_I18N_PATH ${CMAKE_INSTALL_PREFIX}/usr/local/share/locale
         CACHE PATH "Location of KiCad i18n files." )
 else()
     # Default Unix inconvenient locale lookup path
-    set( KICAD_I18N_PATH share/kicad/internat
+    set( KICAD_I18N_PATH usr/local/share/kicad/internat
         CACHE PATH "Location of KiCad i18n files." )
 endif()
 

--- a/README.adoc
+++ b/README.adoc
@@ -25,7 +25,18 @@ $ rm -rf ~/tmp/kicad-i18n-build
 If you want to change the default install prefix to match your KiCad
 build, you can add `cmake` option for example use:
 ```
--DCMAKE_INSTALL_PREFIX=/usr
+-DCMAKE_INSTALL_PREFIX=~/kicad-install-dir
+```
+
+simplest command:
+```sh
+$ cd kicad-i18n
+$ mkdir -p ../kicad-i18n-build
+$ cd ../kicad-i18n-build
+$ cmake ../kicad-i18n -DCMAKE_INSTALL_PREFIX={your-kicad-install-dir}
+$ make install
+$ cd ..
+$ rm -rf kicad-i18n-build
 ```
 
 If you occurred some problems, use `cmake --trace -DCMAKE_VERBOSE_MAKEFILE=ON` instead `cmake` to


### PR DESCRIPTION
the kicad-root-dir should include sub-dir 'usr/local'.