### PR TITLE
WIP: Updating to current source and fixing fuzzy matches

### DIFF
--- a/de/kicad.po
+++ b/de/kicad.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: KiCad i18n Deutsch\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-11-11 13:44+0100\n"
-"PO-Revision-Date: 2017-11-11 13:53+0100\n"
+"POT-Creation-Date: 2017-12-18 07:51+0100\n"
+"PO-Revision-Date: 2017-12-18 08:22+0100\n"
 "Last-Translator: Carsten Schoenert <c.schoenert@t-online.de>\n"
 "Language-Team: \n"
 "Language: de_DE\n"
@@ -12,7 +12,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Poedit-Basepath: /mnt/kicad\n"
 "X-Poedit-KeywordsList: _;_HKI\n"
-"X-Generator: Poedit 2.0.4\n"
+"X-Generator: Poedit 1.8.11\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 "X-Poedit-Bookmarks: -1,2168,-1,-1,-1,-1,-1,-1,-1,-1\n"
@@ -171,18 +171,19 @@ msgstr "Konfigurationsvariable"
 
 #: 3d-viewer/3d_cache/dialogs/dlg_3d_pathconfig_base.cpp:81
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:202
-#: eeschema/libedit.cpp:472 eeschema/viewlibs.cpp:240
+#: eeschema/libedit.cpp:644 eeschema/viewlibs.cpp:240
 msgid "Alias"
 msgstr "Alias"
 
 #: 3d-viewer/3d_cache/dialogs/dlg_3d_pathconfig_base.cpp:83
-#: common/dialog_about/AboutDialog_main.cpp:115 eeschema/bom_table_column.h:34
+#: common/dialog_about/AboutDialog_main.cpp:114
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:117
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:163
-#: eeschema/libedit.cpp:492 eeschema/sch_component.cpp:1799
-#: eeschema/viewlibs.cpp:241 include/lib_table_grid.h:174
+#: eeschema/libedit.cpp:664 eeschema/sch_component.cpp:1464
+#: eeschema/viewlibs.cpp:241
 #: pcbnew/dialogs/dialog_footprint_wizard_list_base.cpp:44
-#: pcbnew/librairi.cpp:852
+#: pcbnew/librairi.cpp:850 eeschema/bom_table_column.h:34
+#: include/lib_table_grid.h:185
 msgid "Description"
 msgstr "Beschreibung"
 
@@ -195,8 +196,8 @@ msgid "Remove Alias"
 msgstr "Alias entfernen"
 
 #: 3d-viewer/3d_cache/dialogs/dlg_3d_pathconfig_base.cpp:110
-#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:44
-#: eeschema/dialogs/dialog_sym_lib_table_base.cpp:144
+#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:42
+#: eeschema/dialogs/dialog_sym_lib_table_base.cpp:147
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:85
 #: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:146
 #: pcbnew/dialogs/dialog_fp_plugin_options_base.cpp:67
@@ -205,16 +206,12 @@ msgstr "Nach oben bewegen"
 
 #: 3d-viewer/3d_cache/dialogs/dlg_3d_pathconfig_base.cpp:113
 #: 3d-viewer/3d_canvas/eda_3d_canvas.cpp:674
-#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:47
-#: eeschema/dialogs/dialog_sym_lib_table_base.cpp:149
+#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:45
+#: eeschema/dialogs/dialog_sym_lib_table_base.cpp:152
 #: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:151
 #: pcbnew/dialogs/dialog_fp_plugin_options_base.cpp:72
 msgid "Move Down"
 msgstr "Nach unten bewegen"
-
-#: 3d-viewer/3d_cache/dialogs/dlg_3d_pathconfig_base.h:64
-msgid "3D Search Path Configuration"
-msgstr "3D-Suchpfad-Konfiguration"
 
 #: 3d-viewer/3d_cache/dialogs/dlg_select_3dmodel.cpp:51
 msgid "Select 3D Model"
@@ -259,22 +256,22 @@ msgstr "Skalierung"
 
 #: 3d-viewer/3d_cache/dialogs/panel_prev_3d_base.cpp:28
 #: 3d-viewer/3d_cache/dialogs/panel_prev_3d_base.cpp:72
-#: 3d-viewer/3d_cache/dialogs/panel_prev_3d_base.cpp:140
+#: 3d-viewer/3d_cache/dialogs/panel_prev_3d_base.cpp:139
 #: pcbnew/dialogs/dialog_set_grid_base.cpp:69
 msgid "X:"
 msgstr "X:"
 
 #: 3d-viewer/3d_cache/dialogs/panel_prev_3d_base.cpp:38
 #: 3d-viewer/3d_cache/dialogs/panel_prev_3d_base.cpp:90
-#: 3d-viewer/3d_cache/dialogs/panel_prev_3d_base.cpp:150
-#: pcbnew/dialogs/dialog_position_relative_base.cpp:77
+#: 3d-viewer/3d_cache/dialogs/panel_prev_3d_base.cpp:149
+#: pcbnew/dialogs/dialog_position_relative_base.cpp:79
 #: pcbnew/dialogs/dialog_set_grid_base.cpp:80
 msgid "Y:"
 msgstr "Y:"
 
 #: 3d-viewer/3d_cache/dialogs/panel_prev_3d_base.cpp:48
 #: 3d-viewer/3d_cache/dialogs/panel_prev_3d_base.cpp:108
-#: 3d-viewer/3d_cache/dialogs/panel_prev_3d_base.cpp:160
+#: 3d-viewer/3d_cache/dialogs/panel_prev_3d_base.cpp:159
 msgid "Z:"
 msgstr "Z:"
 
@@ -282,27 +279,71 @@ msgstr "Z:"
 msgid "Rotation (degrees)"
 msgstr "Drehung (Grad)"
 
-#: 3d-viewer/3d_cache/dialogs/panel_prev_3d_base.cpp:133
+#: 3d-viewer/3d_cache/dialogs/panel_prev_3d_base.cpp:132
 msgid "Offset"
 msgstr "Offset"
 
-#: 3d-viewer/3d_cache/dialogs/panel_prev_3d_base.cpp:202
+#: 3d-viewer/3d_cache/dialogs/panel_prev_3d_base.cpp:201
 msgid "Change to isometric perspective"
 msgstr "Wechsel zur isometrischen Perspektive"
 
-#: 3d-viewer/3d_cache/dialogs/panel_prev_3d_base.cpp:216
+#: 3d-viewer/3d_cache/dialogs/panel_prev_3d_base.cpp:215
 msgid "Reload board and 3D models"
 msgstr "Platine und 3D-Modelle neu laden"
 
-#: 3d-viewer/3d_cache/dialogs/panel_prev_model.cpp:610
+#: 3d-viewer/3d_cache/dialogs/panel_prev_model.cpp:137
+#: common/base_units.cpp:464 common/dialogs/dialog_page_settings.cpp:471
+#: pagelayout_editor/pl_editor_frame.cpp:461
+#: pcbnew/import_dxf/dialog_dxf_import_base.cpp:160
+msgid "inches"
+msgstr "Zoll"
+
+#: 3d-viewer/3d_cache/dialogs/panel_prev_model.cpp:140
+#: bitmap2component/bitmap2cmp_gui_base.cpp:78 common/base_units.cpp:437
+#: common/base_units.cpp:495 common/dialogs/dialog_page_settings.cpp:471
+#: common/draw_frame.cpp:525 common/preview_items/preview_utils.cpp:44
+#: eeschema/dialogs/dialog_lib_edit_draw_item_base.cpp:44
+#: pagelayout_editor/pl_editor_frame.cpp:465 pcb_calculator/UnitSelector.cpp:38
+#: pcb_calculator/UnitSelector.cpp:70
+#: pcbnew/dialogs/dialog_create_array_base.cpp:52
+#: pcbnew/dialogs/dialog_create_array_base.cpp:63
+#: pcbnew/dialogs/dialog_create_array_base.cpp:74
+#: pcbnew/dialogs/dialog_create_array_base.cpp:85
+#: pcbnew/dialogs/dialog_create_array_base.cpp:190
+#: pcbnew/dialogs/dialog_create_array_base.cpp:201
+#: pcbnew/dialogs/dialog_design_rules_base.cpp:198
+#: pcbnew/dialogs/dialog_design_rules_base.cpp:209
+#: pcbnew/dialogs/dialog_design_rules_base.cpp:220
+#: pcbnew/dialogs/dialog_design_rules_base.cpp:251
+#: pcbnew/dialogs/dialog_design_rules_base.cpp:264
+#: pcbnew/dialogs/dialog_export_idf_base.cpp:48
+#: pcbnew/dialogs/dialog_export_step_base.cpp:107
+#: pcbnew/dialogs/dialog_export_vrml_base.cpp:63
+#: pcbnew/dialogs/dialog_export_vrml_base.cpp:111
+#: pcbnew/dialogs/dialog_gen_module_position_file_base.cpp:60
+#: pcbnew/dialogs/dialog_move_exact_base.cpp:39
+#: pcbnew/dialogs/dialog_move_exact_base.cpp:53
+#: pcbnew/dialogs/dialog_position_relative_base.cpp:37
+#: pcbnew/dialogs/dialog_position_relative_base.cpp:51
+#: pcbnew/import_dxf/dialog_dxf_import_base.cpp:111
+#: pcbnew/import_dxf/dialog_dxf_import_base.cpp:160
+msgid "mm"
+msgstr "mm"
+
+#: 3d-viewer/3d_cache/dialogs/panel_prev_model.cpp:148
+#, c-format
+msgid "Offset (%s)"
+msgstr ""
+
+#: 3d-viewer/3d_cache/dialogs/panel_prev_model.cpp:635
 msgid "Invalid X scale"
 msgstr "Ungültige X-Skalierung"
 
-#: 3d-viewer/3d_cache/dialogs/panel_prev_model.cpp:621
+#: 3d-viewer/3d_cache/dialogs/panel_prev_model.cpp:646
 msgid "Invalid Y scale"
 msgstr "Ungültige Y-Skalierung"
 
-#: 3d-viewer/3d_cache/dialogs/panel_prev_model.cpp:632
+#: 3d-viewer/3d_cache/dialogs/panel_prev_model.cpp:657
 msgid "Invalid Z scale"
 msgstr "Ungültige Z-Skalierung"
 
@@ -455,21 +496,23 @@ msgid "Render current view using Raytracing"
 msgstr "Wiedergabe der aktuellen Ansicht unter Benutzung von Raytracing"
 
 #: 3d-viewer/3d_viewer/3d_toolbar.cpp:72 common/zoom.cpp:248
-#: eeschema/help_common_strings.h:43 eeschema/tool_viewlib.cpp:69
-#: gerbview/toolbars_gerber.cpp:82 pagelayout_editor/menubar.cpp:134
+#: eeschema/tool_viewlib.cpp:69 gerbview/toolbars_gerber.cpp:82
+#: pagelayout_editor/menubar.cpp:134
 #: pagelayout_editor/toolbars_pl_editor.cpp:86
-#: pcbnew/footprint_wizard_frame.cpp:687 pcbnew/help_common_strings.h:19
-#: pcbnew/tool_modedit.cpp:128 pcbnew/tool_modview.cpp:79
+#: pcbnew/footprint_wizard_frame.cpp:687 pcbnew/tool_modedit.cpp:128
+#: pcbnew/tool_modview.cpp:79 eeschema/help_common_strings.h:43
+#: pcbnew/help_common_strings.h:19
 msgid "Zoom in"
 msgstr "Hinein zoomen"
 
 #: 3d-viewer/3d_viewer/3d_toolbar.cpp:75
 #: 3d-viewer/3d_viewer/eda_3d_viewer.cpp:1208 common/zoom.cpp:250
-#: eeschema/help_common_strings.h:44 eeschema/tool_viewlib.cpp:74
-#: gerbview/toolbars_gerber.cpp:85 pagelayout_editor/menubar.cpp:137
+#: eeschema/tool_viewlib.cpp:74 gerbview/toolbars_gerber.cpp:85
+#: pagelayout_editor/menubar.cpp:137
 #: pagelayout_editor/toolbars_pl_editor.cpp:89
-#: pcbnew/footprint_wizard_frame.cpp:692 pcbnew/help_common_strings.h:20
-#: pcbnew/tool_modedit.cpp:131 pcbnew/tool_modview.cpp:84
+#: pcbnew/footprint_wizard_frame.cpp:692 pcbnew/tool_modedit.cpp:131
+#: pcbnew/tool_modview.cpp:84 eeschema/help_common_strings.h:44
+#: pcbnew/help_common_strings.h:20
 msgid "Zoom out"
 msgstr "Heraus zoomen"
 
@@ -531,7 +574,7 @@ msgid "Enable/Disable orthographic projection"
 msgstr "Orthogonalprojektion aktivieren/deaktivieren"
 
 #: 3d-viewer/3d_viewer/3d_toolbar.cpp:142 eeschema/menubar.cpp:118
-#: eeschema/menubar_libedit.cpp:293 eeschema/tool_viewlib.cpp:240
+#: eeschema/menubar_libedit.cpp:352 eeschema/tool_viewlib.cpp:240
 #: gerbview/menubar.cpp:301 kicad/menubar.cpp:477
 #: pagelayout_editor/menubar.cpp:242 pcbnew/menubar_modedit.cpp:389
 #: pcbnew/menubar_pcbframe.cpp:153 pcbnew/tool_modview.cpp:203
@@ -782,8 +825,8 @@ msgid "Show 3D M&odels"
 msgstr "3D-M&odell einblenden"
 
 #: 3d-viewer/3d_viewer/3d_toolbar.cpp:353
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:135
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:100
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:137
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:102
 msgid "Through hole"
 msgstr "Durchsteckmontage"
 
@@ -792,8 +835,8 @@ msgid "Footprint Properties -> Placement type -> Through hole"
 msgstr "Footprint-Eigenschaften -> Platzierungstyp -> Durchsteckmontage"
 
 #: 3d-viewer/3d_viewer/3d_toolbar.cpp:357
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:135
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:100
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:137
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:102
 msgid "Surface mount"
 msgstr "Oberflächenmontage"
 
@@ -802,8 +845,8 @@ msgid "Footprint Properties -> Placement type -> Surface mount"
 msgstr "Footprint-Eigenschaften -> Platzierungstyp -> Oberflächenmontage"
 
 #: 3d-viewer/3d_viewer/3d_toolbar.cpp:361 pcbnew/class_module.cpp:578
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:135
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:100
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:137
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:102
 msgid "Virtual"
 msgstr "Virtuell"
 
@@ -848,21 +891,21 @@ msgid "Reset to default settings"
 msgstr "Rücksetzen auf Standardeinstellungen"
 
 #: 3d-viewer/3d_viewer/3d_toolbar.cpp:402 cvpcb/menubar.cpp:134
-#: eeschema/menubar.cpp:124 eeschema/menubar_libedit.cpp:298
+#: eeschema/menubar.cpp:124 eeschema/menubar_libedit.cpp:358
 #: eeschema/tool_viewlib.cpp:243 gerbview/menubar.cpp:304 kicad/menubar.cpp:482
 #: pagelayout_editor/menubar.cpp:247 pcbnew/menubar_modedit.cpp:395
 #: pcbnew/menubar_pcbframe.cpp:162 pcbnew/tool_modview.cpp:206
 msgid "&Help"
 msgstr "&Hilfe"
 
-#: 3d-viewer/3d_viewer/3d_toolbar.cpp:405 eeschema/menubar.cpp:573
-#: eeschema/menubar_libedit.cpp:273 gerbview/menubar.cpp:280
+#: 3d-viewer/3d_viewer/3d_toolbar.cpp:405 eeschema/menubar.cpp:580
+#: eeschema/menubar_libedit.cpp:332 gerbview/menubar.cpp:280
 #: kicad/menubar.cpp:455 pagelayout_editor/menubar.cpp:220
 #: pcbnew/menubar_modedit.cpp:370 pcbnew/menubar_pcbframe.cpp:442
 msgid "&List Hotkeys"
 msgstr "Tastaturbefehle auf&listen"
 
-#: 3d-viewer/3d_viewer/3d_toolbar.cpp:406 eeschema/menubar_libedit.cpp:274
+#: 3d-viewer/3d_viewer/3d_toolbar.cpp:406 eeschema/menubar_libedit.cpp:333
 #: gerbview/menubar.cpp:281 kicad/menubar.cpp:456
 #: pagelayout_editor/menubar.cpp:222
 msgid "Displays the current hotkeys list and corresponding commands"
@@ -916,10 +959,6 @@ msgstr "Alle einblenden"
 #: 3d-viewer/3d_viewer/dialogs/dialog_3D_view_option_base.cpp:96
 msgid "Show None"
 msgstr "Alle ausblenden"
-
-#: 3d-viewer/3d_viewer/dialogs/dialog_3D_view_option_base.h:79
-msgid "3D Display Options"
-msgstr "3D-Anzeigeoptionen"
 
 #: 3d-viewer/3d_viewer/eda_3d_viewer.cpp:353
 msgid "Background Color, Bottom"
@@ -1026,38 +1065,38 @@ msgid "Viewer 3D"
 msgstr "3D-Betrachter"
 
 #: bitmap2component/bitmap2cmp_gui.cpp:269 eeschema/edit_bitmap.cpp:103
-#: pagelayout_editor/pl_editor_frame.cpp:639
+#: pagelayout_editor/pl_editor_frame.cpp:634
 msgid "Choose Image"
 msgstr "Wähle ein Bild"
 
 #: bitmap2component/bitmap2cmp_gui.cpp:270 eeschema/edit_bitmap.cpp:104
-#: pagelayout_editor/pl_editor_frame.cpp:640
+#: pagelayout_editor/pl_editor_frame.cpp:635
 msgid "Image Files "
 msgstr "Bilddateien"
 
 #: bitmap2component/bitmap2cmp_gui.cpp:485
-msgid "Create a logo file"
+msgid "Create Logo File"
 msgstr "Logodatei erstellen"
 
-#: bitmap2component/bitmap2cmp_gui.cpp:504
-#: bitmap2component/bitmap2cmp_gui.cpp:542
-#: bitmap2component/bitmap2cmp_gui.cpp:579
-#: bitmap2component/bitmap2cmp_gui.cpp:616
+#: bitmap2component/bitmap2cmp_gui.cpp:503
+#: bitmap2component/bitmap2cmp_gui.cpp:541
+#: bitmap2component/bitmap2cmp_gui.cpp:578
+#: bitmap2component/bitmap2cmp_gui.cpp:615
 #, c-format
-msgid "File '%s' could not be created."
+msgid "File \"%s\" could not be created."
 msgstr "Konnte die Datei '%s' nicht erstellen."
 
-#: bitmap2component/bitmap2cmp_gui.cpp:522
-msgid "Create a Postscript file"
+#: bitmap2component/bitmap2cmp_gui.cpp:521
+msgid "Create Postscript File"
 msgstr "Postscript-Datei erstellen"
 
-#: bitmap2component/bitmap2cmp_gui.cpp:560
-msgid "Create a component library file for Eeschema"
-msgstr "Bauteilbibliotheksdatei für Eeschema erstellen"
+#: bitmap2component/bitmap2cmp_gui.cpp:559
+msgid "Create Symbol Library"
+msgstr "Symbolbibliothek erstellen"
 
-#: bitmap2component/bitmap2cmp_gui.cpp:597
-msgid "Create a footprint file for Pcbnew"
-msgstr "Footprintdatei für Pcbnew erstellen"
+#: bitmap2component/bitmap2cmp_gui.cpp:596
+msgid "Create Footprint Library"
+msgstr "Footprintbibliothek erstellen"
 
 #: bitmap2component/bitmap2cmp_gui_base.cpp:24
 msgid "Original Picture"
@@ -1094,37 +1133,6 @@ msgstr "0000"
 msgid "pixels"
 msgstr "Pixel"
 
-#: bitmap2component/bitmap2cmp_gui_base.cpp:78 common/base_units.cpp:432
-#: common/base_units.cpp:490 common/dialogs/dialog_page_settings.cpp:471
-#: common/draw_frame.cpp:525 common/preview_items/preview_utils.cpp:44
-#: eeschema/dialogs/dialog_lib_edit_draw_item_base.cpp:44
-#: pagelayout_editor/pl_editor_frame.cpp:471 pcb_calculator/UnitSelector.cpp:38
-#: pcb_calculator/UnitSelector.cpp:70
-#: pcbnew/dialogs/dialog_create_array_base.cpp:50
-#: pcbnew/dialogs/dialog_create_array_base.cpp:61
-#: pcbnew/dialogs/dialog_create_array_base.cpp:72
-#: pcbnew/dialogs/dialog_create_array_base.cpp:83
-#: pcbnew/dialogs/dialog_create_array_base.cpp:188
-#: pcbnew/dialogs/dialog_create_array_base.cpp:199
-#: pcbnew/dialogs/dialog_design_rules_base.cpp:198
-#: pcbnew/dialogs/dialog_design_rules_base.cpp:209
-#: pcbnew/dialogs/dialog_design_rules_base.cpp:220
-#: pcbnew/dialogs/dialog_design_rules_base.cpp:251
-#: pcbnew/dialogs/dialog_design_rules_base.cpp:264
-#: pcbnew/dialogs/dialog_export_idf_base.cpp:46
-#: pcbnew/dialogs/dialog_export_step_base.cpp:105
-#: pcbnew/dialogs/dialog_export_vrml_base.cpp:63
-#: pcbnew/dialogs/dialog_export_vrml_base.cpp:111
-#: pcbnew/dialogs/dialog_gen_module_position_file_base.cpp:60
-#: pcbnew/dialogs/dialog_move_exact_base.cpp:37
-#: pcbnew/dialogs/dialog_move_exact_base.cpp:51
-#: pcbnew/dialogs/dialog_position_relative_base.cpp:35
-#: pcbnew/dialogs/dialog_position_relative_base.cpp:49
-#: pcbnew/import_dxf/dialog_dxf_import_base.cpp:111
-#: pcbnew/import_dxf/dialog_dxf_import_base.cpp:160
-msgid "mm"
-msgstr "mm"
-
 #: bitmap2component/bitmap2cmp_gui_base.cpp:82
 msgid "BPP:"
 msgstr "BPP:"
@@ -1150,7 +1158,7 @@ msgstr "DPI"
 msgid "Load Bitmap"
 msgstr "Bitmap laden"
 
-#: bitmap2component/bitmap2cmp_gui_base.cpp:124 eeschema/libeditframe.cpp:1186
+#: bitmap2component/bitmap2cmp_gui_base.cpp:124 eeschema/libeditframe.cpp:1228
 msgid "Export"
 msgstr "Exportieren"
 
@@ -1187,14 +1195,14 @@ msgstr "Format"
 #: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:203
 #: eeschema/dialogs/dialog_edit_label_base.cpp:76
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:107
-#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:95 eeschema/libedit.cpp:482
-#: eeschema/sch_text.cpp:781 gerbview/class_gerber_file_image.cpp:353
+#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:95 eeschema/libedit.cpp:654
+#: eeschema/sch_text.cpp:663 gerbview/class_gerber_file_image.cpp:353
 #: gerbview/class_gerber_file_image.cpp:357
 #: gerbview/class_gerber_file_image.cpp:360 pcbnew/class_module.cpp:570
-#: pcbnew/dialogs/dialog_dimension_editor_base.cpp:77
-#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:109
-#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:71
-#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:99
+#: pcbnew/dialogs/dialog_dimension_editor_base.cpp:78
+#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:110
+#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:72
+#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:100
 #: pcbnew/microwave.cpp:464
 msgid "Normal"
 msgstr "Normal"
@@ -1209,10 +1217,10 @@ msgstr "Negativ"
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:112
 #: eeschema/dialogs/dialog_erc_base.cpp:147
 #: eeschema/dialogs/dialog_lib_edit_text_base.cpp:75
-#: include/lib_table_grid.h:173 pcbnew/dialogs/dialog_block_options_base.cpp:20
+#: pcbnew/dialogs/dialog_block_options_base.cpp:20
 #: pcbnew/dialogs/dialog_exchange_modules_base.cpp:49
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:74
-#: pcbnew/dialogs/dialog_pns_settings_base.cpp:26
+#: pcbnew/dialogs/dialog_pns_settings_base.cpp:26 include/lib_table_grid.h:184
 msgid "Options"
 msgstr "Optionen"
 
@@ -1229,12 +1237,12 @@ msgstr ""
 "umzuwandeln."
 
 #: bitmap2component/bitmap2cmp_gui_base.cpp:150
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:349
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:351
 msgid "Front silk screen"
 msgstr "Vorderseitiger Siebdruck"
 
 #: bitmap2component/bitmap2cmp_gui_base.cpp:150
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:355
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:357
 msgid "Front solder mask"
 msgstr "Vorderseitige Lötstoppmaske"
 
@@ -1260,10 +1268,6 @@ msgstr ""
 "Die 2 unsichtbaren Felder Referenz und Wert werden auf der Lage für den "
 "Bestückungsdruck platziert."
 
-#: bitmap2component/bitmap2cmp_gui_base.h:92
-msgid "Bitmap to Component Converter"
-msgstr "Bitmap zu Bauteil Konverter"
-
 #: common/base_screen.cpp:188
 msgid "Custom User Grid"
 msgstr "Benutzerdef. Raster"
@@ -1278,41 +1282,35 @@ msgstr "Raster: %.4f mm (%.2f mils)"
 msgid "Grid: %.2f mils (%.4f mm)"
 msgstr "Raster: %.2f mils (%.4f mm)"
 
-#: common/base_units.cpp:160
+#: common/base_units.cpp:161
 msgid " mils"
 msgstr "Mil"
 
-#: common/base_units.cpp:160
+#: common/base_units.cpp:161
 msgid " in"
 msgstr "Zoll"
 
-#: common/base_units.cpp:162 common/base_units.cpp:249
+#: common/base_units.cpp:163 common/base_units.cpp:250
 msgid " mm"
 msgstr " mm"
 
-#: common/base_units.cpp:245
+#: common/base_units.cpp:246
 msgid " \""
 msgstr " \""
 
-#: common/base_units.cpp:253
+#: common/base_units.cpp:254
 msgid " deg"
 msgstr " Grad"
 
-#: common/base_units.cpp:428 common/preview_items/preview_utils.cpp:41
+#: common/base_units.cpp:433 common/preview_items/preview_utils.cpp:41
 msgid "\""
 msgstr "\""
 
-#: common/base_units.cpp:459 common/dialogs/dialog_page_settings.cpp:471
-#: pagelayout_editor/pl_editor_frame.cpp:467
-#: pcbnew/import_dxf/dialog_dxf_import_base.cpp:160
-msgid "inches"
-msgstr "Zoll"
-
-#: common/base_units.cpp:463
+#: common/base_units.cpp:468
 msgid "millimeters"
 msgstr "Millimeter"
 
-#: common/base_units.cpp:467 eeschema/dialogs/dialog_edit_label_base.cpp:57
+#: common/base_units.cpp:472 eeschema/dialogs/dialog_edit_label_base.cpp:57
 #: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:124
 #: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:135
 #: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:146
@@ -1325,21 +1323,21 @@ msgstr "Millimeter"
 msgid "units"
 msgstr "Einheiten"
 
-#: common/base_units.cpp:471
+#: common/base_units.cpp:476
 #: pcbnew/dialogs/dialog_graphic_item_properties_base.cpp:96
 msgid "degrees"
 msgstr "Grad"
 
-#: common/base_units.cpp:486
+#: common/base_units.cpp:491
 msgid "in"
 msgstr "in"
 
-#: common/base_units.cpp:497 common/preview_items/preview_utils.cpp:47
-#: pcbnew/dialogs/dialog_create_array_base.cpp:220
-#: pcbnew/dialogs/dialog_move_exact_base.cpp:65
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:135
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:145
-#: pcbnew/dialogs/dialog_position_relative_base.cpp:63
+#: common/base_units.cpp:502 common/preview_items/preview_utils.cpp:47
+#: pcbnew/dialogs/dialog_create_array_base.cpp:222
+#: pcbnew/dialogs/dialog_move_exact_base.cpp:67
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:137
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:147
+#: pcbnew/dialogs/dialog_position_relative_base.cpp:65
 msgid "deg"
 msgstr "Grad"
 
@@ -1352,25 +1350,30 @@ msgstr ""
 "ein quasi-modales Dialogfenster ist noch geöffnet, bitte dieses zuerst "
 "schließen."
 
-#: common/basicframe.cpp:487
+#: common/basicframe.cpp:429
+#, c-format
+msgid "File \"%s\" was not found."
+msgstr "Datei '%s' nicht gefunden."
+
+#: common/basicframe.cpp:474
 #, c-format
 msgid ""
 "Html or pdf help file \n"
-"'%s'\n"
+"\"%s\"\n"
 " or\n"
-"'%s' could not be found."
+"\"%s\" could not be found."
 msgstr ""
 "Die HTML- oder PDF-Hilfedatei '\n"
 "'%s'\n"
 "oder\n"
 "'%s' wurde nicht gefunden."
 
-#: common/basicframe.cpp:504
+#: common/basicframe.cpp:491
 #, c-format
-msgid "Help file '%s' could not be found."
+msgid "Help file \"%s\" could not be found."
 msgstr "Die Hilfedatei '%s' wurde nicht gefunden."
 
-#: common/basicframe.cpp:538
+#: common/basicframe.cpp:525
 #, c-format
 msgid ""
 "Could not launch the default browser.\n"
@@ -1379,31 +1382,31 @@ msgstr ""
 "Der Standardbrowser konnte nicht geöffnet werden.\n"
 "Für mehr Informationen für Hilfe am KiCad Projekt besuchen Sie %s"
 
-#: common/basicframe.cpp:541
+#: common/basicframe.cpp:528
 msgid "Get involved with KiCad"
 msgstr "Beteilige Dich an KiCad"
 
-#: common/basicframe.cpp:573
+#: common/basicframe.cpp:560
 #, c-format
-msgid "You do not have write permissions to folder <%s>."
-msgstr "Keine Schreibrechte für Verzeichnis <%s>."
+msgid "You do not have write permissions to folder \"%s\"."
+msgstr "Keine Schreibrechte für Verzeichnis '%s'."
 
-#: common/basicframe.cpp:578
+#: common/basicframe.cpp:565
 #, c-format
-msgid "You do not have write permissions to save file <%s> to folder <%s>."
-msgstr "Keine Schreibrechte zum Speichern der Datei <%s> im Verzeichnis <%s>."
+msgid "You do not have write permissions to save file \"%s\" to folder \"%s\"."
+msgstr "Keine Schreibrechte zum Speichern der Datei '%s' im Verzeichnis '%s'."
 
-#: common/basicframe.cpp:583
+#: common/basicframe.cpp:570
 #, c-format
-msgid "You do not have write permissions to save file <%s>."
-msgstr "Keine Schreibrechte zum Speichern der Datei <%s>."
+msgid "You do not have write permissions to save file \"%s\"."
+msgstr "Keine Schreibrechte zum Speichern der Datei '%s'."
 
-#: common/basicframe.cpp:615
+#: common/basicframe.cpp:602
 #, c-format
 msgid ""
 "Well this is potentially embarrassing!\n"
 "It appears that the last time you were editing the file\n"
-"'%s'\n"
+"\"%s\"\n"
 "it was not saved properly.  Do you wish to restore the last saved edits you "
 "made?"
 msgstr ""
@@ -1411,26 +1414,26 @@ msgstr ""
 "gespeichert wurde.\n"
 "Möchten Sie die letzten Änderungen wiederherstellen?"
 
-#: common/basicframe.cpp:643
+#: common/basicframe.cpp:630
 #, c-format
-msgid "Could not create backup file <%s>"
-msgstr "Konnte die Sicherungskopie <%s> nicht erstellen."
+msgid "Could not create backup file \"%s\""
+msgstr "Konnte die Sicherungskopie '%s' nicht erstellen."
 
-#: common/basicframe.cpp:651
+#: common/basicframe.cpp:638
 msgid "The auto save file could not be renamed to the board file name."
 msgstr ""
 "Die beim automatischen Speichern erzeugte Datei konnte nicht in die "
 "Platinendatei umbenannt werden."
 
-#: common/basicframe.cpp:703
+#: common/basicframe.cpp:690
 msgid "Icons in Menus"
 msgstr "Icons in Menüs"
 
-#: common/basicframe.cpp:709
+#: common/basicframe.cpp:696
 msgid "Icons Options"
 msgstr "Icons"
 
-#: common/basicframe.cpp:710
+#: common/basicframe.cpp:697
 msgid "Select show icons in menus and icons sizes"
 msgstr "Auswahl der Anzeige von Icons und deren Größe"
 
@@ -1463,11 +1466,11 @@ msgid "Block Paste"
 msgstr "Gruppe einfügen"
 
 #: common/block_commande.cpp:97 common/tool/zoom_tool.cpp:55
-#: eeschema/libeditframe.cpp:1133 eeschema/schedit.cpp:531
-#: eeschema/tool_lib.cpp:183 eeschema/tool_sch.cpp:127
+#: eeschema/libeditframe.cpp:1175 eeschema/schedit.cpp:514
+#: eeschema/tool_lib.cpp:172 eeschema/tool_sch.cpp:121
 #: gerbview/events_called_functions.cpp:237 gerbview/toolbars_gerber.cpp:92
 #: pagelayout_editor/events_functions.cpp:136 pagelayout_editor/menubar.cpp:143
-#: pagelayout_editor/toolbars_pl_editor.cpp:97 pcbnew/edit.cpp:1444
+#: pagelayout_editor/toolbars_pl_editor.cpp:97 pcbnew/edit.cpp:1449
 #: pcbnew/modedit.cpp:934 pcbnew/tool_modedit.cpp:138 pcbnew/tool_pcb.cpp:266
 msgid "Zoom to selection"
 msgstr "Zoomauswahl"
@@ -1610,160 +1613,141 @@ msgstr "Gelb 4"
 
 #: common/common.cpp:280
 #, c-format
-msgid "Cannot make path '%s' absolute with respect to '%s'."
+msgid "Cannot make path \"%s\" absolute with respect to \"%s\"."
 msgstr ""
 "Kann den absoluten Pfad '%s' nicht erstellen unter Berücksichtigung von '%s'."
 
 #: common/common.cpp:298
 #, c-format
-msgid "Output directory '%s' created.\n"
+msgid "Output directory \"%s\" created.\n"
 msgstr "Das Ausgabeverzeichnis '%s' wurde erstellt.\n"
 
 #: common/common.cpp:307
 #, c-format
-msgid "Cannot create output directory '%s'.\n"
+msgid "Cannot create output directory \"%s\".\n"
 msgstr "Konnte das Ausgabeverzeichnis '%s' nicht erstellen.\n"
 
-#: common/confirm.cpp:77 common/pgm_base.cpp:933 eeschema/symbedit.cpp:103
+#: common/confirm.cpp:79 common/pgm_base.cpp:933 eeschema/symbedit.cpp:107
 #: eeschema/widgets/widget_eeschema_color_config.cpp:294
-#: pcbnew/dialogs/dialog_export_idf.cpp:169
+#: pcbnew/dialogs/dialog_export_idf.cpp:170
 #: pcbnew/dialogs/dialog_export_vrml.cpp:178
 msgid "Warning"
 msgstr "Warnung"
 
-#: common/confirm.cpp:89 kicad/prjconfig.cpp:322
-#: pcbnew/router/length_tuner_tool.cpp:141
+#: common/confirm.cpp:91 kicad/prjconfig.cpp:322
+#: pcbnew/router/length_tuner_tool.cpp:148
 msgid "Error"
 msgstr "Fehler"
 
-#: common/confirm.cpp:106
+#: common/confirm.cpp:108
 msgid "Info"
 msgstr "Hinweis"
 
-#: common/confirm.cpp:131
+#: common/confirm.cpp:133
 msgid "Confirmation"
 msgstr "Bestätigung"
 
-#: common/dialog_about/AboutDialog_main.cpp:119
+#: common/confirm.cpp:257 pcbnew/dialogs/dialog_design_rules_base.cpp:111
+#: pcbnew/dialogs/dialog_design_rules_base.cpp:153
+msgid "Select All"
+msgstr "Alles auswählen"
+
+#: common/confirm.cpp:259
+msgid "Unselect All"
+msgstr "Alles abwählen"
+
+#: common/dialog_about/AboutDialog_main.cpp:118
 msgid ""
 "The KiCad EDA Suite is a set of open source applications for the creation of "
-"electronic schematics and to design printed circuit boards."
+"electronic schematics and printed circuit boards."
 msgstr ""
 "Die KiCad EDA Suite besteht aus quelloffenen Anwendungen für das Erstellen "
 "von elektronischen Schaltungen und den Entwurf gedruckter Leiterplatten."
 
-#: common/dialog_about/AboutDialog_main.cpp:127
+#: common/dialog_about/AboutDialog_main.cpp:126
 msgid "KiCad on the web"
 msgstr "KiCad im Internet"
 
-#: common/dialog_about/AboutDialog_main.cpp:134
-msgid "The official KiCad website"
-msgstr "Die offizielle KiCad Webseite"
-
-#: common/dialog_about/AboutDialog_main.cpp:138
-msgid "Developer's website on Launchpad"
-msgstr "Projektseite auf Launchpad"
-
-#: common/dialog_about/AboutDialog_main.cpp:143
-msgid "Official repository for component and footprint libraries"
-msgstr "Offizielles Repository mit Bauteil- und Footprintbibliotheken"
-
 #: common/dialog_about/AboutDialog_main.cpp:148
-msgid "Footprint wizards info on our official repository"
-msgstr "Footprint Wizard Info in unserem offizielles Repository"
-
-#: common/dialog_about/AboutDialog_main.cpp:153
-msgid "Non official repositories"
-msgstr "Nicht offizielle Repositorys"
-
-#: common/dialog_about/AboutDialog_main.cpp:160
-msgid "Additional component libraries repository (smisioto)"
-msgstr "Repository mit zusätzlichen Bauteilbibliotheken (smisioto)"
-
-#: common/dialog_about/AboutDialog_main.cpp:166
 msgid "Bug tracker"
 msgstr "Bug Tracker"
 
-#: common/dialog_about/AboutDialog_main.cpp:173
-msgid "Report or examine bugs"
-msgstr "Melde oder Prüfe Fehler"
-
-#: common/dialog_about/AboutDialog_main.cpp:178
+#: common/dialog_about/AboutDialog_main.cpp:161
 msgid "KiCad user's groups and community"
 msgstr "KiCad-Benutzergruppen und Community"
 
-#: common/dialog_about/AboutDialog_main.cpp:184
-msgid "KiCad user's group"
-msgstr "KiCad-Benutzergruppen"
-
-#: common/dialog_about/AboutDialog_main.cpp:189
-msgid "KiCad forum"
-msgstr "KiCad-Forum"
-
-#: common/dialog_about/AboutDialog_main.cpp:202
+#: common/dialog_about/AboutDialog_main.cpp:185
 msgid "The complete KiCad EDA Suite is released under the"
 msgstr "Die gesamte KiCad EDA Suite ist veröffentlicht unter der"
 
-#: common/dialog_about/AboutDialog_main.cpp:204
+#: common/dialog_about/AboutDialog_main.cpp:187
 msgid "GNU General Public License (GPL) version 3 or any later version"
 msgstr ""
 "GNU General Public License (GPL) Version 3 oder jeder nachfolgenden Version"
 
-#: common/dialog_about/AboutDialog_main.cpp:398
+#: common/dialog_about/AboutDialog_main.cpp:372
 msgid "Others"
 msgstr "Andere"
 
-#: common/dialog_about/AboutDialog_main.cpp:413
+#: common/dialog_about/AboutDialog_main.cpp:391
 msgid "Icons by"
 msgstr "Icons von"
 
-#: common/dialog_about/AboutDialog_main.cpp:428
+#: common/dialog_about/AboutDialog_main.cpp:409
 msgid "3D models by"
 msgstr "3D-Modelle von"
 
-#: common/dialog_about/dialog_about.cpp:120
+#: common/dialog_about/AboutDialog_main.cpp:426
+msgid "Symbols by"
+msgstr "Symbole von"
+
+#: common/dialog_about/AboutDialog_main.cpp:433
+msgid "Footprints by"
+msgstr "Footprints von"
+
+#: common/dialog_about/dialog_about.cpp:121
 msgid "Information"
 msgstr "Informationen"
 
-#: common/dialog_about/dialog_about.cpp:123
+#: common/dialog_about/dialog_about.cpp:124
 msgid "Developers"
 msgstr "Entwickler"
 
-#: common/dialog_about/dialog_about.cpp:124
+#: common/dialog_about/dialog_about.cpp:125
 msgid "Doc Writers"
 msgstr "Dokumentation"
 
-#: common/dialog_about/dialog_about.cpp:126
+#: common/dialog_about/dialog_about.cpp:127
 msgid "Artists"
 msgstr "Designer"
 
-#: common/dialog_about/dialog_about.cpp:127
+#: common/dialog_about/dialog_about.cpp:128
 msgid "Translators"
 msgstr "Übersetzer"
 
-#: common/dialog_about/dialog_about.cpp:129
+#: common/dialog_about/dialog_about.cpp:130
 msgid "Packagers"
 msgstr "Paketverwalter"
 
-#: common/dialog_about/dialog_about.cpp:132
+#: common/dialog_about/dialog_about.cpp:133
 msgid "License"
 msgstr "Lizenz"
 
-#: common/dialog_about/dialog_about.cpp:557
+#: common/dialog_about/dialog_about.cpp:574
 msgid "Version Info"
 msgstr "Versionsinformationen"
 
-#: common/dialog_about/dialog_about.cpp:569
+#: common/dialog_about/dialog_about.cpp:586
 msgid "Could not open clipboard to write version information."
 msgstr ""
 "Konnte nicht auf die Zwischenablage zugreifen, um die Versionsbezeichnung "
 "einzufügen."
 
-#: common/dialog_about/dialog_about.cpp:570
+#: common/dialog_about/dialog_about.cpp:587
 msgid "Clipboard Error"
 msgstr "Fehler beim Zugriff auf Zwischenablage"
 
-#: common/dialog_about/dialog_about.cpp:579
+#: common/dialog_about/dialog_about.cpp:596
 msgid "Copied..."
 msgstr "Kopiert ..."
 
@@ -1795,10 +1779,6 @@ msgstr "Kopiere Versionsinfo"
 msgid "Copy KiCad version info to the clipboard"
 msgstr "Kopiere KiCad-Version in die Zwischenablage"
 
-#: common/dialog_about/dialog_about_base.h:56
-msgid "About"
-msgstr "Über"
-
 #: common/dialogs/dialog_display_info_HTML_base.cpp:22 common/zoom.cpp:300
 #: eeschema/dialogs/dialog_annotate_base.cpp:212
 #: eeschema/dialogs/dialog_bom_base.cpp:62
@@ -1807,7 +1787,7 @@ msgstr "Über"
 #: eeschema/dialogs/dialog_plot_schematic_base.cpp:125
 #: eeschema/dialogs/dialog_print_using_printer_base.cpp:53
 #: eeschema/dialogs/dialog_schematic_find_base.cpp:125
-#: eeschema/dialogs/dialog_symbol_remap_base.cpp:34
+#: eeschema/dialogs/dialog_symbol_remap_base.cpp:33
 #: gerbview/dialogs/dialog_print_using_printer_base.cpp:107
 #: pcbnew/dialogs/dialog_SVG_print_base.cpp:129
 #: pcbnew/dialogs/dialog_exchange_modules_base.cpp:102
@@ -1824,13 +1804,13 @@ msgstr "Schließen"
 
 #: common/dialogs/dialog_env_var_config.cpp:132
 #: common/dialogs/dialog_env_var_config_base.cpp:118
-#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:82
+#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:80
 #: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:218
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib.cpp:203
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:318
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:321
-#: eeschema/dialogs/dialog_lib_edit_pin_table.cpp:182 eeschema/lib_pin.cpp:2034
-#: eeschema/libedit.cpp:461 eeschema/widgets/tuner_slider_base.cpp:20
+#: eeschema/dialogs/dialog_lib_edit_pin_table.cpp:182 eeschema/lib_pin.cpp:1703
+#: eeschema/libedit.cpp:633 eeschema/widgets/tuner_slider_base.cpp:20
 #: pcb_calculator/dialogs/dialog_regulator_data_base.cpp:26
 #: pcbnew/dialogs/dialog_footprint_wizard_list_base.cpp:43
 #: pcbnew/dialogs/dialog_layers_setup.cpp:336
@@ -1843,7 +1823,7 @@ msgstr "Pfad existiert bereits"
 
 #: common/dialogs/dialog_env_var_config.cpp:251
 #, c-format
-msgid "Environment variable '%s' cannot be renamed"
+msgid "Environment variable \"%s\" cannot be renamed"
 msgstr "Die Umgebungsvariable '%s' kann nicht umbenannt werden."
 
 #: common/dialogs/dialog_env_var_config.cpp:253
@@ -1982,7 +1962,7 @@ msgstr "Pfade der KiCad Umgebungsvariablen"
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:225
 #: eeschema/dialogs/dialog_spice_model_base.cpp:519
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:75
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1067
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1069
 msgid "Add"
 msgstr "Hinzufügen"
 
@@ -1996,11 +1976,11 @@ msgstr "Pfadprefix hinzufügen"
 #: eeschema/libedit_onrightclick.cpp:288 eeschema/onrightclick.cpp:517
 #: eeschema/onrightclick.cpp:553 eeschema/onrightclick.cpp:589
 #: eeschema/onrightclick.cpp:623 eeschema/onrightclick.cpp:805
-#: eeschema/onrightclick.cpp:836
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:36
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:52
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:50
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:66
+#: eeschema/onrightclick.cpp:836 eeschema/widgets/cmp_tree_pane.cpp:61
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:38
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:54
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:52
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:68
 #: pcbnew/modedit_onclick.cpp:383 pcbnew/modedit_onclick.cpp:422
 #: pcbnew/onrightclick.cpp:215 pcbnew/onrightclick.cpp:267
 #: pcbnew/onrightclick.cpp:312 pcbnew/onrightclick.cpp:890
@@ -2015,6 +1995,7 @@ msgstr "Ausgewählten Pfadprefix bearbeiten"
 #: common/dialogs/dialog_env_var_config_base.cpp:44
 #: cvpcb/dialogs/dialog_config_equfiles_base.cpp:39
 #: eeschema/dialogs/dialog_spice_model_base.cpp:527
+#: eeschema/widgets/cmp_tree_pane.cpp:62
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:80
 msgid "Remove"
 msgstr "Entfernen"
@@ -2029,21 +2010,20 @@ msgid "Help"
 msgstr "Hilfe"
 
 #: common/dialogs/dialog_env_var_config_base.cpp:128
-#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:83
-#: eeschema/bom_table_column.h:36
+#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:81
 #: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:221
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib.cpp:206
-#: eeschema/dialogs/dialog_rescue_each.cpp:111
-#: eeschema/dialogs/dialog_spice_model_base.cpp:45 eeschema/lib_field.cpp:620
-#: eeschema/lib_field.cpp:799 eeschema/sch_component.cpp:1771
-#: eeschema/sch_component.cpp:1810 eeschema/template_fieldnames.cpp:42
+#: eeschema/dialogs/dialog_rescue_each.cpp:119
+#: eeschema/dialogs/dialog_spice_model_base.cpp:45 eeschema/lib_field.cpp:449
+#: eeschema/lib_field.cpp:628 eeschema/sch_component.cpp:1436
+#: eeschema/sch_component.cpp:1475 eeschema/template_fieldnames.cpp:42
 #: eeschema/widgets/widget_eeschema_color_config.cpp:77
-#: pcbnew/class_edge_mod.cpp:249 pcbnew/class_text_mod.cpp:354
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:42
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:56
+#: pcbnew/class_edge_mod.cpp:249 pcbnew/class_text_mod.cpp:362
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:44
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:58
 #: pcbnew/dialogs/dialog_fp_plugin_options_base.cpp:40
 #: pcbnew/dialogs/dialog_global_modules_fields_edition_base.cpp:31
-#: pcbnew/footprint_wizard_frame.cpp:294
+#: pcbnew/footprint_wizard_frame.cpp:294 eeschema/bom_table_column.h:36
 msgid "Value"
 msgstr "Wert"
 
@@ -2052,7 +2032,7 @@ msgstr "Wert"
 #: eeschema/dialogs/dialog_plot_schematic_base.cpp:33
 #: kicad/dialogs/dialog_template_selector_base.cpp:36
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:204
-#: pcbnew/dialogs/dialog_gencad_export_options.cpp:52
+#: pcbnew/dialogs/dialog_gencad_export_options.cpp:53
 #: pcbnew/dialogs/dialog_gendrill_base.cpp:28
 #: pcbnew/dialogs/dialog_netlist_fbp.cpp:152
 #: pcbnew/dialogs/dialog_plot_base.cpp:54
@@ -2061,14 +2041,6 @@ msgstr "Wert"
 #: pcbnew/import_dxf/dialog_dxf_import_base.cpp:33
 msgid "Browse"
 msgstr "Durchsuchen"
-
-#: common/dialogs/dialog_env_var_config_base.h:66
-msgid "Path Configuration"
-msgstr "Pfadkonfiguration"
-
-#: common/dialogs/dialog_env_var_config_base.h:97
-msgid "Edit Environment Value Variable"
-msgstr "Bearbeiten Umgebungsvariable"
 
 #: common/dialogs/dialog_exit_base.cpp:34
 msgid "Save the changes before closing?"
@@ -2091,7 +2063,7 @@ msgstr "Beenden ohne zu Speichern"
 #: eeschema/dialogs/dialog_bom_base.cpp:45
 #: eeschema/dialogs/dialog_netlist_base.cpp:113
 #: eeschema/dialogs/dialog_sch_edit_sheet_pin_base.cpp:28
-#: pcbnew/librairi.cpp:685
+#: pcbnew/librairi.cpp:683
 msgid "Name:"
 msgstr "Name:"
 
@@ -2118,22 +2090,18 @@ msgstr "Doppelklicken zum Bearbeiten"
 
 #: common/dialogs/dialog_hotkeys_editor_base.cpp:28
 #: gerbview/dialogs/dialog_layers_select_to_pcb_base.cpp:85
-#: pcbnew/dialogs/dialog_move_exact_base.cpp:41
-#: pcbnew/dialogs/dialog_move_exact_base.cpp:55
-#: pcbnew/dialogs/dialog_move_exact_base.cpp:69
-#: pcbnew/dialogs/dialog_position_relative_base.cpp:39
-#: pcbnew/dialogs/dialog_position_relative_base.cpp:53
-#: pcbnew/dialogs/dialog_position_relative_base.cpp:67
+#: pcbnew/dialogs/dialog_move_exact_base.cpp:43
+#: pcbnew/dialogs/dialog_move_exact_base.cpp:57
+#: pcbnew/dialogs/dialog_move_exact_base.cpp:71
+#: pcbnew/dialogs/dialog_position_relative_base.cpp:41
+#: pcbnew/dialogs/dialog_position_relative_base.cpp:55
+#: pcbnew/dialogs/dialog_position_relative_base.cpp:69
 msgid "Reset"
 msgstr "Rücksetzen"
 
 #: common/dialogs/dialog_hotkeys_editor_base.cpp:31
 msgid "Defaults"
 msgstr "Voreinstellungen wiederherstellen"
-
-#: common/dialogs/dialog_hotkeys_editor_base.h:55
-msgid "Hotkeys Editor"
-msgstr "Editor für Tastaturbefehle"
 
 #: common/dialogs/dialog_image_editor.cpp:139
 msgid "Incorrect scale number"
@@ -2177,10 +2145,6 @@ msgstr "Rückgängig"
 #: common/dialogs/dialog_image_editor_base.cpp:52
 msgid "Image Scale:"
 msgstr "Bildskalierung:"
-
-#: common/dialogs/dialog_image_editor_base.h:64
-msgid "Image Editor"
-msgstr "Bildeditor"
 
 #: common/dialogs/dialog_list_selector_base.cpp:19
 msgid "Filter:"
@@ -2270,9 +2234,9 @@ msgstr "Hochformat"
 
 #: common/dialogs/dialog_page_settings.cpp:436
 #, c-format
-msgid "Page layout description file <%s> not found. Abort"
+msgid "Page layout description file \"%s\" not found. Abort"
 msgstr ""
-"Datei <%s> mit Seitenlayoutbeschreibung konnte nicht gefunden werden. "
+"Datei '%s' mit Seitenlayoutbeschreibung konnte nicht gefunden werden. "
 "Abbruch!"
 
 #: common/dialogs/dialog_page_settings.cpp:467
@@ -2298,17 +2262,17 @@ msgid "Landscape"
 msgstr "Querformat"
 
 #: common/dialogs/dialog_page_settings.cpp:806
-msgid "Select Page Layout Descr File"
-msgstr "Dateiauswahl für Seitenlayoutbeschreibung"
+msgid "Select Page Layout Description File"
+msgstr "Datei für Seitenlayoutbeschreibung auswählen"
 
 #: common/dialogs/dialog_page_settings.cpp:824
 #, c-format
 msgid ""
 "The page layout descr filename has changed.\n"
 "Do you want to use the relative path:\n"
-"'%s'\n"
+"\"%s\"\n"
 "instead of\n"
-"'%s'"
+"\"%s\""
 msgstr ""
 "Der Dateiname für die Seitenlayoutbeschreibung wurde geändert.\n"
 "Möchte Sie den folgenden relativen Pfad verwenden:\n"
@@ -2325,7 +2289,7 @@ msgid "dummy text"
 msgstr "Dummytext"
 
 #: common/dialogs/dialog_page_settings_base.cpp:42
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:125
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:127
 msgid "Orientation:"
 msgstr "Ausrichtung:"
 
@@ -2335,7 +2299,7 @@ msgstr "Benutzerdefinierte Größe:"
 
 #: common/dialogs/dialog_page_settings_base.cpp:62
 #: pcbnew/dialogs/dialog_global_modules_fields_edition_base.cpp:75
-#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:77
+#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:78
 msgid "Height:"
 msgstr "Höhe:"
 
@@ -2344,10 +2308,11 @@ msgid "Custom paper height."
 msgstr "Benutzerdefinierte Seitenhöhe."
 
 #: common/dialogs/dialog_page_settings_base.cpp:78
+#: eeschema/dialogs/dialog_edit_line_style_base.cpp:36
 #: pcbnew/dialogs/dialog_global_modules_fields_edition_base.cpp:64
-#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:46
+#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:47
 #: pcbnew/dialogs/dialog_plot_base.cpp:205
-#: pcbnew/dialogs/dialog_pns_diff_pair_dimensions_base.cpp:25
+#: pcbnew/dialogs/dialog_pns_diff_pair_dimensions_base.cpp:27
 #: pcbnew/dialogs/dialog_track_via_properties_base.cpp:118
 msgid "Width:"
 msgstr "Breite:"
@@ -2426,44 +2391,31 @@ msgstr "Kommentar4"
 msgid "Page layout description file"
 msgstr "Seitenlayoutbeschreibungsdatei"
 
-#: common/dialogs/dialog_page_settings_base.h:121
-msgid "Page Settings"
-msgstr "Seite einrichten"
-
-#: common/dialogs/wx_html_report_panel.cpp:137
-msgid "<b>Error: </b></font><font size=2>"
-msgstr "<b>Fehler: </b></font><font size=2>"
-
 #: common/dialogs/wx_html_report_panel.cpp:139
-msgid "<b>Warning: </b></font><font size=2>"
-msgstr "<b>Warnung: </b></font><font size=2>"
-
-#: common/dialogs/wx_html_report_panel.cpp:141
-msgid "<b>Info: </b>"
-msgstr "<b>Hinweis: </b>"
-
-#: common/dialogs/wx_html_report_panel.cpp:155
+#: common/dialogs/wx_html_report_panel.cpp:166
 msgid "Error: "
 msgstr "Fehler:"
 
-#: common/dialogs/wx_html_report_panel.cpp:157
+#: common/dialogs/wx_html_report_panel.cpp:143
+#: common/dialogs/wx_html_report_panel.cpp:168
 msgid "Warning: "
 msgstr "Warnung:"
 
-#: common/dialogs/wx_html_report_panel.cpp:159
+#: common/dialogs/wx_html_report_panel.cpp:147
+#: common/dialogs/wx_html_report_panel.cpp:170
 msgid "Info: "
 msgstr "Hinweis:"
 
-#: common/dialogs/wx_html_report_panel.cpp:240
-msgid "Save report to file"
+#: common/dialogs/wx_html_report_panel.cpp:251
+msgid "Save Report to File"
 msgstr "Speichere in Protokolldatei"
 
-#: common/dialogs/wx_html_report_panel.cpp:257
+#: common/dialogs/wx_html_report_panel.cpp:268
 #, c-format
-msgid "Cannot write report to file '%s'."
+msgid "Cannot write report to file \"%s\"."
 msgstr "Kann Protokolldatei '%s' nicht erstellen."
 
-#: common/dialogs/wx_html_report_panel.cpp:259
+#: common/dialogs/wx_html_report_panel.cpp:270
 msgid "File save error"
 msgstr "Fehler beim Dateischreibvorgang"
 
@@ -2485,7 +2437,7 @@ msgid "Warnings"
 msgstr "Warnungen"
 
 #: common/dialogs/wx_html_report_panel_base.cpp:47 gerbview/files.cpp:275
-#: gerbview/files.cpp:379 gerbview/readgerb.cpp:67
+#: gerbview/files.cpp:380 gerbview/readgerb.cpp:67
 msgid "Errors"
 msgstr "Fehler"
 
@@ -2536,12 +2488,12 @@ msgstr "Zwischenablage"
 
 #: common/dsnlexer.cpp:356 common/dsnlexer.cpp:364
 #, c-format
-msgid "Expecting '%s'"
+msgid "Expecting \"%s\""
 msgstr "Erwartete Zeichen '%s'"
 
 #: common/dsnlexer.cpp:372 common/dsnlexer.cpp:388
 #, c-format
-msgid "Unexpected '%s'"
+msgid "Unexpected \"%s\""
 msgstr "Unerwartete Zeichen '%s'"
 
 #: common/dsnlexer.cpp:380
@@ -2551,7 +2503,7 @@ msgstr "%s ist ein Duplikat"
 
 #: common/dsnlexer.cpp:433
 #, c-format
-msgid "need a NUMBER for '%s'"
+msgid "need a NUMBER for \"%s\""
 msgstr "benötige eine Zahl für '%s'"
 
 #: common/dsnlexer.cpp:705 common/dsnlexer.cpp:765
@@ -2570,22 +2522,22 @@ msgstr "Doc Dateien"
 
 #: common/eda_doc.cpp:160
 #, c-format
-msgid "Doc File '%s' not found"
+msgid "Doc File \"%s\" not found"
 msgstr "Die Dokumentationsdatei '%s' wurde nicht gefunden."
 
 #: common/eda_doc.cpp:203
 #, c-format
-msgid "Unknown MIME type for doc file <%s>"
-msgstr "Unbekannter MIME-Typ für Doc-Datei <%s>"
+msgid "Unknown MIME type for doc file \"%s\""
+msgstr "Unbekannter MIME-Typ für Doc-Datei '%s'"
 
 #: common/eda_text.cpp:392
 #: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:203
 #: eeschema/dialogs/dialog_edit_label_base.cpp:76
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:107
-#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:95 eeschema/sch_text.cpp:781
+#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:95 eeschema/sch_text.cpp:663
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:109
-#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:109
-#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:99
+#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:110
+#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:100
 msgid "Italic"
 msgstr "Kursiv"
 
@@ -2593,7 +2545,7 @@ msgstr "Kursiv"
 #: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:203
 #: eeschema/dialogs/dialog_edit_label_base.cpp:76
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:107
-#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:95 eeschema/sch_text.cpp:781
+#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:95 eeschema/sch_text.cpp:663
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:90
 msgid "Bold"
 msgstr "Fett"
@@ -2611,19 +2563,19 @@ msgstr "von %s : %s() Zeile:%d"
 #, c-format
 msgid ""
 "%s in input/source\n"
-"'%s'\n"
+"\"%s\"\n"
 "line %d, offset %d"
 msgstr ""
 "%s in Eingang/Quelle\n"
 "'%s'\n"
 "Zeile %d, Offset %d"
 
-#: common/exceptions.cpp:103
+#: common/exceptions.cpp:104
 #, c-format
 msgid ""
-"KiCad was unable to open this file, as it was created with a more recent "
-"version than the one you are running. To open it, you'll need to upgrade "
-"KiCad to a more recent version.\n"
+"KiCad was unable to open this file, as it was created with\n"
+"a more recent version than the one you are running.\n"
+"To open it, you'll need  to upgrade KiCad to a more recent version.\n"
 "\n"
 "Date of KiCad version required (or newer): %s\n"
 "\n"
@@ -2647,47 +2599,48 @@ msgstr "Fehler beim Laden"
 msgid "Errors were encountered loading footprints:"
 msgstr "Diese Fehler traten beim Laden der Footprints auf:"
 
-#: common/fp_lib_table.cpp:187
+#: common/fp_lib_table.cpp:195
 #, c-format
 msgid ""
-"Duplicate library nickname '%s' found in footprint library table file line %d"
+"Duplicate library nickname \"%s\" found in footprint library table file line "
+"%d"
 msgstr ""
 "Doppelter Bibliotheks-Nickname '%s' in der Tabelle der Footprintbibliotheken "
 "in Zeile '%d gefunden."
 
-#: common/fp_lib_table.cpp:254
+#: common/fp_lib_table.cpp:262
 #, c-format
-msgid "fp-lib-table files contain no library with nickname '%s'"
+msgid "fp-lib-table files contain no library with nickname \"%s\""
 msgstr ""
 "Die Footprint-Bibliothekstabelle enthält keine Bibliothek mit dem Nicknamen "
 "'%s'"
 
-#: common/fp_lib_table.cpp:408
+#: common/fp_lib_table.cpp:416
 #: eeschema/dialogs/dialog_global_sym_lib_table_config.cpp:135
-#: eeschema/symbol_lib_table.cpp:441
+#: eeschema/symbol_lib_table.cpp:455
 #, c-format
-msgid "Cannot create global library table path '%s'."
+msgid "Cannot create global library table path \"%s\"."
 msgstr ""
 "Der Pfad '%s' für die globale Bibliothekstabelle konnte nicht erstellen "
 "werden."
 
 #: common/gestfich.cpp:233
 #, c-format
-msgid "Command <%s> could not found"
-msgstr "Programm <%s> nicht gefunden."
+msgid "Command \"%s\" could not found"
+msgstr "Programm '%s' nicht gefunden."
 
 #: common/gestfich.cpp:377
 #, c-format
 msgid ""
 "Problem while running the PDF viewer\n"
-"Command is '%s'"
+"Command is \"%s\""
 msgstr ""
 "Es ist ein Problem beim Starten des PDF-Betrachters aufgetreten.\n"
 "Ausgeführter Befehl: '%s'"
 
 #: common/gestfich.cpp:384
 #, c-format
-msgid "Unable to find a PDF viewer for '%s'"
+msgid "Unable to find a PDF viewer for \"%s\""
 msgstr "Konnte keinen PDF-Betrachter für '%s' finden."
 
 #: common/grid_tricks.cpp:115
@@ -2746,7 +2699,7 @@ msgstr "Tastaturbefehle &editieren"
 msgid "Edit hotkeys list"
 msgstr "Tastaturbefehle editieren"
 
-#: common/hotkeys_basic.cpp:818 eeschema/menubar.cpp:610
+#: common/hotkeys_basic.cpp:818 eeschema/menubar.cpp:617
 msgid "E&xport Hotkeys"
 msgstr "Tastaturbefehle e&xportieren"
 
@@ -2754,11 +2707,11 @@ msgstr "Tastaturbefehle e&xportieren"
 msgid "Export current hotkeys into configuration file"
 msgstr "Export der gegenwärtigen Tastaturbefehle in eine Konfigurationsdatei."
 
-#: common/hotkeys_basic.cpp:824 eeschema/menubar.cpp:616
+#: common/hotkeys_basic.cpp:824 eeschema/menubar.cpp:623
 msgid "&Import Hotkeys"
 msgstr "Tastaturbefehle &importieren"
 
-#: common/hotkeys_basic.cpp:825 eeschema/menubar.cpp:617
+#: common/hotkeys_basic.cpp:825 eeschema/menubar.cpp:624
 msgid "Load existing hotkey configuration file"
 msgstr "Tastaturbefehle aus einer Konfigurationsdatei einlesen."
 
@@ -2772,13 +2725,13 @@ msgstr "Konfiguration und Einstellungen der Tastaturbefehle"
 
 #: common/kiway.cpp:186
 #, c-format
-msgid "Failed to load kiface library '%s'."
+msgid "Failed to load kiface library \"%s\"."
 msgstr "Konnte die kiface-Bibliothek '%s' nicht laden."
 
 #: common/kiway.cpp:195
 #, c-format
 msgid ""
-"Could not read instance name and version symbol form kiface library '%s'."
+"Could not read instance name and version symbol form kiface library \"%s\"."
 msgstr ""
 "Konnte den Instanzierungsnamen und die Symbolversionsform nicht von der "
 "kiface Bibliothek '%s' lesen"
@@ -2787,7 +2740,7 @@ msgstr ""
 #, c-format
 msgid ""
 "Fatal Installation Bug. File:\n"
-"'%s'\n"
+"\"%s\"\n"
 "could not be loaded\n"
 msgstr ""
 "Schwerer Installationsfehler. Die Datei:\n"
@@ -2829,6 +2782,7 @@ msgstr "Die Datei <%s> wurde nicht vollständig eingelesen."
 
 #: common/pgm_base.cpp:112 common/widgets/footprint_select_widget.cpp:275
 #: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:56
+#: eeschema/dialogs/dialog_edit_line_style.cpp:35
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:61
 #: pcbnew/dialogs/dialog_global_edit_tracks_and_vias.cpp:111
 #: pcbnew/dialogs/dialog_global_edit_tracks_and_vias.cpp:125
@@ -2976,23 +2930,23 @@ msgstr ""
 msgid "Do not show this message again."
 msgstr "Diese Meldung nicht erneut zeigen."
 
-#: common/project.cpp:248
+#: common/project.cpp:257
 #, c-format
-msgid "Unable to find '%s' template config file."
+msgid "Unable to find \"%s\" template config file."
 msgstr "Konnte die Vorgaben Konfigurationsdatei '%s' nicht finden."
 
-#: common/project.cpp:251
+#: common/project.cpp:260
 msgid "Error copying project file template"
 msgstr "Beim Kopieren der Projektvorlage ist ein Fehler aufgetreten."
 
-#: common/project.cpp:271
+#: common/project.cpp:280
 #, c-format
-msgid "Cannot create prj file '%s' (Directory not writable)"
+msgid "Cannot create prj file \"%s\" (Directory not writable)"
 msgstr ""
 "Projektdatei '%s' konnte nicht erstellt werden (Ordner ist nicht "
 "beschreibbar)"
 
-#: common/project.cpp:415
+#: common/project.cpp:424
 msgid "Error loading project footprint library table"
 msgstr ""
 "Bei dem Versuch die Tabelle mit den Bibliotheken der Footprints des "
@@ -3000,28 +2954,28 @@ msgstr ""
 
 #: common/richio.cpp:167
 #, c-format
-msgid "Unable to open filename '%s' for reading"
+msgid "Unable to open filename \"%s\" for reading"
 msgstr "Konnte Datei '%s' nicht zum Lesen öffnen"
 
-#: common/richio.cpp:203 common/richio.cpp:299
+#: common/richio.cpp:201 common/richio.cpp:296
 msgid "Maximum line length exceeded"
 msgstr "Maximale Zeilenlänge überschritten"
 
-#: common/richio.cpp:266
+#: common/richio.cpp:263
 msgid "Line length exceeded"
 msgstr "Zeilenlänge überschritten"
 
-#: common/richio.cpp:530
+#: common/richio.cpp:527
 #, c-format
-msgid "cannot open or save file '%s'"
+msgid "cannot open or save file \"%s\""
 msgstr "Konnte Datei '%s' nicht öffnen oder speichern."
 
-#: common/richio.cpp:549
+#: common/richio.cpp:546
 #, c-format
-msgid "error writing to file '%s'"
-msgstr "Ein Fehler ist beim Schreiben von Datei '%s' aufgetreten."
+msgid "error writing to file \"%s\""
+msgstr "Es ist ein Fehler ist beim Schreiben von Datei '%s' aufgetreten."
 
-#: common/richio.cpp:570
+#: common/richio.cpp:567
 msgid "OUTPUTSTREAM_OUTPUTFORMATTER write error"
 msgstr "OUTPUTSTREAM_OUTPUTFORMATTER Schreibfehler"
 
@@ -3051,8 +3005,6 @@ msgstr "Heraus zoomen"
 
 #: common/tool/actions.cpp:32 common/widgets/mathplot.cpp:1765
 #: common/zoom.cpp:246
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:169
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:175
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:69
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:77
 #: gerbview/class_gerber_file_image.cpp:357
@@ -3061,7 +3013,7 @@ msgstr "Heraus zoomen"
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:103
 #: pcbnew/dialogs/dialog_pad_basicshapes_properties.cpp:94
 #: pcbnew/dialogs/dialog_pad_basicshapes_properties.cpp:119
-#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:105
+#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:106
 msgid "Center"
 msgstr "Zentrieren"
 
@@ -3089,7 +3041,7 @@ msgstr ""
 #: common/tool/grid_menu.cpp:40
 #: eeschema/widgets/widget_eeschema_color_config.cpp:94
 #: gerbview/class_gerbview_layer_widget.cpp:116
-#: pcbnew/class_pcb_layer_widget.cpp:77
+#: pcbnew/class_pcb_layer_widget.cpp:78
 msgid "Grid"
 msgstr "Raster"
 
@@ -3259,6 +3211,7 @@ msgid "Edit..."
 msgstr "Bearbeiten ..."
 
 #: common/widgets/widget_hotkey_list.cpp:380
+#: eeschema/dialogs/dialog_edit_components_libid_base.cpp:92
 msgid "Undo Changes"
 msgstr "Keine Änderung"
 
@@ -3277,11 +3230,11 @@ msgstr "Rücksetzen auf Standardeinstellungen"
 #: common/widgets/widget_hotkey_list.cpp:484
 #, c-format
 msgid ""
-"<%s> is already assigned to \"%s\" in section \"%s\". Are you sure you want "
-"to change its assignment?"
+"\"%s\" is already assigned to \"%s\" in section \"%s\". Are you sure you "
+"want to change its assignment?"
 msgstr ""
-"<%s ist bereits zu \"%s\" in Sektion \"%s\" zugewiesen. Sind Sie sicher "
-"diese Zuweisung ändern zu wollen?"
+"'%s' ist bereits zu '%s' in Sektion '%s' zugewiesen. Sind Sie sicher diese "
+"Zuweisung ändern zu wollen?"
 
 #: common/widgets/widget_hotkey_list.cpp:489
 msgid "Confirm change"
@@ -3295,133 +3248,185 @@ msgstr "Aktion"
 msgid "Hotkey"
 msgstr "Taste(n)"
 
-#: common/wildcards_and_files_ext.cpp:71
-msgid "KiCad drawing symbol file (*.sym)|*.sym"
-msgstr "KiCad Zeichensymboldateien (*.sym)|*.sym"
-
-#: common/wildcards_and_files_ext.cpp:72
-msgid "KiCad component library file (*.lib)|*.lib"
-msgstr "KiCad Bauteilbibliotheksdatei (*.lib)|*.lib"
-
-#: common/wildcards_and_files_ext.cpp:73
-msgid "KiCad project files (*.pro)|*.pro"
-msgstr "KiCad Projektdateien (*.pro)|*.pro"
-
-#: common/wildcards_and_files_ext.cpp:74
-msgid "KiCad schematic files (*.sch)|*.sch"
-msgstr "KiCad Schaltplandateien (*.sch)|*.sch"
-
-#: common/wildcards_and_files_ext.cpp:75
-msgid "Eagle XML schematic file (*.sch)|*.sch"
-msgstr "Eagle XML Schaltplandatei (*.sch)|*.sch"
-
-#: common/wildcards_and_files_ext.cpp:76
-msgid "Eagle XML files (*.sch *.brd)|*.sch;*.brd"
-msgstr "Eagle XML Dateien (*.sch *.brd)|*.sch;*.brd"
-
-#: common/wildcards_and_files_ext.cpp:77
-msgid "KiCad netlist files (*.net)|*.net"
-msgstr "KiCad Netzlistedateien (*.net)|*.net"
-
-#: common/wildcards_and_files_ext.cpp:78
-msgid "Gerber files (*.pho)|*.pho"
-msgstr "Gerber Dateien (*.pho)|*.pho"
-
-#: common/wildcards_and_files_ext.cpp:79
-msgid "KiCad printed circuit board files (*.brd)|*.brd"
-msgstr "KiCad Dateien gedruckter Schaltungen (*.brd)|*.brd"
-
-#: common/wildcards_and_files_ext.cpp:80
-msgid "Eagle ver. 6.x XML PCB files (*.brd)|*.brd"
-msgstr "Eagle Ver. 6.x XML PCB Dateien (*.brd)|*.brd"
-
-#: common/wildcards_and_files_ext.cpp:81
-msgid "P-Cad 200x ASCII PCB files (*.pcb)|*.pcb"
-msgstr "P-Cad 200x ASCII PCB Dateien (*.pcb)|*.pcb"
-
-#: common/wildcards_and_files_ext.cpp:82
-msgid "KiCad s-expr printed circuit board files (*.kicad_pcb)|*.kicad_pcb"
-msgstr "KiCad s-expr Dateien gedruckter Schaltungen (*.kicad_pcb)|*.kicad_pcb"
-
-#: common/wildcards_and_files_ext.cpp:83
-msgid "KiCad footprint s-expre file (*.kicad_mod)|*.kicad_mod"
-msgstr "KiCad Footprint S-Expre Dateien (*.kicad_mod)|*.kicad_mod"
-
-#: common/wildcards_and_files_ext.cpp:84
-msgid "KiCad footprint s-expre library path (*.pretty)|*.pretty"
-msgstr "KiCad Footprint S-Expre Bibliothekspfad (*.pretty)|*.pretty"
-
-#: common/wildcards_and_files_ext.cpp:85
-msgid "Legacy footprint library file (*.mod)|*.mod"
-msgstr "Altes Footprint-Bibliotheksformat (*.mod)|*.mod"
-
-#: common/wildcards_and_files_ext.cpp:86
-msgid "Eagle ver. 6.x XML library files (*.lbr)|*.lbr"
-msgstr "Eagle Ver. 6.x XML Bibliotheksdateien (*.lbr)|*.lbr"
-
-#: common/wildcards_and_files_ext.cpp:87
-msgid "Geda PCB footprint library file (*.fp)|*.fp"
-msgstr "Geda PCB Footprint-Bibliotheksdateien (*.fp)|*.fp"
-
-#: common/wildcards_and_files_ext.cpp:88
-msgid "Component-footprint link file (*.cmp)|*cmp"
-msgstr "Bauteil-Footprint-Zuordnungsdateien (*.cmp)|*.cmp"
-
-#: common/wildcards_and_files_ext.cpp:89
-msgid "Page layout design file (*.kicad_wks)|*kicad_wks"
-msgstr "Seitenlayoubeschreibungsdateien (*.kicad_wks)|*kicad_wks"
-
-#: common/wildcards_and_files_ext.cpp:91
+#: common/wildcards_and_files_ext.cpp:107
 msgid "All files (*)|*"
 msgstr "Alle Dateien (*)|*"
 
-#: common/wildcards_and_files_ext.cpp:94
-msgid "KiCad cmp/footprint link files (*.cmp)|*.cmp"
-msgstr "KiCad Bauteil/Footprint-Zuordnungsdatei (*.cmp)|*.cmp"
+#: common/wildcards_and_files_ext.cpp:112
+msgid "KiCad drawing symbol files (*.sym)|*."
+msgstr "KiCad Zeichensymboldateien (*.sym)|*.sym"
 
-#: common/wildcards_and_files_ext.cpp:97
-msgid "Drill files (*.drl)|*.drl;*.DRL"
-msgstr "Bohrdateien (*.drl)|*.drl;*.DRL"
+#: common/wildcards_and_files_ext.cpp:118
+msgid "KiCad symbol library files (*.lib)|*."
+msgstr "KiCad Bauteilbibliotheksdatei (*.lib)|*.lib"
 
-#: common/wildcards_and_files_ext.cpp:98
-msgid "SVG files (*.svg)|*.svg;*.SVG"
-msgstr "SVG Dateien (*.svg)|*.svg;*.SVG"
+#: common/wildcards_and_files_ext.cpp:124
+msgid "KiCad project files (*.pro)|*."
+msgstr "KiCad Projektdateien (*.pro)|*.pro"
 
-#: common/wildcards_and_files_ext.cpp:99
-msgid "HTML files (*.html)|*.htm;*.html"
-msgstr "HTML Dateien (*.html)|*.htm;*.html"
+#: common/wildcards_and_files_ext.cpp:130
+msgid "KiCad schematic files (*.sch)|*."
+msgstr "KiCad Schaltplandateien (*.sch)|*.sch"
 
-#: common/wildcards_and_files_ext.cpp:100
-msgid "CSV Files (*.csv)|*.csv"
-msgstr "Komma separierte Datei (*.csv)|*.csv"
+#: common/wildcards_and_files_ext.cpp:136
+msgid "Eagle XML schematic files (*.sch)|*."
+msgstr "Eagle XML Schaltplandatei (*.sch)|*.sch"
 
-#: common/wildcards_and_files_ext.cpp:101
-msgid "Portable document format files (*.pdf)|*.pdf"
-msgstr "Portables Dokumenten Format Dateien (*.pdf)|*.pdf"
+#: common/wildcards_and_files_ext.cpp:142
+msgid "Eagle XML files (*.sch *.brd)|*."
+msgstr "Eagle XML Dateien (*.sch *.brd)|*.sch;*.brd"
 
-#: common/wildcards_and_files_ext.cpp:102
-msgid "PostScript files (.ps)|*.ps"
-msgstr "PostScript Dateien (.ps)|*.ps"
+#: common/wildcards_and_files_ext.cpp:149
+msgid "KiCad netlist files (*.net)|*."
+msgstr "KiCad Netzlistedateien (*.net)|*.net"
 
-#: common/wildcards_and_files_ext.cpp:103
-msgid "Report files (*.rpt)|*.rpt"
-msgstr "Protokolldateien (*.rpt)|*.rpt"
+#: common/wildcards_and_files_ext.cpp:155
+msgid "Gerber files (*.pho)|*."
+msgstr "Gerber Dateien (*.pho)|*.pho"
 
-#: common/wildcards_and_files_ext.cpp:104
-msgid "Footprint place files (*.pos)|*.pos"
-msgstr "Footprint Platzierungsdateien (*.pos)|*.pos"
+#: common/wildcards_and_files_ext.cpp:161
+msgid "KiCad printed circuit board files (*.brd)|*."
+msgstr "KiCad Dateien gedruckter Schaltungen (*.brd)|*.brd"
 
-#: common/wildcards_and_files_ext.cpp:105
-msgid "Vrml and x3d files (*.wrl *.x3d)|*.wrl;*.x3d"
-msgstr "Vrml und x3d Dateien (*.wrl *.x3d)|*.wrl;*.x3d"
+#: common/wildcards_and_files_ext.cpp:167
+msgid "Eagle ver. 6.x XML PCB files (*.brd)|*."
+msgstr "Eagle Ver. 6.x XML PCB Dateien (*.brd)|*.brd"
 
-#: common/wildcards_and_files_ext.cpp:106
-msgid "IDFv3 component files (*.idf)|*.idf"
-msgstr "IDFv3 Bauteildateien (*.idf)|*.idf"
+#: common/wildcards_and_files_ext.cpp:173
+msgid "P-Cad 200x ASCII PCB files (*.pcb)|*."
+msgstr "P-Cad 200x ASCII PCB Dateien (*.pcb)|*.pcb"
 
-#: common/wildcards_and_files_ext.cpp:107
-msgid "Text files (*.txt)|*.txt"
-msgstr "Textdateien (*.txt)|*.txt"
+#: common/wildcards_and_files_ext.cpp:179
+msgid "KiCad printed circuit board files (*.kicad_pcb)|*."
+msgstr "KiCad Dateien gedruckter Schaltungen (*.kicad_pcb)|*.kicad_pcb"
+
+#: common/wildcards_and_files_ext.cpp:186
+msgid "KiCad footprint files (*.kicad_mod)|*."
+msgstr "KiCad Footprint Dateien"
+
+#: common/wildcards_and_files_ext.cpp:192
+msgid "KiCad footprint library paths (*.pretty)|*."
+msgstr "KiCad Footprintbibliotheks Verzeichnis (*.pretty)|*."
+
+#: common/wildcards_and_files_ext.cpp:198
+msgid "Legacy footprint library files (*.mod)|*."
+msgstr ""
+
+#: common/wildcards_and_files_ext.cpp:204
+msgid "Eagle ver. 6.x XML library files (*.lbr)|*."
+msgstr ""
+
+#: common/wildcards_and_files_ext.cpp:210
+msgid "Geda PCB footprint library files (*.fp)|*."
+msgstr ""
+
+#: common/wildcards_and_files_ext.cpp:216
+msgid "Page layout design files (*.kicad_wks)|*."
+msgstr ""
+
+#: common/wildcards_and_files_ext.cpp:223
+msgid "KiCad symbol footprint link files (*.cmp)|*."
+msgstr ""
+
+#: common/wildcards_and_files_ext.cpp:230
+msgid "Drill files (*.drl)|*."
+msgstr ""
+
+#: common/wildcards_and_files_ext.cpp:236
+msgid "SVG files (*.svg)|*."
+msgstr ""
+
+#: common/wildcards_and_files_ext.cpp:242
+msgid "HTML files (*.html)|*."
+msgstr ""
+
+#: common/wildcards_and_files_ext.cpp:249
+msgid "CSV Files (*.csv)|*."
+msgstr ""
+
+#: common/wildcards_and_files_ext.cpp:255
+msgid "Portable document format files (*.pdf)|*."
+msgstr ""
+
+#: common/wildcards_and_files_ext.cpp:261
+msgid "PostScript files (.ps)|*."
+msgstr ""
+
+#: common/wildcards_and_files_ext.cpp:267
+msgid "Report files (*.rpt)|*."
+msgstr ""
+
+#: common/wildcards_and_files_ext.cpp:273
+msgid "Footprint place files (*.pos)|*."
+msgstr ""
+
+#: common/wildcards_and_files_ext.cpp:279
+msgid "VRML and X3D files (*.wrl *.x3d)|*."
+msgstr ""
+
+#: common/wildcards_and_files_ext.cpp:286
+msgid "IDFv3 component files (*.idf)|*."
+msgstr ""
+
+#: common/wildcards_and_files_ext.cpp:292
+msgid "Text files (*.txt)|*."
+msgstr ""
+
+#: common/wildcards_and_files_ext.cpp:298
+msgid "Legacy footprint export files (*.emp)|*."
+msgstr ""
+
+#: common/wildcards_and_files_ext.cpp:304
+msgid "Electronic rule check file (.erc)|*."
+msgstr ""
+
+#: common/wildcards_and_files_ext.cpp:310
+msgid "Spice library file (*.lib)|*."
+msgstr ""
+
+#: common/wildcards_and_files_ext.cpp:316
+msgid "SPICE netlist file (.cir)|*."
+msgstr ""
+
+#: common/wildcards_and_files_ext.cpp:322
+msgid "CadStar netlist file (.frp)|*."
+msgstr ""
+
+#: common/wildcards_and_files_ext.cpp:328
+msgid "Symbol footprint association files (*.equ)|*."
+msgstr ""
+
+#: common/wildcards_and_files_ext.cpp:334
+msgid "Zip file (*.zip)|*."
+msgstr ""
+
+#: common/wildcards_and_files_ext.cpp:340
+msgid "GenCAD 1.4 board files (.cad)|*."
+msgstr ""
+
+#: common/wildcards_and_files_ext.cpp:346
+msgid "DXF Files (*.dxf)|*."
+msgstr ""
+
+#: common/wildcards_and_files_ext.cpp:352
+msgid "Gerber job file (*.gbrjob)|*."
+msgstr ""
+
+#: common/wildcards_and_files_ext.cpp:359
+msgid "Specctra DSN file (*.dsn)|*."
+msgstr ""
+
+#: common/wildcards_and_files_ext.cpp:365
+msgid "IPC-D-356 Test Files (.d356)|*."
+msgstr ""
+
+#: common/wildcards_and_files_ext.cpp:371
+msgid "Workbook file (*.wbk)|*."
+msgstr ""
+
+#: common/wildcards_and_files_ext.cpp:377
+msgid "PNG file (*.png)|*."
+msgstr ""
 
 #: common/wxwineda.cpp:61
 #, c-format
@@ -3433,19 +3438,19 @@ msgid "Pos "
 msgstr "Pos "
 
 #: common/wxwineda.cpp:170
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:87
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:781
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:803
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:905
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:89
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:783
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:805
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:907
 #: pcbnew/dialogs/dialog_target_properties_base.cpp:54
 msgid "X"
 msgstr "X"
 
 #: common/wxwineda.cpp:183
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:98
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:788
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:810
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:912
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:100
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:790
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:812
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:914
 msgid "Y"
 msgstr "Y"
 
@@ -3470,14 +3475,14 @@ msgstr "Rasterauswahl"
 
 #: cvpcb/autosel.cpp:107
 #, c-format
-msgid "Equivalence file '%s' could not be found in the default search paths."
+msgid "Equivalence file \"%s\" could not be found in the default search paths."
 msgstr ""
 "Äquivalenz Datei '%s' konnte nicht in den voreingestellten Suchpfaden "
 "gefunden werden."
 
 #: cvpcb/autosel.cpp:128
 #, c-format
-msgid "Error opening equivalence file '%s'."
+msgid "Error opening equivalence file \"%s\"."
 msgstr "Ein Fehler ist beim Öffnen der Äquivalenzdatei '%s' aufgetreten."
 
 #: cvpcb/autosel.cpp:179
@@ -3504,7 +3509,7 @@ msgstr "CvPcb Warnung"
 
 #: cvpcb/cfg.cpp:77
 #, c-format
-msgid "Project file '%s' is not writable"
+msgid "Project file \"%s\" is not writable"
 msgstr "Projektdatei '%s' ist nicht beschreibbar."
 
 #: cvpcb/class_DisplayFootprintsFrame.cpp:76
@@ -3516,20 +3521,20 @@ msgstr "Footprintbetrachter"
 msgid "Display polar coordinates"
 msgstr "Polarkoordinaten einblenden"
 
-#: cvpcb/class_DisplayFootprintsFrame.cpp:186 eeschema/tool_lib.cpp:236
+#: cvpcb/class_DisplayFootprintsFrame.cpp:186 eeschema/tool_lib.cpp:225
 #: gerbview/toolbars_gerber.cpp:239 pcbnew/tool_modedit.cpp:228
 #: pcbnew/tool_pcb.cpp:344
 msgid "Set units to inches"
 msgstr "Einheiten in Zoll"
 
-#: cvpcb/class_DisplayFootprintsFrame.cpp:190 eeschema/tool_lib.cpp:241
+#: cvpcb/class_DisplayFootprintsFrame.cpp:190 eeschema/tool_lib.cpp:230
 #: gerbview/toolbars_gerber.cpp:243 pcbnew/tool_modedit.cpp:232
 #: pcbnew/tool_pcb.cpp:347
 msgid "Set units to millimeters"
 msgstr "Einheiten in Millimeter"
 
-#: cvpcb/class_DisplayFootprintsFrame.cpp:195 eeschema/tool_lib.cpp:246
-#: eeschema/tool_sch.cpp:293 gerbview/toolbars_gerber.cpp:248
+#: cvpcb/class_DisplayFootprintsFrame.cpp:195 eeschema/tool_lib.cpp:235
+#: eeschema/tool_sch.cpp:287 gerbview/toolbars_gerber.cpp:248
 #: pcbnew/tool_pcb.cpp:352
 msgid "Change cursor shape"
 msgstr "Cursorform ändern"
@@ -3596,7 +3601,7 @@ msgstr "3D-Betrachter"
 
 #: cvpcb/class_DisplayFootprintsFrame.cpp:480
 #, c-format
-msgid "Footprint '%s' not found"
+msgid "Footprint \"%s\" not found"
 msgstr "Footprint '%s' nicht gefunden"
 
 #: cvpcb/class_DisplayFootprintsFrame.cpp:496
@@ -3609,16 +3614,7 @@ msgstr "Footprint: %s"
 msgid "Lib: %s"
 msgstr "Bibliothek: %s"
 
-#: cvpcb/common_help_msg.h:28 cvpcb/menubar.cpp:66
-msgid "Save footprint association in schematic component footprint fields"
-msgstr ""
-"Speichere Footprints Assoziierung in den Schaltplan Bauteil Footprintfeldern."
-
-#: cvpcb/cvpcb.cpp:51
-msgid "Component/footprint equ files (*.equ)|*.equ"
-msgstr "Bauteil-/Footprintaliasdateien (*.equ)|*.equ"
-
-#: cvpcb/cvpcb.cpp:163
+#: cvpcb/cvpcb.cpp:161
 msgid ""
 "You have run CvPcb for the first time using the new footprint library table "
 "method for finding footprints.  CvPcb has either copied the default table or "
@@ -3635,7 +3631,7 @@ msgstr ""
 "auch den Abschnitt \"Footprint-Bibliothekstabelle\" der CvPcb-Dokumentation "
 "für mehr Informationen."
 
-#: cvpcb/cvpcb.cpp:178
+#: cvpcb/cvpcb.cpp:176
 msgid "An error occurred attempting to load the global footprint library table"
 msgstr ""
 "Bei dem Versuch die globale Tabelle mit den Bibliotheken der Footprints zu "
@@ -3657,7 +3653,7 @@ msgstr "Auswahl löschen"
 #, c-format
 msgid ""
 "Error occurred saving the global footprint library table:\n"
-"'%s'\n"
+"\"%s\"\n"
 "%s"
 msgstr ""
 "Bei dem Versuch die globale Bibliothekstabelle für Footprints zu speichern "
@@ -3666,7 +3662,7 @@ msgstr ""
 "%s"
 
 #: cvpcb/cvpcb_mainframe.cpp:431 cvpcb/cvpcb_mainframe.cpp:451
-#: eeschema/sch_base_frame.cpp:282 eeschema/sch_base_frame.cpp:298
+#: eeschema/sch_base_frame.cpp:328 eeschema/sch_base_frame.cpp:346
 #: pcbnew/moduleframe.cpp:918 pcbnew/moduleframe.cpp:938
 #: pcbnew/pcbnew_config.cpp:142 pcbnew/pcbnew_config.cpp:164
 msgid "File Save Error"
@@ -3676,7 +3672,7 @@ msgstr "Fehler beim Dateischreibvorgang"
 #, c-format
 msgid ""
 "Error occurred saving the project footprint library table:\n"
-"'%s'\n"
+"\"%s\"\n"
 "%s"
 msgstr ""
 "Bei dem Versuch die Projektbibliothek für Footprints zu speichern ist ein "
@@ -3737,8 +3733,8 @@ msgstr ""
 msgid "Configuration Error"
 msgstr "Konfigurationsfehler"
 
-#: cvpcb/cvpcb_mainframe.cpp:756 eeschema/schframe.cpp:1466
-#: kicad/prjconfig.cpp:87 pcbnew/moduleframe.cpp:824 pcbnew/pcbframe.cpp:1042
+#: cvpcb/cvpcb_mainframe.cpp:756 eeschema/schframe.cpp:1486
+#: kicad/prjconfig.cpp:87 pcbnew/moduleframe.cpp:824 pcbnew/pcbframe.cpp:1035
 msgid " [Read Only]"
 msgstr " [Nur lesbar]"
 
@@ -3758,7 +3754,7 @@ msgstr "Fehler beim Laden der Netzliste"
 
 #: cvpcb/dialogs/dialog_config_equfiles.cpp:52
 #, c-format
-msgid "Project file: '%s'"
+msgid "Project file: \"%s\""
 msgstr "Projektdatei: '%s'"
 
 #: cvpcb/dialogs/dialog_config_equfiles.cpp:99
@@ -3766,40 +3762,36 @@ msgid "No editor defined in Kicad. Please choose it."
 msgstr ""
 "Es wurde kein Texteditor für KiCad ausgewählt. Bitte wählen Sie einen aus."
 
-#: cvpcb/dialogs/dialog_config_equfiles.cpp:253
-msgid "Equ files:"
-msgstr "Footprint Alias-Bibliotheksdatein:"
+#: cvpcb/dialogs/dialog_config_equfiles.cpp:248
+msgid "Footprint Association File"
+msgstr "Footprints Assoziierungsdatei"
 
-#: cvpcb/dialogs/dialog_config_equfiles.cpp:298
+#: cvpcb/dialogs/dialog_config_equfiles.cpp:293
 #, c-format
-msgid "File '%s' already exists in list"
+msgid "File \"%s\" already exists in list"
 msgstr "Datei '%s' existiert bereits in der Liste"
 
 #: cvpcb/dialogs/dialog_config_equfiles_base.cpp:20
 msgid "Footprint/Component equ files (.equ files)"
 msgstr "Footprint Alias-Bibliotheksdatei Dateien (.equ)"
 
-#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:40
-msgid "Unload the selected library"
-msgstr "Die gewählte Bibliothek entladen"
-
-#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:50
+#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:48
 msgid "Edit Equ File"
 msgstr "Footprint Alias-Bibliotheksdatei editieren"
 
-#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:65
+#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:63
 msgid "Available environment variables for relative paths:"
 msgstr "Zur Verfügung stehende Umgebungsvariablen für relative Pfade:"
 
-#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:101
+#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:99
 msgid "Absolute path"
 msgstr "Absoluter Pfad"
 
-#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:101
+#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:99
 msgid "Relative path"
 msgstr "Relativer Pfad"
 
-#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:103
+#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:101
 msgid "Path option:"
 msgstr "Pfad Optionen:"
 
@@ -3840,12 +3832,6 @@ msgstr "Cursor beim Zoomen nicht zentrieren und umpositionieren"
 msgid "Keep the cursor at its current location when zooming"
 msgstr "Halte beim Zoomen den Cursor an seiner aktuellen Position"
 
-#: cvpcb/dialogs/dialog_display_options_base.h:60
-#: pcbnew/dialogs/dialog_display_options_base.h:64
-#: pcbnew/dialogs/dialog_modedit_display_options.cpp:45
-msgid "Display Options"
-msgstr "Anzeigeoptionen"
-
 #: cvpcb/dialogs/fp_conflict_assignment_selector.cpp:37
 msgid "Ref"
 msgstr "Ref"
@@ -3861,6 +3847,11 @@ msgstr "Bauteildatei Zuordnung"
 #: cvpcb/menubar.cpp:65
 msgid "&Save Footprint Associations\tCtrl+S"
 msgstr "&Speichere Footprints Assoziierungen\tStrg+S"
+
+#: cvpcb/menubar.cpp:66 cvpcb/common_help_msg.h:28
+msgid "Save footprint association in schematic component footprint fields"
+msgstr ""
+"Speichere Footprints Assoziierung in den Schaltplan Bauteil Footprintfeldern."
 
 #: cvpcb/menubar.cpp:74 eeschema/menubar.cpp:409 gerbview/menubar.cpp:179
 #: kicad/menubar.cpp:306 pagelayout_editor/menubar.cpp:113
@@ -3917,15 +3908,15 @@ msgstr "&CvPcb-Benutzerhandbuch"
 msgid "Open CvPcb Manual"
 msgstr "CvPcb-Benutzerhandbuch öffnen"
 
-#: cvpcb/menubar.cpp:121 eeschema/menubar.cpp:567
-#: eeschema/menubar_libedit.cpp:267 eeschema/tool_viewlib.cpp:223
+#: cvpcb/menubar.cpp:121 eeschema/menubar.cpp:574
+#: eeschema/menubar_libedit.cpp:326 eeschema/tool_viewlib.cpp:223
 #: kicad/menubar.cpp:449 pagelayout_editor/menubar.cpp:216
 #: pcbnew/menubar_modedit.cpp:365 pcbnew/menubar_pcbframe.cpp:437
 #: pcbnew/tool_modview.cpp:191
 msgid "&Getting Started in KiCad"
 msgstr "&Erste Schritte mit KiCad"
 
-#: cvpcb/menubar.cpp:122 eeschema/menubar.cpp:568 kicad/menubar.cpp:450
+#: cvpcb/menubar.cpp:122 eeschema/menubar.cpp:575 kicad/menubar.cpp:450
 #: pagelayout_editor/menubar.cpp:217 pcbnew/menubar_pcbframe.cpp:438
 msgid "Open \"Getting Started in KiCad\" guide for beginners"
 msgstr "Das Handbuch für Anfänger \"Erste Schritte mit KiCad\" öffnen"
@@ -3935,8 +3926,8 @@ msgstr "Das Handbuch für Anfänger \"Erste Schritte mit KiCad\" öffnen"
 msgid "&About Kicad"
 msgstr "&Über KiCad"
 
-#: cvpcb/menubar.cpp:128 eeschema/menubar.cpp:587
-#: eeschema/menubar_libedit.cpp:289 gerbview/menubar.cpp:297
+#: cvpcb/menubar.cpp:128 eeschema/menubar.cpp:594
+#: eeschema/menubar_libedit.cpp:348 gerbview/menubar.cpp:297
 #: kicad/menubar.cpp:473 pagelayout_editor/menubar.cpp:238
 #: pcbnew/menubar_modedit.cpp:385
 msgid "About KiCad"
@@ -3962,17 +3953,19 @@ msgstr ""
 
 #: cvpcb/readwrite_dlgs.cpp:249
 #, c-format
-msgid "Component '%s' footprint '%s' was <b>not found</b> in any library.\n"
+msgid ""
+"Component \"%s\" footprint \"%s\" was <b>not found</b> in any library.\n"
 msgstr ""
 "Das Bauteil '%s' mit dem Footprint '%s' konnte in <b>keiner</b> der "
 "Bibliotheken gefunden werden.\n"
 
 #: cvpcb/readwrite_dlgs.cpp:257
 #, c-format
-msgid "Component '%s' footprint '%s' was found in <b>multiple</b> libraries.\n"
+msgid ""
+"Component \"%s\" footprint \"%s\" was found in <b>multiple</b> libraries.\n"
 msgstr ""
 "Das Bauteil '%s' mit dem Footprint '%s' wurde in <b>mehreren</b> "
-"Bibliotheken gefunden werden.\n"
+"Bibliotheken gefunden.\n"
 
 #: cvpcb/readwrite_dlgs.cpp:270
 msgid "First check your footprint library table entries."
@@ -4051,7 +4044,7 @@ msgid "%d duplicate time stamps were found and replaced."
 msgstr "%d mehrfach vorkommende(r) Zeitstempel wurde(n) gefunden und ersetzt."
 
 #: eeschema/backanno.cpp:221
-msgid "Load Component Footprint Link File"
+msgid "Load Symbol Footprint Link File"
 msgstr "Laden einer Bauteil-Footprint-Zuordnungsdatei"
 
 #: eeschema/backanno.cpp:232
@@ -4076,51 +4069,20 @@ msgstr "Sichtbarkeit umstellen"
 
 #: eeschema/backanno.cpp:248
 #, c-format
-msgid "Failed to open component-footprint link file '%s'"
+msgid "Failed to open component-footprint link file \"%s\""
 msgstr "Konnte Bauteil-Footprint Zuordnungsdatei '%s' nicht öffnen."
 
-#: eeschema/block.cpp:473
+#: eeschema/block.cpp:465
 msgid "No item to paste."
 msgstr "Kein Element zum einfügen."
 
-#: eeschema/block.cpp:503 eeschema/sheet.cpp:248
+#: eeschema/block.cpp:495 eeschema/files-io.cpp:478 eeschema/sheet.cpp:291
 #, c-format
 msgid ""
 "The sheet changes cannot be made because the destination sheet already has "
-"the sheet <%s> or one of it's subsheets as a parent somewhere in the "
+"the sheet \"%s\" or one of it's subsheets as a parent somewhere in the "
 "schematic hierarchy."
 msgstr ""
-"Die Änderungen des Zeichnungsblatts können nicht durchgeführt werden, da das "
-"Ziel bereits das Blatt <%s> hat oder irgendwo eines der Unterblätter in der "
-"Obergruppe ist in der Schaltplanhierarchie."
-
-#: eeschema/bom_table_column.h:33 eeschema/dialogs/dialog_rescue_each.cpp:110
-#: eeschema/lib_field.cpp:613 eeschema/sch_component.cpp:1767
-#: eeschema/sch_component.cpp:1807 eeschema/template_fieldnames.cpp:39
-#: eeschema/widgets/widget_eeschema_color_config.cpp:76
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:26
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:40
-#: pcbnew/dialogs/dialog_netlist_fbp.cpp:33
-#: pcbnew/dialogs/dialog_update_pcb_base.cpp:30
-msgid "Reference"
-msgstr "Referenz"
-
-#: eeschema/bom_table_column.h:35 eeschema/lib_field.cpp:627
-#: eeschema/sch_component.cpp:1796 eeschema/template_fieldnames.cpp:45
-#: pcbnew/class_edge_mod.cpp:248 pcbnew/class_module.cpp:587
-#: pcbnew/class_pad.cpp:693 pcbnew/class_text_mod.cpp:358
-#: pcbnew/loadcmp.cpp:445 pcbnew/loadcmp.cpp:509
-msgid "Footprint"
-msgstr "Footprint"
-
-#: eeschema/bom_table_column.h:37 eeschema/lib_field.cpp:634
-#: eeschema/libedit.cpp:494 eeschema/template_fieldnames.cpp:48
-msgid "Datasheet"
-msgstr "Datenblatt"
-
-#: eeschema/bom_table_column.h:38 pcbnew/build_BOM_from_board.cpp:119
-msgid "Quantity"
-msgstr "Stückzahl"
 
 #: eeschema/class_drc_erc_item.cpp:40
 msgid "ERC err unspecified"
@@ -4172,11 +4134,11 @@ msgid "Global labels are similar (lower/upper case difference only)"
 msgstr ""
 "Globale Bezeichner sind gleich (Unterschiede nur in Groß-/Kleinschreibung)"
 
-#: eeschema/class_libentry.cpp:107 eeschema/class_libentry.cpp:270
+#: eeschema/class_libentry.cpp:107 eeschema/class_libentry.cpp:232
 msgid "none"
 msgstr "keine"
 
-#: eeschema/class_libentry.cpp:551
+#: eeschema/class_libentry.cpp:521
 #, c-format
 msgid ""
 "An attempt was made to remove the %s field from component %s in library %s."
@@ -4186,47 +4148,40 @@ msgstr ""
 #: eeschema/class_library.cpp:54
 #, c-format
 msgid ""
-"Library '%s' has duplicate entry name '%s'.\n"
+"Library \"%s\" has duplicate entry name \"%s\".\n"
 "This may cause some unexpected behavior when loading components into a "
 "schematic."
 msgstr ""
-"Die Bauteilbibliothek '%s' hat einen doppelten Eintrag '%s'.\n"
-"Dies kann zu unerwartetem Verhalten führen, wenn Bauteile für den Schaltplan "
-"geladen werden."
 
-#: eeschema/class_library.cpp:525
+#: eeschema/class_library.cpp:537
 #, c-format
-msgid "Unable to load project's '%s' file"
-msgstr "Konnte Projektdatei '%s' nicht laden"
+msgid "Unable to load project's \"%s\" file"
+msgstr ""
 
-#: eeschema/class_library.cpp:580
+#: eeschema/class_library.cpp:592
 msgid "Loading Symbol Libraries"
 msgstr "Symbolbibliotheken laden"
 
-#: eeschema/class_library.cpp:597
+#: eeschema/class_library.cpp:609
 msgid "Loading "
 msgstr "Lade"
 
-#: eeschema/class_library.cpp:640
+#: eeschema/class_library.cpp:652
 #, c-format
 msgid ""
-"Part library '%s' failed to load. Error:\n"
+"Part library \"%s\" failed to load. Error:\n"
 " %s"
 msgstr ""
-"Bauteilbibliothek '%s' wurde nicht geladen. Fehler:\n"
-"%s"
 
-#: eeschema/class_library.cpp:664
+#: eeschema/class_library.cpp:676
 #, c-format
 msgid ""
-"Part library '%s' failed to load.\n"
+"Part library \"%s\" failed to load.\n"
 "Error: %s"
 msgstr ""
-"Bauteilbibliothek '%s' wurde nicht geladen.\n"
-"Fehler: %s"
 
 #: eeschema/cmp_tree_model.cpp:122 eeschema/lib_draw_item.cpp:72
-#: eeschema/libedit.cpp:477 eeschema/onrightclick.cpp:481
+#: eeschema/libedit.cpp:649 eeschema/onrightclick.cpp:481
 #: pcbnew/dialogs/dialog_graphic_item_properties_base.cpp:37
 #: pcbnew/dialogs/dialog_graphic_item_properties_base.cpp:48
 #: pcbnew/dialogs/dialog_graphic_item_properties_base.cpp:59
@@ -4247,7 +4202,7 @@ msgstr ""
 msgid "Unit"
 msgstr "Komponente"
 
-#: eeschema/cmp_tree_model_adapter.cpp:127
+#: eeschema/cmp_tree_model_adapter.cpp:58
 #, c-format
 msgid ""
 "Error occurred loading symbol  library %s.\n"
@@ -4259,10 +4214,10 @@ msgstr ""
 "\n"
 "%s"
 
-#: eeschema/cmp_tree_model_adapter.cpp:154
+#: eeschema/cmp_tree_model_adapter.cpp:87
 #: eeschema/dialogs/dialog_choose_component.cpp:204
 #: eeschema/dialogs/dialog_choose_component.cpp:264
-#: eeschema/dialogs/dialog_choose_component.cpp:310
+#: eeschema/dialogs/dialog_choose_component.cpp:314
 #: eeschema/generate_alias_info.cpp:81
 #, c-format
 msgid ""
@@ -4275,12 +4230,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: eeschema/cmp_tree_model_adapter.cpp:213 eeschema/libedit.cpp:489
+#: eeschema/cmp_tree_model_adapter_base.cpp:113 eeschema/libeditframe.cpp:1621
+msgid "Loading symbol libraries"
+msgstr ""
+
+#: eeschema/cmp_tree_model_adapter_base.cpp:122 eeschema/libeditframe.cpp:1625
+#, c-format
+msgid "Loading library \"%s\""
+msgstr ""
+
+#: eeschema/cmp_tree_model_adapter_base.cpp:182 eeschema/libedit.cpp:661
 #: eeschema/viewlibs.cpp:239
 msgid "Part"
 msgstr "Bauteil"
 
-#: eeschema/cmp_tree_model_adapter.cpp:214
+#: eeschema/cmp_tree_model_adapter_base.cpp:183
 msgid "Desc"
 msgstr "Beschreibung"
 
@@ -4321,8 +4285,9 @@ msgstr "Unterschiedliche Werte für %s%d%s (%s) und %s%d%s (%s)"
 msgid "Duplicate time stamp (%s) for %s%d and %s%d"
 msgstr "Doppelter Zeitstempel (%s) für %s%d und %s%d"
 
-#: eeschema/controle.cpp:177 eeschema/libeditframe.cpp:1313
+#: eeschema/controle.cpp:177 eeschema/libeditframe.cpp:1355
 #: pcbnew/controle.cpp:231 pcbnew/modedit.cpp:133
+#: pcbnew/tools/selection_tool.cpp:1333
 msgid "Clarify Selection"
 msgstr "Auswahl klarstellen"
 
@@ -4454,14 +4419,10 @@ msgstr "Lösche Annotationen"
 msgid "Annotate"
 msgstr "Annotation"
 
-#: eeschema/dialogs/dialog_annotate_base.h:89
-msgid "Annotate Schematic"
-msgstr "Annotation des Schaltplans"
-
 #: eeschema/dialogs/dialog_bom.cpp:356
 #, c-format
-msgid "Failed to open file '%s'"
-msgstr "Konnte Datei '%s' nicht öffnen"
+msgid "Failed to open file \"%s\""
+msgstr ""
 
 #: eeschema/dialogs/dialog_bom.cpp:489
 msgid "Plugin name in plugin list"
@@ -4538,45 +4499,41 @@ msgstr ""
 msgid "Plugin Info:"
 msgstr "Plugin Info:"
 
-#: eeschema/dialogs/dialog_bom_base.h:97
-msgid "Bill of Material"
-msgstr "Stückliste (BOM)"
-
-#: eeschema/dialogs/dialog_bom_editor.cpp:60 eeschema/lib_field.cpp:87
-#: eeschema/lib_field.cpp:796 eeschema/template_fieldnames.cpp:55
+#: eeschema/dialogs/dialog_bom_editor.cpp:57 eeschema/lib_field.cpp:87
+#: eeschema/lib_field.cpp:625 eeschema/template_fieldnames.cpp:55
 msgid "Field"
 msgstr "Feld"
 
-#: eeschema/dialogs/dialog_bom_editor.cpp:63
+#: eeschema/dialogs/dialog_bom_editor.cpp:60
 #: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:190
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:94
 msgid "Show"
 msgstr "sichtbar"
 
-#: eeschema/dialogs/dialog_bom_editor.cpp:68
+#: eeschema/dialogs/dialog_bom_editor.cpp:65
 msgid "Sort"
 msgstr "Sortieren"
 
-#: eeschema/dialogs/dialog_bom_editor.cpp:142
+#: eeschema/dialogs/dialog_bom_editor.cpp:126
 msgid "Changes exist in component table"
 msgstr "Änderungen die in der Bauteiltabelle existieren"
 
-#: eeschema/dialogs/dialog_bom_editor.cpp:278
+#: eeschema/dialogs/dialog_bom_editor.cpp:262
 #, c-format
 msgid "Component table - %u components in %u groups"
 msgstr "Tabelle der Bauteile - %u Bauteile in %u Gruppen"
 
-#: eeschema/dialogs/dialog_bom_editor.cpp:283
+#: eeschema/dialogs/dialog_bom_editor.cpp:267
 #, c-format
 msgid "Component table - %u components"
 msgstr "Tabelle der Bauteile - %u Bauteile"
 
-#: eeschema/dialogs/dialog_bom_editor.cpp:289
+#: eeschema/dialogs/dialog_bom_editor.cpp:273
 #, c-format
 msgid " - %u changed"
 msgstr " - %u geändert"
 
-#: eeschema/dialogs/dialog_bom_editor.cpp:445
+#: eeschema/dialogs/dialog_bom_editor.cpp:429
 msgid "Revert all component table changes?"
 msgstr "Möchten Sie alle Bauteiländerungen zurücknehmen?"
 
@@ -4594,7 +4551,7 @@ msgstr "Bauteile neu gruppieren"
 
 #: eeschema/dialogs/dialog_bom_editor_base.cpp:53
 #: eeschema/widgets/widget_eeschema_color_config.cpp:78
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:24
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:26
 msgid "Fields"
 msgstr "Felder"
 
@@ -4606,10 +4563,6 @@ msgstr "Änderungen anwenden"
 msgid "Revert Changes"
 msgstr "Änderung zurücknehmen"
 
-#: eeschema/dialogs/dialog_bom_editor_base.h:74
-msgid "BOM editor"
-msgstr "BOM Editor"
-
 #: eeschema/dialogs/dialog_choose_component.cpp:227
 msgid "No footprint specified"
 msgstr "Kein Footprint angegeben"
@@ -4617,6 +4570,12 @@ msgstr "Kein Footprint angegeben"
 #: eeschema/dialogs/dialog_choose_component.cpp:241
 msgid "Invalid footprint specified"
 msgstr "Kein gültiger Footprint angegeben"
+
+#: eeschema/dialogs/dialog_choose_component.cpp:423
+msgid ""
+"Double click here to select a symbol\n"
+"from the library browser"
+msgstr ""
 
 #: eeschema/dialogs/dialog_edit_component_in_lib.cpp:73
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.h:115
@@ -4641,8 +4600,8 @@ msgstr "Anzahl der Einheiten (max. %d erlaubt)"
 #: eeschema/dialogs/dialog_edit_component_in_lib.cpp:300
 #: eeschema/dialogs/dialog_edit_component_in_lib.cpp:375
 #, c-format
-msgid "Alias <%s> cannot be removed while it is being edited!"
-msgstr "Alias <%s> kann nicht während der Bearbeitung entfernt werden!"
+msgid "Alias \"%s\" cannot be removed while it is being edited!"
+msgstr ""
 
 #: eeschema/dialogs/dialog_edit_component_in_lib.cpp:306
 msgid "Remove all aliases from list?"
@@ -4658,13 +4617,13 @@ msgstr "Symbol Alias:"
 
 #: eeschema/dialogs/dialog_edit_component_in_lib.cpp:342
 #, c-format
-msgid "Alias or component name <%s> already in use."
-msgstr "Alias oder Bauteilname <%s> wird bereits verwendet."
+msgid "Alias or component name \"%s\" already in use."
+msgstr ""
 
 #: eeschema/dialogs/dialog_edit_component_in_lib.cpp:351
 #, c-format
-msgid "Symbol name '%s' already exists in library '%s'."
-msgstr "Symbolname '%s' existiert bereits in der Bibliothek '%s'."
+msgid "Symbol name \"%s\" already exists in library \"%s\"."
+msgstr ""
 
 #: eeschema/dialogs/dialog_edit_component_in_lib.cpp:406
 msgid "Delete extra parts from component?"
@@ -4696,17 +4655,18 @@ msgstr "Footprint-Filter"
 
 #: eeschema/dialogs/dialog_edit_component_in_lib.cpp:530
 #, c-format
-msgid "Foot print filter <%s> is already defined."
-msgstr "Footprintfilter <%s> ist bereits definiert."
+msgid "Foot print filter \"%s\" is already defined."
+msgstr ""
 
 #: eeschema/dialogs/dialog_edit_component_in_lib.cpp:566
 msgid "Edit footprint filter"
 msgstr "Footprintdatei bearbeiten"
 
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:28
+#: eeschema/dialogs/dialog_edit_line_style_base.cpp:28
 #: eeschema/dialogs/dialog_lib_edit_draw_item_base.cpp:22
 #: eeschema/widgets/widget_eeschema_color_config.cpp:101
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:414
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:416
 msgid "General"
 msgstr "Generell"
 
@@ -4805,7 +4765,7 @@ msgstr ""
 "werden."
 
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:127
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:33
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:35
 msgid "Keywords"
 msgstr "Schlüsselwörter"
 
@@ -4867,7 +4827,7 @@ msgstr ""
 #: pcbnew/dialogs/dialog_netlist_fbp.cpp:55
 #: pcbnew/dialogs/dialog_netlist_fbp.cpp:63
 #: pcbnew/dialogs/dialog_netlist_fbp.cpp:71
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1070
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1072
 #: pcbnew/modedit_onclick.cpp:389 pcbnew/modedit_onclick.cpp:426
 #: pcbnew/onrightclick.cpp:221 pcbnew/onrightclick.cpp:286
 #: pcbnew/onrightclick.cpp:316 pcbnew/onrightclick.cpp:495
@@ -4901,28 +4861,28 @@ msgstr ""
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:258
 #, c-format
-msgid "'%s' is not a valid library symbol indentifier."
-msgstr "'%s' ist keine gültige Bezeichnung für eine Symbolbibliothekskennung."
+msgid "\"%s\" is not a valid library symbol indentifier."
+msgstr ""
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:275
 #, c-format
-msgid "Symbol '%s' not found in library '%s'"
-msgstr "Symbol '%s' konnte nicht in der Bibliothek '%s' gefunden werden."
+msgid "Symbol \"%s\" not found in library \"%s\""
+msgstr ""
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:281
 #, c-format
-msgid "Symbol '%s' found in library '%s'"
-msgstr "Symbol '%s' in der Bibliothek '%s' gefunden"
+msgid "Symbol \"%s\" found in library \"%s\""
+msgstr ""
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:355
 #, c-format
-msgid "Symbol library identifier '%s' is not valid!"
-msgstr "Die Symbolbibliothekskennung '%s' ist keine gültige Bezeichnung!"
+msgid "Symbol library identifier \"%s\" is not valid!"
+msgstr ""
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:372
 #, c-format
-msgid "Symbol '%s' not found in library '%s'!"
-msgstr "Das Symbol '%s' konnte nicht in der Bibliothek '%s' gefunden werden."
+msgid "Symbol \"%s\" not found in library \"%s\"!"
+msgstr ""
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:447
 msgid "Illegal reference. A reference must start with a letter"
@@ -4932,15 +4892,10 @@ msgstr ""
 #: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:473
 #, c-format
 msgid ""
-"The field name <%s> does not have a value and is not defined in the field "
+"The field name \"%s\" does not have a value and is not defined in the field "
 "template list.  Empty field values are invalid an will be removed from the "
 "component.  Do you wish to remove this and all remaining undefined fields?"
 msgstr ""
-"Der Feldname <%s> besitzt keinen Wert und ist nicht in der Feldvorlage "
-"definiert. Leere Felder sind nicht zulässig und werden vom Bauteil "
-"entfernt.\n"
-"Möchten Sie diese Felder und alle verbliebenen undefinierten Felder "
-"entfernen?"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:480
 msgid "Remove Fields"
@@ -4980,16 +4935,16 @@ msgstr "Nur in den Feldern Footprint und Datenblatt benutzt."
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:1108
 #: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:41
-#: eeschema/lib_pin.cpp:2047 gerbview/class_gerber_draw_item.cpp:639
-#: gerbview/class_gerber_draw_item.cpp:640 pcbnew/class_pcb_text.cpp:140
-#: pcbnew/class_text_mod.cpp:369
+#: eeschema/lib_pin.cpp:1716 gerbview/class_gerber_draw_item.cpp:709
+#: gerbview/class_gerber_draw_item.cpp:710 pcbnew/class_pcb_text.cpp:140
+#: pcbnew/class_text_mod.cpp:377
 msgid "Yes"
 msgstr "Ja"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:1110
-#: eeschema/lib_pin.cpp:2049 gerbview/class_gerber_draw_item.cpp:639
-#: gerbview/class_gerber_draw_item.cpp:640 pcbnew/class_pcb_text.cpp:138
-#: pcbnew/class_text_mod.cpp:367
+#: eeschema/lib_pin.cpp:1718 gerbview/class_gerber_draw_item.cpp:709
+#: gerbview/class_gerber_draw_item.cpp:710 pcbnew/class_pcb_text.cpp:138
+#: pcbnew/class_text_mod.cpp:375
 msgid "No"
 msgstr "Nein"
 
@@ -5002,31 +4957,31 @@ msgid "Interchangeable Unit:"
 msgstr "Austauschbare Einheiten:"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:48
-#: pcbnew/dialogs/dialog_create_array_base.cpp:69
-#: pcbnew/dialogs/dialog_create_array_base.cpp:80
-#: pcbnew/dialogs/dialog_create_array_base.cpp:185
-#: pcbnew/dialogs/dialog_create_array_base.cpp:196
-#: pcbnew/dialogs/dialog_create_array_base.cpp:215
+#: pcbnew/dialogs/dialog_create_array_base.cpp:71
+#: pcbnew/dialogs/dialog_create_array_base.cpp:82
+#: pcbnew/dialogs/dialog_create_array_base.cpp:187
+#: pcbnew/dialogs/dialog_create_array_base.cpp:198
+#: pcbnew/dialogs/dialog_create_array_base.cpp:217
 #: pcbnew/dialogs/dialog_drc_base.cpp:219
 #: pcbnew/dialogs/dialog_drc_base.cpp:230
-#: pcbnew/dialogs/dialog_export_idf_base.cpp:62
-#: pcbnew/dialogs/dialog_export_idf_base.cpp:83
-#: pcbnew/dialogs/dialog_export_step_base.cpp:118
-#: pcbnew/dialogs/dialog_export_step_base.cpp:136
+#: pcbnew/dialogs/dialog_export_idf_base.cpp:64
+#: pcbnew/dialogs/dialog_export_idf_base.cpp:85
+#: pcbnew/dialogs/dialog_export_step_base.cpp:120
+#: pcbnew/dialogs/dialog_export_step_base.cpp:138
 #: pcbnew/dialogs/dialog_export_vrml_base.cpp:73
 #: pcbnew/dialogs/dialog_export_vrml_base.cpp:88
-#: pcbnew/dialogs/dialog_move_exact_base.cpp:34
-#: pcbnew/dialogs/dialog_move_exact_base.cpp:48
-#: pcbnew/dialogs/dialog_move_exact_base.cpp:62
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:129
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:389
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:909
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:916
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:930
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1098
-#: pcbnew/dialogs/dialog_position_relative_base.cpp:32
-#: pcbnew/dialogs/dialog_position_relative_base.cpp:46
-#: pcbnew/dialogs/dialog_position_relative_base.cpp:60
+#: pcbnew/dialogs/dialog_move_exact_base.cpp:36
+#: pcbnew/dialogs/dialog_move_exact_base.cpp:50
+#: pcbnew/dialogs/dialog_move_exact_base.cpp:64
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:131
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:391
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:911
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:918
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:932
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1100
+#: pcbnew/dialogs/dialog_position_relative_base.cpp:34
+#: pcbnew/dialogs/dialog_position_relative_base.cpp:48
+#: pcbnew/dialogs/dialog_position_relative_base.cpp:62
 msgid "0"
 msgstr "0"
 
@@ -5039,7 +4994,7 @@ msgid "+180"
 msgstr "+180"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:48
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:129
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:131
 msgid "-90"
 msgstr "-90"
 
@@ -5158,10 +5113,19 @@ msgid "Create new custom field"
 msgstr "Ein neues optionales Feld hinzufügen"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:169
+#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:101
 msgid "Align Left"
 msgstr "Links ausrichten"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:169
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:175
+#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:101
+#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:107
+msgid "Align Center"
+msgstr ""
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:169
+#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:101
 msgid "Align Right"
 msgstr "Rechts ausrichten"
 
@@ -5170,10 +5134,12 @@ msgid "Horizontal Position:"
 msgstr "Position horizontal:"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:175
+#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:107
 msgid "Align Top"
 msgstr "Oben ausrichten"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:175
+#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:107
 msgid "Align Bottom"
 msgstr "Unten ausrichten"
 
@@ -5196,7 +5162,7 @@ msgstr "Rotation des gewählten Feldes um 90 Grad"
 #: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:203
 #: eeschema/dialogs/dialog_edit_label_base.cpp:76
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:107
-#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:95 eeschema/sch_text.cpp:781
+#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:95 eeschema/sch_text.cpp:663
 msgid "Bold Italic"
 msgstr "Fett Kursiv"
 
@@ -5246,41 +5212,42 @@ msgstr "Die Textgröße des aktuell ausgewählten Feldes"
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:160
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:171
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:184
+#: eeschema/dialogs/dialog_edit_line_style_base.cpp:45
 #: pcbnew/dialogs/dialog_drc_base.cpp:69 pcbnew/dialogs/dialog_drc_base.cpp:84
 #: pcbnew/dialogs/dialog_drc_base.cpp:99
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:94
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:105
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:228
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:250
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:263
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:96
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:107
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:230
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:252
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:265
 #: pcbnew/dialogs/dialog_global_modules_fields_edition_base.cpp:71
 #: pcbnew/dialogs/dialog_global_modules_fields_edition_base.cpp:82
 #: pcbnew/dialogs/dialog_global_modules_fields_edition_base.cpp:93
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:41
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:52
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:63
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:74
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:251
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:795
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:817
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:857
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:919
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1101
-#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:74
-#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:103
-#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:114
-#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:125
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:43
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:54
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:65
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:76
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:253
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:797
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:819
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:859
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:921
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1103
+#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:76
+#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:105
+#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:116
+#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:127
 #: pcbnew/dialogs/dialog_target_properties_base.cpp:35
 #: pcbnew/dialogs/dialog_target_properties_base.cpp:46
-#: pcbnew/dialogs/dialog_track_via_size_base.cpp:32
-#: pcbnew/dialogs/dialog_track_via_size_base.cpp:43
-#: pcbnew/dialogs/dialog_track_via_size_base.cpp:54
+#: pcbnew/dialogs/dialog_track_via_size_base.cpp:34
+#: pcbnew/dialogs/dialog_track_via_size_base.cpp:45
+#: pcbnew/dialogs/dialog_track_via_size_base.cpp:56
 msgid "unit"
 msgstr "Einheit"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:260
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:81
-#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:50
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:83
+#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:51
 #: pcbnew/dialogs/dialog_track_via_properties_base.cpp:161
 msgid "Position X:"
 msgstr "Position X:"
@@ -5291,16 +5258,73 @@ msgid "X coordinate of the selected field"
 msgstr "X-Koordinate des ausgewählten Feldes"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:273
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:92
-#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:81
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:94
+#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:82
 #: pcbnew/dialogs/dialog_track_via_properties_base.cpp:172
 msgid "Position Y:"
 msgstr "Position Y:"
 
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.h:114
-#: eeschema/dialogs/dialog_lib_new_component_base.h:62
-msgid "Component Properties"
-msgstr "Bauteileigenschaften"
+#: eeschema/dialogs/dialog_edit_components_libid.cpp:365
+#, c-format
+msgid "Symbol library identifier \"%s\" is not valid at row %d!"
+msgstr ""
+
+#: eeschema/dialogs/dialog_edit_components_libid.cpp:485
+#, c-format
+msgid "Available Candidates for %s "
+msgstr ""
+
+#: eeschema/dialogs/dialog_edit_components_libid.cpp:489
+#, c-format
+msgid "Candidates count %d "
+msgstr ""
+
+#: eeschema/dialogs/dialog_edit_components_libid.cpp:499
+#, c-format
+msgid "%u link(s) mapped, %d not found"
+msgstr ""
+
+#: eeschema/dialogs/dialog_edit_components_libid.cpp:503
+#, c-format
+msgid "All %u link(s) resolved"
+msgstr ""
+
+#: eeschema/dialogs/dialog_edit_components_libid.cpp:526
+msgid "Invalid symbol library identifier"
+msgstr ""
+
+#: eeschema/dialogs/dialog_edit_components_libid_base.cpp:39
+#: pcbnew/netlist.cpp:204
+msgid "Components"
+msgstr "Bauteile"
+
+#: eeschema/dialogs/dialog_edit_components_libid_base.cpp:40
+msgid "Current Symbol"
+msgstr ""
+
+#: eeschema/dialogs/dialog_edit_components_libid_base.cpp:41
+msgid "New Symbol"
+msgstr ""
+
+#: eeschema/dialogs/dialog_edit_components_libid_base.cpp:69
+msgid ""
+"Warning: Changes made from this dialog cannot be undone, after closing it."
+msgstr ""
+
+#: eeschema/dialogs/dialog_edit_components_libid_base.cpp:95
+msgid "Browse Libraries"
+msgstr ""
+
+#: eeschema/dialogs/dialog_edit_components_libid_base.cpp:98
+msgid "Map Orphans"
+msgstr ""
+
+#: eeschema/dialogs/dialog_edit_components_libid_base.cpp:99
+msgid ""
+"If  some components are orphan (the linked symbol is found nowhere),\n"
+"try to find a candidate having the same name in one of loaded symbol "
+"libraries"
+msgstr ""
 
 #: eeschema/dialogs/dialog_edit_label.cpp:160
 msgid "Global Label Properties"
@@ -5319,7 +5343,7 @@ msgid "Hierarchical Sheet Pin Properties."
 msgstr "Eigenschaften eines hierarchischen Schaltplanpins"
 
 #: eeschema/dialogs/dialog_edit_label.cpp:176
-#: pcbnew/dialogs/dialog_pcb_text_properties_base.h:76
+#: pcbnew/dialogs/dialog_pcb_text_properties_base.h:77
 msgid "Text Properties"
 msgstr "Texteigenschaften"
 
@@ -5347,25 +5371,25 @@ msgstr "&Größe:"
 
 #: eeschema/dialogs/dialog_edit_label_base.cpp:70
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:69
-#: eeschema/lib_pin.cpp:114
+#: eeschema/lib_pin.cpp:115
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:84
-#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:105
+#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:106
 msgid "Right"
 msgstr "Rechts"
 
-#: eeschema/dialogs/dialog_edit_label_base.cpp:70 eeschema/lib_pin.cpp:116
+#: eeschema/dialogs/dialog_edit_label_base.cpp:70 eeschema/lib_pin.cpp:117
 msgid "Up"
 msgstr "Oben"
 
 #: eeschema/dialogs/dialog_edit_label_base.cpp:70
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:69
-#: eeschema/lib_pin.cpp:115
+#: eeschema/lib_pin.cpp:116
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:84
-#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:105
+#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:106
 msgid "Left"
 msgstr "Links"
 
-#: eeschema/dialogs/dialog_edit_label_base.cpp:70 eeschema/lib_pin.cpp:117
+#: eeschema/dialogs/dialog_edit_label_base.cpp:70 eeschema/lib_pin.cpp:118
 msgid "Down"
 msgstr "Unten"
 
@@ -5379,40 +5403,36 @@ msgstr "&Stil"
 
 #: eeschema/dialogs/dialog_edit_label_base.cpp:82
 #: eeschema/dialogs/dialog_sch_edit_sheet_pin.cpp:30 eeschema/pin_type.cpp:38
-#: eeschema/sch_text.cpp:800
+#: eeschema/sch_text.cpp:682
 msgid "Input"
 msgstr "Eingang"
 
 #: eeschema/dialogs/dialog_edit_label_base.cpp:82
 #: eeschema/dialogs/dialog_sch_edit_sheet_pin.cpp:31 eeschema/pin_type.cpp:41
-#: eeschema/sch_text.cpp:801
+#: eeschema/sch_text.cpp:683
 msgid "Output"
 msgstr "Ausgang"
 
 #: eeschema/dialogs/dialog_edit_label_base.cpp:82
 #: eeschema/dialogs/dialog_sch_edit_sheet_pin.cpp:32 eeschema/pin_type.cpp:44
-#: eeschema/sch_text.cpp:802
+#: eeschema/sch_text.cpp:684
 msgid "Bidirectional"
 msgstr "Bidirektional"
 
-#: eeschema/dialogs/dialog_edit_label_base.cpp:82 eeschema/sch_text.cpp:803
+#: eeschema/dialogs/dialog_edit_label_base.cpp:82 eeschema/sch_text.cpp:685
 msgid "Tri-State"
 msgstr "Tri-State"
 
 #: eeschema/dialogs/dialog_edit_label_base.cpp:82
 #: eeschema/dialogs/dialog_sch_edit_sheet_pin.cpp:34
 #: eeschema/dialogs/dialog_spice_model_base.cpp:199 eeschema/pin_type.cpp:50
-#: eeschema/sch_text.cpp:804
+#: eeschema/sch_text.cpp:686
 msgid "Passive"
 msgstr "Passiv"
 
 #: eeschema/dialogs/dialog_edit_label_base.cpp:84
 msgid "S&hape"
 msgstr "&Form"
-
-#: eeschema/dialogs/dialog_edit_label_base.h:70
-msgid "Text Editor"
-msgstr "Text Editor"
 
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib.cpp:268
 msgid "Illegal reference.  References must start with a letter."
@@ -5465,8 +5485,8 @@ msgid "Vert. Justify"
 msgstr "Vertik. Ausrichtung"
 
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:92
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:121
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:150
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:123
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:152
 msgid "Visibility"
 msgstr "Sichtbarkeit"
 
@@ -5479,7 +5499,7 @@ msgid "Check if you want this field's text rotated 90 degrees"
 msgstr "Auswählen, wenn der Text dieses Feldes um 90 Grad gedreht sein soll"
 
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:109
-#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:85
+#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:86
 msgid "Style:"
 msgstr "Stil:"
 
@@ -5501,7 +5521,7 @@ msgid "Show in Browser"
 msgstr "Im Browser anzeigen"
 
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:151
-#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:52 eeschema/sch_text.cpp:813
+#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:52 eeschema/sch_text.cpp:695
 #: pcbnew/microwave.cpp:473
 msgid "Size"
 msgstr "Größe"
@@ -5523,9 +5543,33 @@ msgstr "Y Position"
 msgid "The Y coordinate of the text relative to the component"
 msgstr "Die Y-Koordinate des Textes relativ zum Bauteil"
 
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.h:95
-msgid "Field Properties"
-msgstr "Feldeigenschaften"
+#: eeschema/dialogs/dialog_edit_line_style_base.cpp:49
+msgid "Color:"
+msgstr ""
+
+#: eeschema/dialogs/dialog_edit_line_style_base.cpp:62
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:153
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:197
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:503
+msgid "Solid"
+msgstr "Solide"
+
+#: eeschema/dialogs/dialog_edit_line_style_base.cpp:62
+msgid "Dashed"
+msgstr ""
+
+#: eeschema/dialogs/dialog_edit_line_style_base.cpp:62
+msgid "Dotted"
+msgstr ""
+
+#: eeschema/dialogs/dialog_edit_line_style_base.cpp:62
+msgid "Dash-Dot"
+msgstr ""
+
+#: eeschema/dialogs/dialog_edit_line_style_base.cpp:64
+#: eeschema/dialogs/dialog_edit_line_style_base.h:74
+msgid "Line Style"
+msgstr ""
 
 #: eeschema/dialogs/dialog_edit_one_field.cpp:227
 msgid "Illegal reference field value!"
@@ -5622,9 +5666,9 @@ msgstr "Anzeige von Seiten&rändern"
 # For dialog with options about polar coordinates...
 # 2) einblenden
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:119
-#: pcbnew/class_text_mod.cpp:371
-#: pcbnew/dialogs/dialog_dimension_editor_base.cpp:79
-#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:105
+#: pcbnew/class_text_mod.cpp:379
+#: pcbnew/dialogs/dialog_dimension_editor_base.cpp:80
+#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:106
 msgid "Display"
 msgstr "Darstellung"
 
@@ -5719,10 +5763,10 @@ msgid "Default Value"
 msgstr "Voreingestellter Wert"
 
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:320
-#: eeschema/lib_pin.cpp:2051
-#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:103
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:125
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:154
+#: eeschema/lib_pin.cpp:1720
+#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:104
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:127
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:156
 msgid "Visible"
 msgstr "Sichtbar"
 
@@ -5738,41 +5782,33 @@ msgstr "Ent&fernen"
 msgid "Default Fields"
 msgstr "Vorgabe Felder"
 
-#: eeschema/dialogs/dialog_eeschema_options_base.h:129
-msgid "Schematic Editor Options"
-msgstr "Einstellungen Schaltplaneditor"
-
-#: eeschema/dialogs/dialog_erc.cpp:231
+#: eeschema/dialogs/dialog_erc.cpp:232
 msgid "Marker not found"
 msgstr "Marker nicht gefunden"
 
-#: eeschema/dialogs/dialog_erc.cpp:355
+#: eeschema/dialogs/dialog_erc.cpp:356
 msgid "No error or warning"
 msgstr "Keine Fehler oder Warnungen"
 
-#: eeschema/dialogs/dialog_erc.cpp:360
+#: eeschema/dialogs/dialog_erc.cpp:361
 msgid "Generate warning"
 msgstr "Erzeuge Warnhinweis"
 
-#: eeschema/dialogs/dialog_erc.cpp:365
+#: eeschema/dialogs/dialog_erc.cpp:366
 msgid "Generate error"
 msgstr "Erzeuge Fehler"
 
-#: eeschema/dialogs/dialog_erc.cpp:467
+#: eeschema/dialogs/dialog_erc.cpp:468
 msgid "Annotation required!"
 msgstr "Eine Annotation ist noch notwendig!"
 
-#: eeschema/dialogs/dialog_erc.cpp:591 pcbnew/drc.cpp:310
+#: eeschema/dialogs/dialog_erc.cpp:583 pcbnew/drc.cpp:475
 msgid "Finished"
 msgstr "Fertig"
 
-#: eeschema/dialogs/dialog_erc.cpp:600
+#: eeschema/dialogs/dialog_erc.cpp:592
 msgid "ERC File"
 msgstr "ERC Datei"
-
-#: eeschema/dialogs/dialog_erc.cpp:601
-msgid "Electronic rule check file (.erc)|*.erc"
-msgstr "Elektronische Regel Check (ERC) Datei (.erc)|*.erc"
 
 #: eeschema/dialogs/dialog_erc_base.cpp:30
 msgid "ERC Report:"
@@ -5806,7 +5842,7 @@ msgstr "Entferne Marker"
 msgid "Run"
 msgstr "Starte"
 
-#: eeschema/dialogs/dialog_erc_base.cpp:111
+#: eeschema/dialogs/dialog_erc_base.cpp:111 eeschema/menubar_libedit.cpp:242
 msgid "ERC"
 msgstr "ERC"
 
@@ -5847,10 +5883,6 @@ msgstr ""
 "hinweg miteinander zu verbinden. Dazu werden mindestens zwei Bezeichner\n"
 "mit dem gleichen Namen benötigt."
 
-#: eeschema/dialogs/dialog_erc_base.h:90
-msgid "Electrical Rules Checker"
-msgstr "Elektrischer Regel Check"
-
 #: eeschema/dialogs/dialog_global_sym_lib_table_config.cpp:86
 #, c-format
 msgid ""
@@ -5869,38 +5901,28 @@ msgstr "Wähle bitte eine Symbolbibliotheksdatei."
 
 #: eeschema/dialogs/dialog_global_sym_lib_table_config.cpp:110
 #, c-format
-msgid "File '%s' not found."
-msgstr "Datei '%s' nicht gefunden."
+msgid "File \"%s\" not found."
+msgstr ""
 
 #: eeschema/dialogs/dialog_global_sym_lib_table_config.cpp:124
 #, c-format
 msgid ""
-"File '%s' is not a valid symbol library table file.\n"
+"File \"%s\" is not a valid symbol library table file.\n"
 "\n"
 "%s"
 msgstr ""
-"Datei '%s' ist keine gültige Symbolbibliotheksdatei.\n"
-"\n"
-"%s"
 
 #: eeschema/dialogs/dialog_global_sym_lib_table_config.cpp:144
 #, c-format
 msgid ""
 "Cannot copy global symbol library table file:\n"
 "\n"
-" '%s'\n"
+" \"%s\"\n"
 "\n"
 ":to:\n"
 "\n"
-"%s."
+"\"%s\"."
 msgstr ""
-"Die globale Symbolbibliothekstabelle konnte nicht kopiert werden:\n"
-"\n"
-" '%s'\n"
-"\n"
-":to:\n"
-"\n"
-"%s."
 
 #: eeschema/dialogs/dialog_global_sym_lib_table_config.cpp:161
 #, c-format
@@ -5972,10 +5994,6 @@ msgstr "Auswahl globale Symbolbibliotheksdatei:"
 msgid "Select a file"
 msgstr "Wähle eine Datei"
 
-#: eeschema/dialogs/dialog_global_sym_lib_table_config_base.h:58
-msgid "Configure Global Symbol Library Table"
-msgstr "Konfiguriere globale Symbol Bibliothekstabelle"
-
 #: eeschema/dialogs/dialog_lib_edit_draw_item_base.cpp:34
 msgid "&Width:"
 msgstr "&Breite:"
@@ -6011,10 +6029,6 @@ msgstr "Fülle &Vordergrund"
 #: eeschema/dialogs/dialog_lib_edit_draw_item_base.cpp:106
 msgid "Fill &background"
 msgstr "Fülle &Hintergrund"
-
-#: eeschema/dialogs/dialog_lib_edit_draw_item_base.h:62
-msgid "Drawing Properties"
-msgstr "Darstellungs Eigenschaften"
 
 #: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:35
 msgid "Pin &name:"
@@ -6072,44 +6086,36 @@ msgstr "Pin Pos X:"
 msgid "Pin Pos Y:"
 msgstr "Pin Pos Y:"
 
-#: eeschema/dialogs/dialog_lib_edit_pin_base.h:107
-msgid "Pin Properties"
-msgstr "Pin Eigenschaften"
-
-#: eeschema/dialogs/dialog_lib_edit_pin_table.cpp:175 eeschema/lib_pin.cpp:2036
+#: eeschema/dialogs/dialog_lib_edit_pin_table.cpp:175 eeschema/lib_pin.cpp:1705
 msgid "Number"
 msgstr "Nummer"
 
 #: eeschema/dialogs/dialog_lib_edit_pin_table.cpp:189
 #: eeschema/dialogs/dialog_spice_model_base.cpp:30
 #: eeschema/dialogs/dialog_spice_model_base.cpp:233
-#: eeschema/lib_draw_item.cpp:65 eeschema/lib_pin.cpp:2038
-#: eeschema/libedit.cpp:491 eeschema/sch_text.cpp:808
-#: gerbview/class_gerber_draw_item.cpp:609
+#: eeschema/lib_draw_item.cpp:65 eeschema/lib_pin.cpp:1707
+#: eeschema/libedit.cpp:663 eeschema/sch_text.cpp:690
+#: gerbview/class_gerber_draw_item.cpp:679
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:29
 #: pcb_calculator/dialogs/dialog_regulator_data_base.cpp:47
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:163
-#: pcbnew/class_drawsegment.cpp:341 pcbnew/class_marker_pcb.cpp:98
-#: pcbnew/class_text_mod.cpp:364 pcbnew/class_track.cpp:1151
+#: pcbnew/class_drawsegment.cpp:359 pcbnew/class_marker_pcb.cpp:98
+#: pcbnew/class_text_mod.cpp:372 pcbnew/class_track.cpp:1151
 #: pcbnew/class_track.cpp:1178 pcbnew/class_track.cpp:1227
-#: pcbnew/class_zone.cpp:832 pcbnew/dialogs/dialog_layers_setup.cpp:342
+#: pcbnew/class_zone.cpp:828 pcbnew/dialogs/dialog_layers_setup.cpp:342
 msgid "Type"
 msgstr "Typ"
 
 #: eeschema/dialogs/dialog_lib_edit_pin_table.cpp:196 pcbnew/class_pad.cpp:739
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:77
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:79
 msgid "Position"
 msgstr "Position"
 
-#: eeschema/dialogs/dialog_lib_edit_pin_table_base.h:50
-msgid "Pin Table"
-msgstr "Pinname"
-
-#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:28 eeschema/lib_text.cpp:52
+#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:28 eeschema/lib_text.cpp:51
 #: pagelayout_editor/dialogs/dialog_new_dataitem_base.cpp:113
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:67
-#: pcbnew/class_text_mod.cpp:354 pcbnew/class_text_mod.cpp:361
-#: pcbnew/dialogs/dialog_dimension_editor_base.cpp:21
+#: pcbnew/class_text_mod.cpp:362 pcbnew/class_text_mod.cpp:369
+#: pcbnew/dialogs/dialog_dimension_editor_base.cpp:22
 #: pcbnew/dialogs/dialog_global_deletion_base.cpp:28
 msgid "Text"
 msgstr "Text"
@@ -6123,7 +6129,7 @@ msgid "Power component value text cannot be modified!"
 msgstr "Text von Stromkomponenten kann nicht verändert werden!"
 
 #: eeschema/dialogs/dialog_lib_edit_text_base.cpp:77
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:208
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:210
 msgid "Vertical"
 msgstr "Vertikal"
 
@@ -6136,50 +6142,25 @@ msgid "Common to all body styles"
 msgstr "Von allen Bauteileformen gemeinsam genutzt"
 
 #: eeschema/dialogs/dialog_lib_edit_text_base.cpp:89
-#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:103
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:125
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:154
+#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:104
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:127
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:156
 msgid "Invisible"
 msgstr "Nicht sichtbar"
 
-#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:97 eeschema/lib_field.cpp:786
-#: eeschema/lib_pin.cpp:2044 eeschema/sch_text.cpp:790
-#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:111
+#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:97 eeschema/lib_field.cpp:615
+#: eeschema/lib_pin.cpp:1713 eeschema/sch_text.cpp:672
+#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:112
 msgid "Style"
 msgstr "Stil"
-
-#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:101
-msgid "Align left"
-msgstr "Links ausrichten"
-
-#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:101
-#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:107
-msgid "Align center"
-msgstr "Mittig ausrichten"
-
-#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:101
-msgid "Align right"
-msgstr "Rechts ausrichten"
 
 #: eeschema/dialogs/dialog_lib_edit_text_base.cpp:103
 msgid "Horizontal Justify"
 msgstr "Horizontale Ausrichtung"
 
-#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:107
-msgid "Align bottom"
-msgstr "Unten ausrichten"
-
-#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:107
-msgid "Align top"
-msgstr "Oben ausrichten"
-
 #: eeschema/dialogs/dialog_lib_edit_text_base.cpp:109
 msgid "Vertical Justify"
 msgstr "Vertikale Ausrichtung"
-
-#: eeschema/dialogs/dialog_lib_edit_text_base.h:69
-msgid "Library Text Properties"
-msgstr "Bauteilbibliothek - Texteigenschaften"
 
 #: eeschema/dialogs/dialog_lib_new_component_base.cpp:22
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.h:86
@@ -6275,10 +6256,6 @@ msgstr "50"
 msgid "Show pin &electrical type"
 msgstr "Zeige El&ektrischen Anschlusstyp"
 
-#: eeschema/dialogs/dialog_libedit_options_base.h:78
-msgid "Library Editor Options"
-msgstr "Bibliothekseditor Optionen"
-
 #: eeschema/dialogs/dialog_netlist.cpp:297
 #: gerbview/dialogs/dialog_print_using_printer_base.cpp:75
 #: pcbnew/dialogs/dialog_drc_base.cpp:27
@@ -6323,14 +6300,6 @@ msgstr "Netzliste speichern"
 msgid "%s Export"
 msgstr "%s Export"
 
-#: eeschema/dialogs/dialog_netlist.cpp:634
-msgid "SPICE netlist file (.cir)|*.cir"
-msgstr "SPICE Netzliste Datei (.cir)|*.cir"
-
-#: eeschema/dialogs/dialog_netlist.cpp:639
-msgid "CadStar netlist file (.frp)|*.frp"
-msgstr "CadStar Netzliste Datei (.frp)|*.frp"
-
 #: eeschema/dialogs/dialog_netlist.cpp:786
 msgid "This plugin already exists. Abort"
 msgstr "Dieses Plugin existiert bereits. Abbruch!"
@@ -6361,16 +6330,7 @@ msgstr "Voreingestellter Netzlisten Dateiname:"
 msgid "Browse Plugins"
 msgstr "Plugins durchsuchen"
 
-#: eeschema/dialogs/dialog_netlist_base.h:78
-#: pcbnew/dialogs/dialog_netlist_fbp.h:84
-msgid "Netlist"
-msgstr "Netzliste"
-
-#: eeschema/dialogs/dialog_netlist_base.h:119
-msgid "Plugins:"
-msgstr "Plugins:"
-
-#: eeschema/dialogs/dialog_plot_schematic.cpp:171
+#: eeschema/dialogs/dialog_plot_schematic.cpp:170
 #: pcbnew/dialogs/dialog_SVG_print.cpp:214
 #: pcbnew/dialogs/dialog_gendrill.cpp:324 pcbnew/dialogs/dialog_plot.cpp:352
 #: pcbnew/exporters/gen_modules_placefile.cpp:180
@@ -6378,18 +6338,16 @@ msgstr "Plugins:"
 msgid "Select Output Directory"
 msgstr "Wähle das Ausgabeverzeichnis"
 
-#: eeschema/dialogs/dialog_plot_schematic.cpp:183
+#: eeschema/dialogs/dialog_plot_schematic.cpp:182
 #: pcbnew/dialogs/dialog_gendrill.cpp:334 pcbnew/dialogs/dialog_plot.cpp:362
 #, c-format
 msgid ""
 "Do you want to use a path relative to\n"
-"'%s'"
+"\"%s\""
 msgstr ""
-"Möchten Sie einen relativen Pfad zu '%s'\n"
-"benutzen?"
 
-#: eeschema/dialogs/dialog_plot_schematic.cpp:186
-#: eeschema/dialogs/dialog_plot_schematic.cpp:194
+#: eeschema/dialogs/dialog_plot_schematic.cpp:185
+#: eeschema/dialogs/dialog_plot_schematic.cpp:193
 #: pcbnew/dialogs/dialog_SVG_print.cpp:222
 #: pcbnew/dialogs/dialog_SVG_print.cpp:233
 #: pcbnew/dialogs/dialog_gendrill.cpp:336
@@ -6400,18 +6358,19 @@ msgstr ""
 msgid "Plot Output Directory"
 msgstr "Ausgabeverzeichnis für Plot"
 
-#: eeschema/dialogs/dialog_plot_schematic.cpp:193
+#: eeschema/dialogs/dialog_plot_schematic.cpp:192
 #: pcbnew/dialogs/dialog_gendrill.cpp:342 pcbnew/dialogs/dialog_plot.cpp:371
 msgid "Cannot make path relative (target volume different from file volume)!"
 msgstr ""
 "Kann keinen relativen Pfad erzeugen (Zieldatei und Platinendatei haben "
 "unterschiedliche Datenträger)!"
 
-#: eeschema/dialogs/dialog_plot_schematic.cpp:350
-#: pcbnew/dialogs/dialog_SVG_print.cpp:274
+#: eeschema/dialogs/dialog_plot_schematic.cpp:349
+#: pcbnew/dialogs/dialog_SVG_print.cpp:274 pcbnew/dialogs/dialog_plot.cpp:767
+#: pcbnew/exporters/gen_modules_placefile.cpp:257
 #, c-format
-msgid "Could not write plot files to folder '%s'."
-msgstr "Konnte die Plotdateien nicht in dem Verzeichnis '%s' anlegen."
+msgid "Could not write plot files to folder \"%s\"."
+msgstr "Konnte die Plotdateien nicht in dem Verzeichnis \"%s\" anlegen."
 
 #: eeschema/dialogs/dialog_plot_schematic_base.cpp:24
 #: pcbnew/dialogs/dialog_SVG_print_base.cpp:21
@@ -6604,10 +6563,6 @@ msgstr "Aktuelle Seite plotten"
 msgid "Plot All Pages"
 msgstr "Alle Seiten plotten"
 
-#: eeschema/dialogs/dialog_plot_schematic_base.h:85
-msgid "Plot Schematic Options"
-msgstr "Optionen Schaltplan Plotten"
-
 #: eeschema/dialogs/dialog_print_using_printer.cpp:249
 #: eeschema/dialogs/dialog_print_using_printer_base.cpp:47
 #: gerbview/dialogs/dialog_print_using_printer_base.cpp:100
@@ -6660,57 +6615,60 @@ msgid "Page Setup"
 msgstr "Seiteneinstellungen"
 
 #: eeschema/dialogs/dialog_print_using_printer_base.cpp:50
-#: eeschema/dialogs/dialog_print_using_printer_base.h:56
 #: gerbview/dialogs/dialog_print_using_printer.cpp:403
 #: gerbview/dialogs/dialog_print_using_printer_base.cpp:103
-#: gerbview/dialogs/dialog_print_using_printer_base.h:73
 #: pagelayout_editor/hotkeys.cpp:98
 #: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:54
-#: pcbnew/dialogs/dialog_print_for_modedit_base.h:61
 #: pcbnew/dialogs/dialog_print_using_printer.cpp:495
 #: pcbnew/dialogs/dialog_print_using_printer_base.cpp:156
+#: eeschema/dialogs/dialog_print_using_printer_base.h:56
+#: gerbview/dialogs/dialog_print_using_printer_base.h:73
+#: pcbnew/dialogs/dialog_print_for_modedit_base.h:61
 #: pcbnew/dialogs/dialog_print_using_printer_base.h:85
 msgid "Print"
 msgstr "Drucken"
 
 #: eeschema/dialogs/dialog_rescue_each.cpp:85
 msgid ""
-"It looks like this project was made using older schematic symbol libraries.\n"
-"Some parts may need to be relinked to a different symbol name, and some "
-"symbols\n"
-"may need to be \"rescued\" (cloned and renamed) into a new library.\n"
+"This schematic was made using older symbol libraries which may break the "
+"schematic.  Some symbols may need to be linked to a different symbol name.  "
+"Some symbols may need to be \"rescued\" (copied and renamed) into a new "
+"library.\n"
 "\n"
 "The following changes are recommended to update the project."
 msgstr ""
-"Es scheint das dieses Projekt unter Benutzung von älteren "
-"Bauteilsymbolbibliotheken erstellt worden ist.\n"
-"Manche Teile müssen neu zu einem anderen Symbolnamen verbunden werden, und "
-"manche Symbole\n"
-"müssen in eine neue Bibliothek \"gesichert\" werden (z.B. geklont oder "
-"umbenannt).\n"
-"\n"
-"Die folgenden Änderungen werden empfohlen um Ihr Projekt zu aktualisieren."
 
-#: eeschema/dialogs/dialog_rescue_each.cpp:107
+#: eeschema/dialogs/dialog_rescue_each.cpp:92
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:192
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:609
 msgid "Accept"
 msgstr "OK"
 
-#: eeschema/dialogs/dialog_rescue_each.cpp:108 eeschema/sch_component.cpp:1812
-msgid "Symbol"
-msgstr "Symbol"
+#: eeschema/dialogs/dialog_rescue_each.cpp:107
+msgid "Symbol Name"
+msgstr ""
 
-#: eeschema/dialogs/dialog_rescue_each.cpp:109
-msgid "Action"
-msgstr "Aktion"
+#: eeschema/dialogs/dialog_rescue_each.cpp:111
+msgid "Action Taken"
+msgstr ""
 
-#: eeschema/dialogs/dialog_rescue_each.cpp:177
+#: eeschema/dialogs/dialog_rescue_each.cpp:115 eeschema/lib_field.cpp:442
+#: eeschema/sch_component.cpp:1432 eeschema/sch_component.cpp:1472
+#: eeschema/template_fieldnames.cpp:39
+#: eeschema/widgets/widget_eeschema_color_config.cpp:76
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:28
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:42
+#: pcbnew/dialogs/dialog_netlist_fbp.cpp:33
+#: pcbnew/dialogs/dialog_update_pcb_base.cpp:30 eeschema/bom_table_column.h:33
+msgid "Reference"
+msgstr "Referenz"
+
+#: eeschema/dialogs/dialog_rescue_each.cpp:203
 #, c-format
 msgid "Instances of this symbol (%d items):"
 msgstr "Instanzen von diesem Symbol (%d Elemente):"
 
-#: eeschema/dialogs/dialog_rescue_each.cpp:293
+#: eeschema/dialogs/dialog_rescue_each.cpp:319
 msgid ""
 "Stop showing this tool?\n"
 "No changes will be made.\n"
@@ -6725,58 +6683,49 @@ msgstr ""
 "werden,\n"
 "das Tool kann manuell im \"Werkzeug\" Menü wieder aktiviert werden."
 
-#: eeschema/dialogs/dialog_rescue_each.cpp:297
-msgid "Rescue Symbolss"
-msgstr "Bauteile wiederherstellen"
+#: eeschema/dialogs/dialog_rescue_each.cpp:323
+msgid "Rescue Symbols"
+msgstr ""
 
-#: eeschema/dialogs/dialog_rescue_each_base.cpp:23
+#: eeschema/dialogs/dialog_rescue_each_base.cpp:22
 msgid "Symbols to update:"
 msgstr "Symbole zum Aktualisieren:"
 
-#: eeschema/dialogs/dialog_rescue_each_base.cpp:32
+#: eeschema/dialogs/dialog_rescue_each_base.cpp:31
 msgid "Instances of this symbol:"
 msgstr "Instanzen von diesem Symbol:"
 
-#: eeschema/dialogs/dialog_rescue_each_base.cpp:47
-msgid "Cached Part:"
-msgstr "Gespeicherter Bauteil:"
+#: eeschema/dialogs/dialog_rescue_each_base.cpp:46
+msgid "Cached Symbol:"
+msgstr ""
 
-#: eeschema/dialogs/dialog_rescue_each_base.cpp:64
-msgid "Library Part:"
-msgstr "Bibliotheksbauteil:"
+#: eeschema/dialogs/dialog_rescue_each_base.cpp:63
+msgid "Library Symbol:"
+msgstr ""
 
-#: eeschema/dialogs/dialog_rescue_each_base.cpp:84
+#: eeschema/dialogs/dialog_rescue_each_base.cpp:83
 msgid "Never Show Again"
 msgstr "Nicht nochmal anzeigen"
-
-#: eeschema/dialogs/dialog_rescue_each_base.h:65
-#: eeschema/project_rescue.cpp:517 eeschema/project_rescue.cpp:533
-msgid "Project Rescue Helper"
-msgstr "Projekt Wiederherstellungs Helfer"
 
 #: eeschema/dialogs/dialog_sch_edit_sheet_pin.cpp:33 eeschema/pin_type.cpp:47
 msgid "Tri-state"
 msgstr "Tri-State"
 
 #: eeschema/dialogs/dialog_sch_edit_sheet_pin_base.cpp:39
-#: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:46
-#: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:80
+#: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:48
+#: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:82
 msgid "Text height:"
 msgstr "Texthöhe:"
 
 #: eeschema/dialogs/dialog_sch_edit_sheet_pin_base.cpp:51
-#: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:53
-#: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:87
+#: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:55
+#: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:89
 msgid "Text width:"
 msgstr "Textbreite:"
 
 #: eeschema/dialogs/dialog_sch_edit_sheet_pin_base.cpp:63
 msgid "Connection type:"
 msgstr "Verbindungstyp:"
-
-#: eeschema/dialogs/dialog_sch_edit_sheet_pin_base.h:56
-msgid "Sheet Pin Properties"
-msgstr "Schaltplanpin Eigenschaften"
 
 #: eeschema/dialogs/dialog_sch_sheet_props_base.cpp:28
 msgid "&File name:"
@@ -6793,10 +6742,6 @@ msgstr "&Schaltplanname:"
 #: eeschema/dialogs/dialog_sch_sheet_props_base.cpp:94
 msgid "Unique timestamp:"
 msgstr "Einheitlicher Zeitstempel:"
-
-#: eeschema/dialogs/dialog_sch_sheet_props_base.h:60
-msgid "Schematic Sheet Properties"
-msgstr "Schaltplan Eigenschaften"
 
 #: eeschema/dialogs/dialog_schematic_find.cpp:39
 #: eeschema/dialogs/dialog_schematic_find_base.h:77
@@ -7031,7 +6976,7 @@ msgstr "Lade Regeln aus dem Schaltplan"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:384
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:29
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:129
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:131
 msgid "Custom"
 msgstr "Benutzerdefiniert"
 
@@ -7043,10 +6988,9 @@ msgstr "Passive Komponentenwerte anpassen (z.B. M -> Meg; 100 nF -> 100n)"
 msgid "Add full path for .include library directives"
 msgstr "Kompletten Pfad in die .include Bibliothek Anweisungen hinzufügen"
 
-#: eeschema/dialogs/dialog_sim_settings_base.h:123
-#: eeschema/sim/sim_plot_frame.cpp:164
-msgid "Simulation settings"
-msgstr "Einstellungen für Simulationen"
+#: eeschema/dialogs/dialog_spice_model.cpp:723
+msgid "Select library"
+msgstr ""
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:34
 #: eeschema/dialogs/dialog_spice_model_base.cpp:35
@@ -7118,9 +7062,9 @@ msgid "1e-9"
 msgstr "1e-9"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:117
-#: pcbnew/dialogs/dialog_pns_diff_pair_dimensions_base.cpp:32
-#: pcbnew/dialogs/dialog_pns_diff_pair_dimensions_base.cpp:43
-#: pcbnew/dialogs/dialog_pns_diff_pair_dimensions_base.cpp:60
+#: pcbnew/dialogs/dialog_pns_diff_pair_dimensions_base.cpp:34
+#: pcbnew/dialogs/dialog_pns_diff_pair_dimensions_base.cpp:45
+#: pcbnew/dialogs/dialog_pns_diff_pair_dimensions_base.cpp:62
 msgid "u"
 msgstr "u"
 
@@ -7193,9 +7137,9 @@ msgid "1e12"
 msgstr "1e12"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:210
-#: eeschema/sch_component.cpp:1783 eeschema/sch_component.cpp:1785
-#: eeschema/sch_component.cpp:1788 eeschema/sch_component.cpp:1818
-#: eeschema/sch_component.cpp:1824 eeschema/selpart.cpp:88
+#: eeschema/sch_component.cpp:1448 eeschema/sch_component.cpp:1450
+#: eeschema/sch_component.cpp:1453 eeschema/sch_component.cpp:1483
+#: eeschema/sch_component.cpp:1489 eeschema/selpart.cpp:88
 #: pcbnew/dialogs/wizard_add_fplib_base.cpp:185 pcbnew/loadcmp.cpp:446
 msgid "Library"
 msgstr "Bibliothek"
@@ -7384,31 +7328,32 @@ msgstr "Bauteil in der Simulation deaktivieren"
 msgid "Alternate node sequence:"
 msgstr "Alternative Knotensequenz:"
 
-#: eeschema/dialogs/dialog_spice_model_base.h:177
-msgid "Spice Model Editor"
-msgstr "Spice-Modell Editor"
-
-#: eeschema/dialogs/dialog_sym_lib_table.cpp:265
-#: pcbnew/dialogs/dialog_fp_lib_table.cpp:302
+#: eeschema/dialogs/dialog_sym_lib_table.cpp:270
+#: pcbnew/dialogs/dialog_fp_lib_table.cpp:303
 #, c-format
-msgid "Illegal character '%s' found in Nickname: '%s' in row %d"
-msgstr "Unzulässiges Zeichen '%s' im Nicknamen '%s' und Zeile %d gefunden."
+msgid "Illegal character \"%s\" found in Nickname: \"%s\" in row %d"
+msgstr ""
 
-#: eeschema/dialogs/dialog_sym_lib_table.cpp:279
-#: pcbnew/dialogs/dialog_fp_lib_table.cpp:316
+#: eeschema/dialogs/dialog_sym_lib_table.cpp:284
+#: pcbnew/dialogs/dialog_fp_lib_table.cpp:317
 msgid "No Colon in Nicknames"
 msgstr "Kein Doppelpunkt in Nicknamen"
 
-#: eeschema/dialogs/dialog_sym_lib_table.cpp:309
-#: pcbnew/dialogs/dialog_fp_lib_table.cpp:346
+#: eeschema/dialogs/dialog_sym_lib_table.cpp:314
+#: pcbnew/dialogs/dialog_fp_lib_table.cpp:347
 #, c-format
-msgid "Duplicate Nickname: '%s' in rows %d and %d"
-msgstr "Doppelter Nickname: '%s' in Zeile %d und %d"
+msgid "Duplicate Nickname: \"%s\" in rows %d and %d"
+msgstr ""
 
-#: eeschema/dialogs/dialog_sym_lib_table.cpp:324
-#: pcbnew/dialogs/dialog_fp_lib_table.cpp:361
+#: eeschema/dialogs/dialog_sym_lib_table.cpp:329
+#: pcbnew/dialogs/dialog_fp_lib_table.cpp:362
 msgid "Please Delete or Modify One"
 msgstr "Bitte einen Nicknamen entfernen oder ändern."
+
+#: eeschema/dialogs/dialog_sym_lib_table.cpp:350 eeschema/libeditframe.cpp:1556
+#: pcbnew/librairi.cpp:80
+msgid "Select Library"
+msgstr "Wähle Bibliothek"
 
 #: eeschema/dialogs/dialog_sym_lib_table_base.cpp:20
 #: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:20
@@ -7440,72 +7385,83 @@ msgid "Project Specific Libraries"
 msgstr "Projektspezifische Bibliotheken"
 
 #: eeschema/dialogs/dialog_sym_lib_table_base.cpp:134
+msgid "Browse Libraries..."
+msgstr ""
+
+#: eeschema/dialogs/dialog_sym_lib_table_base.cpp:137
 #: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:136
 msgid "Append Library"
 msgstr "Bibliothek einfügen"
 
-#: eeschema/dialogs/dialog_sym_lib_table_base.cpp:135
+#: eeschema/dialogs/dialog_sym_lib_table_base.cpp:138
 #: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:137
 msgid "Add a PCB library row to this table"
 msgstr "Hinzufügen eine Zeile mit einer PCB-Bibliothek"
 
-#: eeschema/dialogs/dialog_sym_lib_table_base.cpp:139
+#: eeschema/dialogs/dialog_sym_lib_table_base.cpp:142
 #: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:141
 msgid "Remove Library"
 msgstr "Bibliothek entfernen"
 
-#: eeschema/dialogs/dialog_sym_lib_table_base.cpp:140
+#: eeschema/dialogs/dialog_sym_lib_table_base.cpp:143
 #: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:142
 msgid "Remove a PCB library from this library table"
 msgstr "Entfernt eine PCB-Bibliothek aus der Bibliothekstabelle"
 
-#: eeschema/dialogs/dialog_sym_lib_table_base.cpp:145
+#: eeschema/dialogs/dialog_sym_lib_table_base.cpp:148
 #: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:147
 msgid "Move the currently selected row up one position"
 msgstr "Die ausgewählte Reihe um eine Position nach oben verschieben"
 
-#: eeschema/dialogs/dialog_sym_lib_table_base.cpp:150
+#: eeschema/dialogs/dialog_sym_lib_table_base.cpp:153
 #: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:152
 msgid "Move the currently selected row down one position"
 msgstr "Die ausgewählte Reihe um eine Position nach unten verschieben"
 
-#: eeschema/dialogs/dialog_sym_lib_table_base.cpp:161
+#: eeschema/dialogs/dialog_sym_lib_table_base.cpp:164
 #: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:168
 msgid "Path Substitutions"
 msgstr "Pfadsubstitutionen"
 
-#: eeschema/dialogs/dialog_sym_lib_table_base.cpp:179
+#: eeschema/dialogs/dialog_sym_lib_table_base.cpp:182
 #: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:186
 msgid "Environment Variable"
 msgstr "Umgebungsvariable"
 
-#: eeschema/dialogs/dialog_sym_lib_table_base.cpp:180
+#: eeschema/dialogs/dialog_sym_lib_table_base.cpp:183
 #: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:187
 msgid "Path Segment"
 msgstr "Pfadabschnitt"
 
-#: eeschema/dialogs/dialog_sym_lib_table_base.cpp:192
+#: eeschema/dialogs/dialog_sym_lib_table_base.cpp:195
 #: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:199
 msgid "This is a read-only table which shows pertinent environment variables."
 msgstr ""
 "Dies ist eine nicht veränderbare Tabelle, welche die entsprechenden "
 "Umgebungsvariablen anzeigt."
 
-#: eeschema/dialogs/dialog_sym_lib_table_base.h:73
-msgid "Schematic Library Tables"
-msgstr "Tabelle Bauteilbibliotheken"
+#: eeschema/dialogs/dialog_symbol_remap.cpp:51
+msgid ""
+"This schematic currently uses the symbol library list look up method for "
+"loading schematic symbols.  KiCad will attempt to map the existing symbols "
+"to use the new symbol library table.  Remapping will change project files "
+"and schematics will not be compatible with previous versions of KiCad.  All "
+"files that are changed will be backed up with the .v4 extension should you "
+"need to revert any changes.  If you choose to skip this step, you will be "
+"responsible for manually remapping the symbols."
+msgstr ""
 
-#: eeschema/dialogs/dialog_symbol_remap.cpp:178
+#: eeschema/dialogs/dialog_symbol_remap.cpp:158
 #, c-format
-msgid "Adding library '%s', file '%s' to project symbol library table."
-msgstr "Hinzufügen der Bibliothek '%s' (Datei '%s') zur Bauteilsymboltabelle."
+msgid "Adding library \"%s\", file \"%s\" to project symbol library table."
+msgstr ""
 
-#: eeschema/dialogs/dialog_symbol_remap.cpp:187
+#: eeschema/dialogs/dialog_symbol_remap.cpp:167
 #, c-format
-msgid "Library '%s' not found."
-msgstr "Bibliothek '%s' nicht gefunden."
+msgid "Library \"%s\" not found."
+msgstr ""
 
-#: eeschema/dialogs/dialog_symbol_remap.cpp:204
+#: eeschema/dialogs/dialog_symbol_remap.cpp:184
 #, c-format
 msgid ""
 "Failed to write project symbol library table. Error:\n"
@@ -7514,42 +7470,39 @@ msgstr ""
 "Konnte die Bauteilsymboltabelle des Projektes nicht erstellen.\n"
 "Fehler: %s"
 
-#: eeschema/dialogs/dialog_symbol_remap.cpp:209
+#: eeschema/dialogs/dialog_symbol_remap.cpp:189
 msgid "Created project symbol library table.\n"
 msgstr "Erstellt eine leere projektspezifische Symbolbibliothekstabelle.\n"
 
-#: eeschema/dialogs/dialog_symbol_remap.cpp:237
+#: eeschema/dialogs/dialog_symbol_remap.cpp:217
 #, c-format
-msgid "No symbol '%s' found in symbol library table."
-msgstr "Symbol '%s' konnte in keiner Bibliothek gefunden werden."
+msgid "No symbol \"%s\" found in symbol library table."
+msgstr ""
 
-#: eeschema/dialogs/dialog_symbol_remap.cpp:243
+#: eeschema/dialogs/dialog_symbol_remap.cpp:223
 #, c-format
-msgid "Symbol '%s' mapped to symbol library '%s'."
-msgstr "Das Symbol '%s' ist in die Symbolbibliothek '%s' gemappt."
+msgid "Symbol \"%s\" mapped to symbol library \"%s\"."
+msgstr ""
 
-#: eeschema/dialogs/dialog_symbol_remap.cpp:252
+#: eeschema/dialogs/dialog_symbol_remap.cpp:232
 msgid "Symbol library table mapping complete!"
 msgstr "Kartierung der Symbolbibliothekstabelle ist fertig gestellt!"
 
-#: eeschema/dialogs/dialog_symbol_remap_base.cpp:24
-msgid ""
-"This schematic currently uses the symbol library look\n"
-"up method for loading schematic symbols.  KiCad will\n"
-"attempt to map the existing symbols to use the new\n"
-"symbol library table.  If you choose to skip\n"
-"this step, you will be responsible for manually assigning\n"
-"symbols."
+#: eeschema/dialogs/dialog_symbol_remap.cpp:303
+#: eeschema/dialogs/dialog_symbol_remap.cpp:318
+#: eeschema/dialogs/dialog_symbol_remap.cpp:338
+#: eeschema/dialogs/dialog_symbol_remap.cpp:351
+#: eeschema/dialogs/dialog_symbol_remap.cpp:365
+#, c-format
+msgid "Failed to back up file \"%s\".\n"
 msgstr ""
-"Dieser Schaltplan benutzt derzeit die Symbolbibliothek\n"
-"als Referenzierungsmethode um Symbole laden zu können.\n"
-"KiCad wird versuchen die existierenden Symbole abzubilden damit\n"
-"die neue Symbolbibliothekstabelle benutzt werden kann. Wenn Sie\n"
-"diesen Schritt abbrechen sind Sie selbst für die manuelle korrekte\n"
-"Zuordnung der Symbole verantwortlich."
 
-#: eeschema/dialogs/dialog_symbol_remap_base.cpp:31
-#: eeschema/dialogs/dialog_symbol_remap_base.h:51 eeschema/menubar.cpp:498
+#: eeschema/dialogs/dialog_symbol_remap.cpp:371
+msgid "Some of the project files could not be backed up."
+msgstr ""
+
+#: eeschema/dialogs/dialog_symbol_remap_base.cpp:30 eeschema/menubar.cpp:505
+#: eeschema/dialogs/dialog_symbol_remap_base.h:50
 msgid "Remap Symbols"
 msgstr "Symbole neu zuordnen"
 
@@ -7576,16 +7529,12 @@ msgid "Removes fields that do not occur in the original library symbols"
 msgstr ""
 "Entfernt Felder welche nicht in den originalen Bibliothekssymbolen vorkommen."
 
-#: eeschema/dialogs/dialog_update_fields_base.h:58
-msgid "Update symbol fields"
-msgstr "Symbolfelder aktualisieren"
-
 #: eeschema/edit_bitmap.cpp:115 eeschema/edit_bitmap.cpp:125
-#: pagelayout_editor/pl_editor_frame.cpp:650
-#: pagelayout_editor/pl_editor_frame.cpp:657
+#: pagelayout_editor/pl_editor_frame.cpp:645
+#: pagelayout_editor/pl_editor_frame.cpp:653
 #, c-format
-msgid "Couldn't load image from <%s>"
-msgstr "Konnte Bild von <%s> nicht einlesen."
+msgid "Couldn't load image from \"%s\""
+msgstr ""
 
 #: eeschema/edit_component_in_schematic.cpp:82
 #, c-format
@@ -7609,7 +7558,7 @@ msgstr "Öffnen einer Projektdatei"
 msgid "Save Project File"
 msgstr "Projektdatei speichern"
 
-#: eeschema/eeschema_config.cpp:785
+#: eeschema/eeschema_config.cpp:783
 #, c-format
 msgid ""
 "An error occurred loading the symbol library table.\n"
@@ -7733,39 +7682,39 @@ msgstr ""
 "Schaltplan Bezeichnung %s ist nicht mit einem hierarchischen Bezeichner "
 "assoziiert."
 
-#: eeschema/erc.cpp:298
+#: eeschema/erc.cpp:293
 #, c-format
 msgid "Pin %s (%s) of component %s is unconnected."
 msgstr "Pin %s (%s) von Bauteil %s ist nicht verbunden."
 
-#: eeschema/erc.cpp:315
+#: eeschema/erc.cpp:310
 #, c-format
 msgid "Pin %s (%s) of component %s is not driven (Net %d)."
 msgstr "Pin %s (%s) von Bauteil %s wird nicht angesteuert (Netz %d)."
 
-#: eeschema/erc.cpp:329
+#: eeschema/erc.cpp:324
 msgid "More than 1 pin connected to an UnConnect symbol."
 msgstr "Mehr als 1 Pin ist mit dem 'Keine-Verbindung' Symbol verbunden."
 
-#: eeschema/erc.cpp:357
+#: eeschema/erc.cpp:349
 #, c-format
 msgid "Pin %s (%s) of component %s is connected to "
 msgstr "Pin %s (%s) von Bauteil %s ist verbunden mit "
 
-#: eeschema/erc.cpp:362
+#: eeschema/erc.cpp:354
 #, c-format
 msgid "pin %s (%s) of component %s (net %d)."
 msgstr "Pin %s (%s) von Bauteil %s (Netz %d)."
 
-#: eeschema/erc.cpp:534
+#: eeschema/erc.cpp:526
 msgid "ERC report"
 msgstr "ERC Bericht"
 
-#: eeschema/erc.cpp:536
+#: eeschema/erc.cpp:528
 msgid "Encoding UTF8"
 msgstr "Kodierung UTF8"
 
-#: eeschema/erc.cpp:545
+#: eeschema/erc.cpp:537
 #, c-format
 msgid ""
 "\n"
@@ -7774,7 +7723,7 @@ msgstr ""
 "\n"
 "***** Schaltplan %s\n"
 
-#: eeschema/erc.cpp:570
+#: eeschema/erc.cpp:562
 #, c-format
 msgid ""
 "\n"
@@ -7783,25 +7732,25 @@ msgstr ""
 "\n"
 " ** ERC Meldungen: %d  Fehler %d  Warnungen %d\n"
 
-#: eeschema/erc.cpp:825
+#: eeschema/erc.cpp:817
 #, c-format
-msgid "Global label '%s' (sheet '%s') looks like:"
-msgstr "Globaler Bezeichner '%s' (Schaltplan '%s') sieht aus wie:"
+msgid "Global label \"%s\" (sheet \"%s\") looks like:"
+msgstr ""
+
+#: eeschema/erc.cpp:818
+#, c-format
+msgid "Local label \"%s\" (sheet \"%s\") looks like:"
+msgstr ""
 
 #: eeschema/erc.cpp:826
 #, c-format
-msgid "Local label '%s' (sheet '%s') looks like:"
-msgstr "Lokaler Bezeichner '%s' (Schaltplan '%s') sieht aus wie:"
+msgid "Global label \"%s\" (sheet \"%s\")"
+msgstr ""
 
-#: eeschema/erc.cpp:834
+#: eeschema/erc.cpp:827
 #, c-format
-msgid "Global label '%s' (sheet '%s')"
-msgstr "Globaler Bezeichner '%s' (Schaltplan '%s')"
-
-#: eeschema/erc.cpp:835
-#, c-format
-msgid "Local label '%s' (sheet '%s')"
-msgstr "Lokaler Bezeichner '%s' (Schaltplan '%s')"
+msgid "Local label \"%s\" (sheet \"%s\")"
+msgstr ""
 
 #: eeschema/files-io.cpp:74
 msgid "Schematic Files"
@@ -7809,22 +7758,20 @@ msgstr "Schaltplan Dateien"
 
 #: eeschema/files-io.cpp:104
 #, c-format
-msgid "Could not save backup of file '%s'"
-msgstr "Konnte Sicherungskopie der Datei '%s' nicht speichern."
+msgid "Could not save backup of file \"%s\""
+msgstr ""
 
 #: eeschema/files-io.cpp:123
 #, c-format
 msgid ""
-"Error saving schematic file '%s'.\n"
+"Error saving schematic file \"%s\".\n"
 "%s"
 msgstr ""
-"Fehler beim Speichern des Schaltplanes '%s'.\n"
-"%s"
 
 #: eeschema/files-io.cpp:127
 #, c-format
-msgid "Failed to save '%s'"
-msgstr "Konnte Datei '%s' nicht speichern"
+msgid "Failed to save \"%s\""
+msgstr ""
 
 #: eeschema/files-io.cpp:155
 #, c-format
@@ -7835,31 +7782,35 @@ msgstr "Datei %s gespeichert."
 msgid "File write operation failed."
 msgstr "Konnte Datei nicht schreiben."
 
-#: eeschema/files-io.cpp:210 eeschema/files-io.cpp:637
+#: eeschema/files-io.cpp:210 eeschema/files-io.cpp:778
 #, c-format
-msgid "Schematic file '%s' is already open."
-msgstr "Schaltplan Datei '%s' ist bereits geöffnet."
+msgid "Schematic file \"%s\" is already open."
+msgstr ""
 
 #: eeschema/files-io.cpp:230
 #, c-format
-msgid "Schematic '%s' does not exist.  Do you wish to create it?"
-msgstr "Der Schaltplan'%s' existiert nicht. Möchten Sie diesen erstellen?"
+msgid "Schematic \"%s\" does not exist.  Do you wish to create it?"
+msgstr ""
 
-#: eeschema/files-io.cpp:305 eeschema/files-io.cpp:678
+#: eeschema/files-io.cpp:300 eeschema/files-io.cpp:450 eeschema/sheet.cpp:254
+msgid ""
+"The entire schematic could not be load.  Errors occurred attempting to load "
+"hierarchical sheet schematics."
+msgstr ""
+
+#: eeschema/files-io.cpp:314 eeschema/files-io.cpp:824
 #, c-format
 msgid ""
-"Error loading schematic file '%s'.\n"
+"Error loading schematic file \"%s\".\n"
 "%s"
 msgstr ""
-"Fehler beim Laden des Schaltplanes '%s'.\n"
-"%s"
 
-#: eeschema/files-io.cpp:309 eeschema/files-io.cpp:682
+#: eeschema/files-io.cpp:318 eeschema/files-io.cpp:828
 #, c-format
-msgid "Failed to load '%s'"
-msgstr "Konnte Datei '%s' nicht laden"
+msgid "Failed to load \"%s\""
+msgstr ""
 
-#: eeschema/files-io.cpp:324
+#: eeschema/files-io.cpp:333
 msgid ""
 "An error was found when loading the schematic that has been automatically "
 "fixed.  Please save the schematic to repair the broken file or it may not be "
@@ -7870,43 +7821,53 @@ msgstr ""
 "defekte Datei zu reparieren. Andernfalls kann passieren, dass die Datei in "
 "anderen Versionen von KiCad nicht benutzbar ist."
 
-#: eeschema/files-io.cpp:390
+#: eeschema/files-io.cpp:401
 msgid "Append Schematic"
 msgstr "Schaltplan hinzufügen"
 
-#: eeschema/files-io.cpp:513
+#: eeschema/files-io.cpp:458 eeschema/sheet.cpp:262
+#, c-format
+msgid "Error occurred loading schematic file \"%s\"."
+msgstr ""
+
+#: eeschema/files-io.cpp:461 eeschema/sheet.cpp:265
+#, c-format
+msgid "Failed to load schematic \"%s\""
+msgstr ""
+
+#: eeschema/files-io.cpp:526
+#, c-format
+msgid "An error occurred loading the symbol library table \"%s\"."
+msgstr ""
+
+#: eeschema/files-io.cpp:648
 msgid ""
-"This operation cannot be undone. Besides, take into account that "
-"hierarchical sheets will not be appended.\n"
+"This operation cannot be undone.\n"
 "\n"
 "Do you want to save the current document before proceeding?"
 msgstr ""
-"Diese Aktion kann nicht wieder rückgängig gemacht werden. Bedenken Sie, dass "
-"hierarchische Schaltpläne nicht hinzugefügt werden.\n"
-"\n"
-"Möchten Sie das gegenwärtige Dokument speichern, bevor Sie fortfahren?"
 
-#: eeschema/files-io.cpp:531
+#: eeschema/files-io.cpp:668
 msgid "Import Schematic"
 msgstr "Schaltplanimport"
 
-#: eeschema/files-io.cpp:556
+#: eeschema/files-io.cpp:699
 #, c-format
-msgid "Directory '%s' is not writable"
-msgstr "Das Verzeichnis '%s' ist nicht beschreibbar."
+msgid "Directory \"%s\" is not writable."
+msgstr ""
 
-#: eeschema/files-io.cpp:708
+#: eeschema/files-io.cpp:854
 msgid ""
 "The current schematic has been modified.  Do you wish to save the changes?"
 msgstr ""
 "Der gegenwärtige Schaltplan wurde verändert. Möchten Sie die Änderungen "
 "speichern?"
 
-#: eeschema/files-io.cpp:710 pcbnew/files.cpp:437
+#: eeschema/files-io.cpp:856 pcbnew/files.cpp:437
 msgid "Save and Load"
 msgstr "Speichern und Laden"
 
-#: eeschema/files-io.cpp:711 pcbnew/files.cpp:438
+#: eeschema/files-io.cpp:857 pcbnew/files.cpp:438
 msgid "Load Without Saving"
 msgstr "Laden ohne zu Speichern"
 
@@ -7921,46 +7882,46 @@ msgstr ""
 msgid "No more markers were found."
 msgstr "Es wurden keine weiteren Marker gefunden."
 
-#: eeschema/find.cpp:242
+#: eeschema/find.cpp:243
 msgid "component"
 msgstr "Bauteil"
 
-#: eeschema/find.cpp:246
+#: eeschema/find.cpp:247
 #, c-format
 msgid "pin %s"
 msgstr "Pin %s"
 
-#: eeschema/find.cpp:250
+#: eeschema/find.cpp:251
 #, c-format
 msgid "reference %s"
 msgstr "Referenz %s"
 
-#: eeschema/find.cpp:254
+#: eeschema/find.cpp:255
 #, c-format
 msgid "value %s"
 msgstr "Wert %s"
 
-#: eeschema/find.cpp:258
+#: eeschema/find.cpp:259
 #, c-format
 msgid "field %s"
 msgstr "Feld %s"
 
-#: eeschema/find.cpp:266
+#: eeschema/find.cpp:267
 #, c-format
 msgid "%s %s found"
 msgstr "%s %s gefunden."
 
-#: eeschema/find.cpp:271
+#: eeschema/find.cpp:272
 #, c-format
 msgid "%s found but %s not found"
 msgstr "%s gefunden, jedoch %s nicht gefunden."
 
-#: eeschema/find.cpp:277
+#: eeschema/find.cpp:278
 #, c-format
 msgid "Component %s not found"
 msgstr "Bauteil %s nicht gefunden."
 
-#: eeschema/find.cpp:510
+#: eeschema/find.cpp:511
 #, c-format
 msgid "No item found matching %s."
 msgstr "Keine Element gefunden mit %s."
@@ -7981,182 +7942,21 @@ msgstr "Unbekannt"
 msgid "History"
 msgstr "Historie"
 
-#: eeschema/getpart.cpp:164
+#: eeschema/getpart.cpp:161
 #, c-format
 msgid "Choose Symbol (%d items loaded)"
 msgstr "Symbolauswahl (%d Elemente geladen)"
 
-#: eeschema/getpart.cpp:391
+#: eeschema/getpart.cpp:395
 #, c-format
-msgid "No alternate body style found for symbol '%s' in library '%s'."
+msgid "No alternate body style found for symbol \"%s\" in library \"%s\"."
 msgstr ""
-"Keine alternative Bauteilform für Symbol %s in der Bauteilbibliothek '%s' "
-"gefunden."
 
-#: eeschema/help_common_strings.h:40 eeschema/tool_lib.cpp:151
-msgid "Undo last command"
-msgstr "Letzte Änderung rückgängig machen"
-
-#: eeschema/help_common_strings.h:41 eeschema/tool_lib.cpp:153
-msgid "Redo last command"
-msgstr "Wiederherstellen des letzten Rückgängigmachens"
-
-#: eeschema/help_common_strings.h:45
-msgid "Fit schematic sheet on screen"
-msgstr "Schaltplan an Bildschirmgöße anpassen"
-
-#: eeschema/help_common_strings.h:46
-msgid "Redraw schematic view"
-msgstr "Schaltplandarstellung neu zeichnen"
-
-#: eeschema/help_common_strings.h:48 eeschema/libeditframe.cpp:1198
-#: eeschema/schedit.cpp:605 pcbnew/edit.cpp:1514 pcbnew/modedit.cpp:977
-#: pcbnew/tool_modedit.cpp:195 pcbnew/tools/pcbnew_control.cpp:720
-msgid "Delete item"
-msgstr "Element entfernen"
-
-#: eeschema/help_common_strings.h:51
-msgid "Find components and text"
-msgstr "Bauteil und Text suchen"
-
-#: eeschema/help_common_strings.h:52
-msgid "Find and replace text in schematic items"
-msgstr "Suchen und Ersetzen von Text in Schaltplanelementen"
-
-#: eeschema/help_common_strings.h:53
-msgid "Place component"
-msgstr "Bauteil hinzufügen"
-
-#: eeschema/help_common_strings.h:54
-msgid "Place power port"
-msgstr "Spannungsquelle hinzufügen"
-
-#: eeschema/help_common_strings.h:55
-msgid "Place wire"
-msgstr "Elektr. Verbindung hinzufügen"
-
-#: eeschema/help_common_strings.h:56
-msgid "Place bus"
-msgstr "Einen Bus verlegen"
-
-#: eeschema/help_common_strings.h:57
-msgid "Place wire to bus entry"
-msgstr "Elektr. Verbindung an Buseingang führen"
-
-#: eeschema/help_common_strings.h:58
-msgid "Place bus to bus entry"
-msgstr "Buseingang zu Buseingang führen"
-
-#: eeschema/help_common_strings.h:59
-msgid "Place not-connected flag"
-msgstr "'Keine-Verbindung' Symbol hinzufügen"
-
-#: eeschema/help_common_strings.h:61
-msgid "Place net name - local label"
-msgstr "Netznamen - lokales Label hinzufügen"
-
-#: eeschema/help_common_strings.h:64
-msgid ""
-"Place global label.\n"
-"Warning: inside global hierarchy , all global labels with same name are "
-"connected"
-msgstr ""
-"Ein globales Label hinzufügen.\n"
-"Warnung: Alle globalen Label mit dem selben Namen sind in der gesamten "
-"Hierarchie miteinander verbunden."
-
-#: eeschema/help_common_strings.h:66
-msgid ""
-"Place a hierarchical label. Label will be seen as a hierarchical pin in the "
-"sheet symbol"
-msgstr ""
-"Ein hierarchisches Label hinzufügen. Dieses Label wird als ein Pin am "
-"Schaltungssymbol betrachtet."
-
-#: eeschema/help_common_strings.h:68
-msgid "Place junction"
-msgstr "Knotenpunkt hinzufügen"
-
-#: eeschema/help_common_strings.h:69
-msgid "Create hierarchical sheet"
-msgstr "Einen hierarchischen Schaltplan erstellen"
-
-#: eeschema/help_common_strings.h:71
-msgid ""
-"Place hierarchical pin imported from the corresponding hierarchical label"
-msgstr ""
-"Hierarchischen Pin hinzufügen, importiert aus entsprechendem hierarchischen "
-"Label."
-
-#: eeschema/help_common_strings.h:72
-msgid "Place hierarchical pin in sheet"
-msgstr "Hierarchischen Pin dem Schaltplan hinzufügen"
-
-#: eeschema/help_common_strings.h:73
-msgid "Place graphic lines or polygons"
-msgstr "Grafische Linien oder Polygone hinzufügen"
-
-#: eeschema/help_common_strings.h:74
-msgid "Place text"
-msgstr "Text hinzufügen"
-
-#: eeschema/help_common_strings.h:76
-msgid "Annotate schematic components"
-msgstr "Annotation im Schaltplan durchführen"
-
-#: eeschema/help_common_strings.h:77
-msgid "Library Editor - Create/edit components"
-msgstr "Bibliothekseditor - Bauteile erstellen oder bearbeiten"
-
-#: eeschema/help_common_strings.h:78
-msgid "Library Browser - Browse components"
-msgstr "Bibliotheksbrowser - Bauteilbestand durchsuchen"
-
-#: eeschema/help_common_strings.h:79
-msgid "Generate bill of materials"
-msgstr "Stückliste (BOM) erstellen"
-
-#: eeschema/help_common_strings.h:81
-msgid ""
-"Back-import component footprint association fields from the .cmp back import "
-"file created by Pcbnew"
-msgstr ""
-"Rückimport von Bauteil Footprintfeldern durch eine in Pcbnew erstellte "
-"CvPvb .cmp Datei."
-
-#: eeschema/help_common_strings.h:84
-msgid "Add pins to component"
-msgstr "Pins dem Bauteil hinzufügen"
-
-#: eeschema/help_common_strings.h:85
-msgid "Add text to component body"
-msgstr "Text dem Bauteil hinzufügen"
-
-#: eeschema/help_common_strings.h:86
-msgid "Add graphic rectangle to component body"
-msgstr "Rechteck hinzufügen"
-
-#: eeschema/help_common_strings.h:87
-msgid "Add circles to component body"
-msgstr "Kreis hinzufügen"
-
-#: eeschema/help_common_strings.h:88
-msgid "Add arcs to component body"
-msgstr "Bögen hinzufügen"
-
-#: eeschema/help_common_strings.h:89
-msgid "Add lines and polygons to component body"
-msgstr "Linien und Polygone hinzufügen"
-
-#: eeschema/help_common_strings.h:90 eeschema/tool_sch.cpp:258
-msgid "Add bitmap image"
-msgstr "Bitmap Grafik hinzufügen"
-
-#: eeschema/hierarch.cpp:160
+#: eeschema/hierarch.cpp:149
 msgid "Navigator"
 msgstr "Hierarchie"
 
-#: eeschema/hierarch.cpp:171
+#: eeschema/hierarch.cpp:161
 msgid "Root"
 msgstr "Hauptschaltplan"
 
@@ -8318,7 +8118,8 @@ msgstr "Bauteil oder Label duplizieren"
 msgid "Drag Item"
 msgstr "Element ziehen"
 
-#: eeschema/hotkeys.cpp:196 eeschema/onrightclick.cpp:865
+#: eeschema/hotkeys.cpp:196 eeschema/libedit_onrightclick.cpp:343
+#: eeschema/onrightclick.cpp:865
 msgid "Copy Block"
 msgstr "Gruppe kopieren"
 
@@ -8326,7 +8127,8 @@ msgstr "Gruppe kopieren"
 msgid "Paste Block"
 msgstr "Gruppe einfügen"
 
-#: eeschema/hotkeys.cpp:198 eeschema/onrightclick.cpp:862
+#: eeschema/hotkeys.cpp:198 eeschema/libedit_onrightclick.cpp:340
+#: eeschema/onrightclick.cpp:862
 msgid "Cut Block"
 msgstr "Gruppe ausschneiden"
 
@@ -8361,24 +8163,24 @@ msgid "Find Next DRC Marker"
 msgstr "Finde nächsten DRC Marker"
 
 #: eeschema/hotkeys.cpp:216
-msgid "Load Component"
-msgstr "Bauteil laden"
-
-#: eeschema/hotkeys.cpp:217
 msgid "Create Pin"
 msgstr "Anschluss erstellen"
 
-#: eeschema/hotkeys.cpp:218
+#: eeschema/hotkeys.cpp:217
 msgid "Repeat Pin"
 msgstr "Anschluss wiederholen"
 
-#: eeschema/hotkeys.cpp:219
+#: eeschema/hotkeys.cpp:218
 msgid "Move Library Item"
 msgstr "Bibliothekselement bewegen"
 
-#: eeschema/hotkeys.cpp:222
+#: eeschema/hotkeys.cpp:221
 msgid "Save Library"
 msgstr "Bibliothek speichern"
+
+#: eeschema/hotkeys.cpp:222
+msgid "Save Part"
+msgstr ""
 
 #: eeschema/hotkeys.cpp:223
 msgid "Save Schematic"
@@ -8392,8 +8194,8 @@ msgstr "Schaltplan laden"
 msgid "Autoplace Fields"
 msgstr "Felder autoplatzieren"
 
-#: eeschema/hotkeys.cpp:230 eeschema/menubar.cpp:464
-#: pcbnew/dialogs/dialog_update_pcb_base.h:54 pcbnew/menubar_pcbframe.cpp:376
+#: eeschema/hotkeys.cpp:230 eeschema/menubar.cpp:471
+#: pcbnew/menubar_pcbframe.cpp:376 pcbnew/dialogs/dialog_update_pcb_base.h:54
 msgid "Update PCB from Schematic"
 msgstr "Aktualisiere PCB aus dem Schaltplan"
 
@@ -8401,40 +8203,35 @@ msgstr "Aktualisiere PCB aus dem Schaltplan"
 msgid "Highlight Connection"
 msgstr "Netz hervorheben"
 
-#: eeschema/hotkeys.cpp:345 pagelayout_editor/hotkeys.cpp:123
+#: eeschema/hotkeys.cpp:348 pagelayout_editor/hotkeys.cpp:123
 #: pcbnew/dialogs/dialog_track_via_properties_base.cpp:21
 #: pcbnew/hotkeys.cpp:333
 msgid "Common"
 msgstr "Allgemein"
 
-#: eeschema/hotkeys.cpp:346
+#: eeschema/hotkeys.cpp:349
 msgid "Schematic Editor"
 msgstr "Schaltplan Editor"
 
-#: eeschema/hotkeys.cpp:347 eeschema/libeditframe.cpp:188
+#: eeschema/hotkeys.cpp:350 eeschema/libeditframe.cpp:204
 msgid "Library Editor"
 msgstr "Bibliothekseditor"
 
-#: eeschema/hotkeys.cpp:787
+#: eeschema/hotkeys.cpp:789
 msgid "Add Pin"
 msgstr "Pin hinzufügen"
 
-#: eeschema/lib_arc.cpp:96 gerbview/class_gerber_draw_item.cpp:170
-#: pcbnew/class_board_item.cpp:44 pcbnew/class_drawsegment.cpp:352
+#: eeschema/lib_arc.cpp:95 gerbview/class_gerber_draw_item.cpp:236
+#: pcbnew/class_board_item.cpp:45 pcbnew/class_drawsegment.cpp:370
 #: pcbnew/dialogs/dialog_pad_basicshapes_properties.cpp:93
 #: pcbnew/dialogs/dialog_pad_properties.cpp:743
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1832
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1849
 msgid "Arc"
 msgstr "Kreisbogen"
 
-#: eeschema/lib_arc.cpp:137
-#, c-format
-msgid "Arc only had %d parameters of the required 8"
-msgstr "Der Kreisbogen hatte nur %d Parameter von den benötigten 8."
-
-#: eeschema/lib_arc.cpp:566 eeschema/lib_bezier.cpp:410
-#: eeschema/lib_circle.cpp:277 eeschema/lib_polyline.cpp:406
-#: eeschema/lib_rectangle.cpp:257 eeschema/lib_text.cpp:442
+#: eeschema/lib_arc.cpp:492 eeschema/lib_bezier.cpp:333
+#: eeschema/lib_circle.cpp:243 eeschema/lib_polyline.cpp:326
+#: eeschema/lib_rectangle.cpp:222 eeschema/lib_text.cpp:303
 #: pcb_calculator/transline_ident.cpp:186
 #: pcb_calculator/transline_ident.cpp:216
 #: pcb_calculator/transline_ident.cpp:248
@@ -8444,58 +8241,33 @@ msgid "Line Width"
 msgstr "Leiterbreite"
 
 # Einen Bereich (gezeichnete Elemente) umgebendes Rechteck.
-#: eeschema/lib_arc.cpp:571 eeschema/lib_bezier.cpp:415
-#: eeschema/lib_circle.cpp:285 eeschema/lib_polyline.cpp:411
+#: eeschema/lib_arc.cpp:497 eeschema/lib_bezier.cpp:338
+#: eeschema/lib_circle.cpp:251 eeschema/lib_polyline.cpp:331
 msgid "Bounding Box"
 msgstr "Darstellungsbereich"
 
-#: eeschema/lib_arc.cpp:577
+#: eeschema/lib_arc.cpp:503
 #, c-format
 msgid "Arc center (%s, %s), radius %s"
 msgstr "Kreisbogenmitte (%s, %s), Radius %s"
 
-#: eeschema/lib_bezier.cpp:51
+#: eeschema/lib_bezier.cpp:50
 msgid "Bezier"
 msgstr "Bezierkurve"
 
-#: eeschema/lib_bezier.cpp:80
-#, c-format
-msgid "Bezier only had %d parameters of the required 4"
-msgstr "Die Bezierkurve hatte nur %d Parameter von den benötigten 4"
-
-#: eeschema/lib_bezier.cpp:86
-#, c-format
-msgid "Bezier count parameter %d is invalid"
-msgstr "Der Zählparameter %d der Bezierkurve ist ungültig"
-
-#: eeschema/lib_bezier.cpp:101
-#, c-format
-msgid "Bezier point %d X position not defined"
-msgstr "Die X-Position von Punkt %d der Bezierkurve ist nicht definiert"
-
-#: eeschema/lib_bezier.cpp:109
-#, c-format
-msgid "Bezier point %d Y position not defined"
-msgstr "Die Y-Position von Punkt %d der Bezierkurve ist nicht definiert"
-
-#: eeschema/lib_circle.cpp:54 gerbview/class_gerber_draw_item.cpp:173
-#: pcbnew/class_board_item.cpp:45 pcbnew/class_drawsegment.cpp:348
+#: eeschema/lib_circle.cpp:53 gerbview/class_gerber_draw_item.cpp:239
+#: pcbnew/class_board_item.cpp:46 pcbnew/class_drawsegment.cpp:366
 #: pcbnew/class_pad.cpp:1134
 #: pcbnew/dialogs/dialog_pad_basicshapes_properties.cpp:108
 msgid "Circle"
 msgstr "Kreis"
 
-#: eeschema/lib_circle.cpp:77
-#, c-format
-msgid "Circle only had %d parameters of the required 6"
-msgstr "Der Kreis hatte nur %d Parameter von den benötigten 6."
-
-#: eeschema/lib_circle.cpp:280
+#: eeschema/lib_circle.cpp:246
 #: pcbnew/dialogs/dialog_pad_basicshapes_properties.cpp:124
 msgid "Radius"
 msgstr "Radius"
 
-#: eeschema/lib_circle.cpp:291
+#: eeschema/lib_circle.cpp:257
 #, c-format
 msgid "Circle center (%s, %s), radius %s"
 msgstr "Kreismitte (%s, %s), Radius %s"
@@ -8516,175 +8288,149 @@ msgstr "Ja"
 msgid "Converted"
 msgstr "Konvertiert"
 
-#: eeschema/lib_export.cpp:52
+#: eeschema/lib_export.cpp:60 eeschema/symbedit.cpp:66
 msgid "Import Symbol"
 msgstr "Symbol importieren"
 
-#: eeschema/lib_export.cpp:72
+#: eeschema/lib_export.cpp:80 eeschema/symbedit.cpp:92
 #, c-format
-msgid "Cannot import symbol library '%s'."
-msgstr "Symbolbibliothek '%s' kann nicht importiert werden."
+msgid "Cannot import symbol library \"%s\"."
+msgstr ""
 
-#: eeschema/lib_export.cpp:79
+#: eeschema/lib_export.cpp:87 eeschema/symbedit.cpp:99
 #, c-format
-msgid "Symbol library file '%s' is empty."
-msgstr "Symbolbibliothek '%s' ist leer."
+msgid "Symbol library file \"%s\" is empty."
+msgstr ""
 
-#: eeschema/lib_export.cpp:108
+#: eeschema/lib_export.cpp:97
+#, c-format
+msgid "Symbol \"%s\" already exists in library \"%s\"."
+msgstr ""
+
+#: eeschema/lib_export.cpp:114
 msgid "There is no symbol selected to save."
 msgstr "Es wurde kein Symbol zum Speichern ausgewählt."
 
-#: eeschema/lib_export.cpp:117
-msgid "New Symbol Library"
-msgstr "Neue Symbolbibliothek"
-
-#: eeschema/lib_export.cpp:117
+#: eeschema/lib_export.cpp:123 eeschema/symbedit.cpp:171
 msgid "Export Symbol"
 msgstr "Symbol exportieren"
 
-#: eeschema/lib_export.cpp:143
+#: eeschema/lib_export.cpp:147
 #, c-format
-msgid "Error occurred attempting to load symbol library file '%s'"
+msgid "Error occurred attempting to load symbol library file \"%s\""
 msgstr ""
-"Bei dem Versuch die Symbolbibliothek '%s' zu laden ist ein Fehler "
-"aufgetreten."
 
-#: eeschema/lib_export.cpp:151
+#: eeschema/lib_export.cpp:155
 #, c-format
-msgid "Symbol '%s' already exists. Overwrite it?"
-msgstr "Das Symbol %s existiert bereits, überschreiben?"
+msgid "Symbol \"%s\" already exists. Overwrite it?"
+msgstr ""
 
-#: eeschema/lib_export.cpp:160
+#: eeschema/lib_export.cpp:164
 #, c-format
-msgid "Write permissions are requured to save library '%s'."
-msgstr "Keine Schreibberechtigung zum Speichern der Bibliothek <%s>."
+msgid "Write permissions are required to save library \"%s\"."
+msgstr ""
 
-#: eeschema/lib_export.cpp:174
+#: eeschema/lib_export.cpp:178
 msgid "Failed to create symbol library file "
 msgstr "Konnte die Symbolbibliothek nicht erstellen"
 
-#: eeschema/lib_export.cpp:176
+#: eeschema/lib_export.cpp:180
 #, c-format
-msgid "Error creating symbol library '%s'"
-msgstr "Ein Fehler ist aufgetreten beim Erstellen der Bibliothek '%s'."
-
-#: eeschema/lib_export.cpp:184
-msgid ""
-"This library will not be available until it is added to the symbol library "
-"table."
+msgid "Error creating symbol library \"%s\""
 msgstr ""
-"Diese Bibliothek steht erst zur Verfügung wenn diese zur Symbolbibliothek "
-"hinzugefügt wurden ist."
 
-#: eeschema/lib_export.cpp:190
+#: eeschema/lib_export.cpp:188
 #, c-format
-msgid "Symbol '%s' saved in library '%s'"
-msgstr "Symbol '%s' in Bibliothek '%s' gespeichert."
+msgid "Symbol \"%s\" saved in library \"%s\""
+msgstr ""
 
-#: eeschema/lib_field.cpp:643
+#: eeschema/lib_field.cpp:456 eeschema/sch_component.cpp:1461
+#: eeschema/template_fieldnames.cpp:45 pcbnew/class_edge_mod.cpp:248
+#: pcbnew/class_module.cpp:587 pcbnew/class_pad.cpp:693
+#: pcbnew/class_text_mod.cpp:366 pcbnew/loadcmp.cpp:445 pcbnew/loadcmp.cpp:509
+#: eeschema/bom_table_column.h:35
+msgid "Footprint"
+msgstr "Footprint"
+
+#: eeschema/lib_field.cpp:463 eeschema/libedit.cpp:666
+#: eeschema/template_fieldnames.cpp:48 eeschema/bom_table_column.h:37
+msgid "Datasheet"
+msgstr "Datenblatt"
+
+#: eeschema/lib_field.cpp:472
 #, c-format
 msgid "Field%d"
 msgstr "Feld%d"
 
-#: eeschema/lib_field.cpp:706
+#: eeschema/lib_field.cpp:535
 #, c-format
 msgid "Field %s %s"
 msgstr "Feld %s %s"
 
-#: eeschema/lib_field.cpp:789 pcbnew/class_drawsegment.cpp:385
+#: eeschema/lib_field.cpp:618 pcbnew/class_drawsegment.cpp:403
 #: pcbnew/class_pad.cpp:707 pcbnew/class_pcb_text.cpp:149
-#: pcbnew/class_text_mod.cpp:390 pcbnew/class_track.cpp:1166
+#: pcbnew/class_text_mod.cpp:398 pcbnew/class_track.cpp:1166
 #: pcbnew/class_track.cpp:1193 pcbnew/dialogs/dialog_design_rules_base.cpp:354
-#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:52
+#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:53
 msgid "Width"
 msgstr "Breite"
 
-#: eeschema/lib_field.cpp:792 pcbnew/class_pad.cpp:710
-#: pcbnew/class_pcb_text.cpp:152 pcbnew/class_text_mod.cpp:393
-#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:59
+#: eeschema/lib_field.cpp:621 pcbnew/class_pad.cpp:710
+#: pcbnew/class_pcb_text.cpp:152 pcbnew/class_text_mod.cpp:401
+#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:60
 msgid "Height"
 msgstr "Höhe"
 
-#: eeschema/lib_pin.cpp:156
+#: eeschema/lib_pin.cpp:157
 #: eeschema/widgets/widget_eeschema_color_config.cpp:73
 msgid "Pin"
 msgstr "Pin"
 
-#: eeschema/lib_pin.cpp:2055 pcbnew/class_drawsegment.cpp:366
+#: eeschema/lib_pin.cpp:1724 pcbnew/class_drawsegment.cpp:384
 #: pcbnew/class_track.cpp:1054
 msgid "Length"
 msgstr "Länge"
 
-#: eeschema/lib_pin.cpp:2058 eeschema/onrightclick.cpp:388
-#: eeschema/onrightclick.cpp:796 eeschema/sch_text.cpp:779
-#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:120
+#: eeschema/lib_pin.cpp:1727 eeschema/onrightclick.cpp:388
+#: eeschema/onrightclick.cpp:796 eeschema/sch_text.cpp:661
+#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:121
 msgid "Orientation"
 msgstr "Ausrichtung"
 
-#: eeschema/lib_pin.cpp:2071 eeschema/lib_pin.cpp:2090
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1048
+#: eeschema/lib_pin.cpp:1740 eeschema/lib_pin.cpp:1759
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1050
 msgid "Pos X"
 msgstr "Pos X"
 
-#: eeschema/lib_pin.cpp:2074 eeschema/lib_pin.cpp:2093
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1049
+#: eeschema/lib_pin.cpp:1743 eeschema/lib_pin.cpp:1762
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1051
 msgid "Pos Y"
 msgstr "Pos Y"
 
-#: eeschema/lib_pin.cpp:2294
+#: eeschema/lib_pin.cpp:1963
 #, c-format
 msgid "Pin %s, %s, %s"
 msgstr "Pin %s, %s, %s"
 
-#: eeschema/lib_polyline.cpp:52
+#: eeschema/lib_polyline.cpp:51
 msgid "PolyLine"
 msgstr "Linienzug"
 
-#: eeschema/lib_polyline.cpp:87
-#, c-format
-msgid "Polyline only had %d parameters of the required 4"
-msgstr "Der Linienzug hatte nur %d Parameter von den benötigten 4."
-
-#: eeschema/lib_polyline.cpp:93
-#, c-format
-msgid "Polyline count parameter %d is invalid"
-msgstr "Der Zählerwert %d des Linienzugs ist ungültig."
-
-#: eeschema/lib_polyline.cpp:108
-#, c-format
-msgid "Polyline point %d X position not defined"
-msgstr "Die X-Position von Punkt %d des Linienzugs ist nicht definiert."
-
-#: eeschema/lib_polyline.cpp:116
-#, c-format
-msgid "Polyline point %d Y position not defined"
-msgstr "Die Y-Position von Punkt %d des Linienzugs ist nicht definiert."
-
-#: eeschema/lib_polyline.cpp:417
+#: eeschema/lib_polyline.cpp:337
 #, c-format
 msgid "Polyline at (%s, %s) with %d points"
 msgstr "Linienzug bei (%s, %s) mit %d Punkten"
 
-#: eeschema/lib_rectangle.cpp:52
+#: eeschema/lib_rectangle.cpp:51
 msgid "Rectangle"
 msgstr "Rechteck"
 
-#: eeschema/lib_rectangle.cpp:79
-#, c-format
-msgid "Rectangle only had %d parameters of the required 7"
-msgstr "Das Rechteck hatte nur %d Parameter von den benötigten 7."
-
-#: eeschema/lib_rectangle.cpp:333
+#: eeschema/lib_rectangle.cpp:298
 #, c-format
 msgid "Rectangle from (%s, %s) to (%s, %s)"
 msgstr "Rechteck von (%s, %s) nach (%s, %s)"
 
-#: eeschema/lib_text.cpp:138
-#, c-format
-msgid "Text only had %d parameters of the required 8"
-msgstr "Der Text hatte nur %d Parameter von den benötigten 8."
-
-#: eeschema/lib_text.cpp:504 eeschema/sch_text.cpp:617
+#: eeschema/lib_text.cpp:365 eeschema/sch_text.cpp:499
 #, c-format
 msgid "Graphic Text %s"
 msgstr "Grafischer Text %s"
@@ -8698,35 +8444,35 @@ msgstr "Konnte das Symbol %s nicht zur Bauteilbibliothek hinzufügen."
 msgid "Unexpected exception occurred."
 msgstr "Ein nicht erwarteter Fehler ist aufgetreten."
 
-#: eeschema/libarch.cpp:122
+#: eeschema/libarch.cpp:127
 #, c-format
 msgid "Symbol %s not found in any library or cache."
 msgstr ""
 "Symbol '%s' konnte in keiner Bibliothek oder dem Cache gefunden werden."
 
-#: eeschema/libarch.cpp:138
+#: eeschema/libarch.cpp:143
 #, c-format
 msgid "Errors occurred creating symbol library %s."
 msgstr "Ein Fehler ist aufgetreten beim Erstellen der Symbolbibliothek '%s'."
 
-#: eeschema/libarch.cpp:150
+#: eeschema/libarch.cpp:155
 #, c-format
-msgid "Failed to save symbol library file '%s'"
-msgstr "Konnte die Bauteilbibliothek '%s' nicht speichern."
+msgid "Failed to save symbol library file \"%s\""
+msgstr ""
 
-#: eeschema/libedit.cpp:59
+#: eeschema/libedit.cpp:62
 msgid "Symbol Library Editor - "
 msgstr "Symbolbibliothekseditor - "
 
-#: eeschema/libedit.cpp:68
+#: eeschema/libedit.cpp:71
 msgid "[Read Only]"
 msgstr " [Nur lesbar]"
 
-#: eeschema/libedit.cpp:71 pcbnew/modview_frame.cpp:747
+#: eeschema/libedit.cpp:74 pcbnew/modview_frame.cpp:747
 msgid "no library selected"
 msgstr "Keine Bibliothek ausgewählt"
 
-#: eeschema/libedit.cpp:94 eeschema/libedit.cpp:148
+#: eeschema/libedit.cpp:97
 msgid ""
 "The current symbol is not saved.\n"
 "\n"
@@ -8736,138 +8482,103 @@ msgstr ""
 "\n"
 "Möchten Sie die Änderungen verwerfen?"
 
-#: eeschema/libedit.cpp:115 eeschema/schframe.cpp:1244 eeschema/selpart.cpp:63
+#: eeschema/libedit.cpp:118 eeschema/schframe.cpp:1240 eeschema/selpart.cpp:63
 #, c-format
-msgid "Error occurred loading symbol '%s' from library '%s'."
+msgid "Error occurred loading symbol \"%s\" from library \"%s\"."
 msgstr ""
-"Bei dem Versuch das Symbol '%s' aus der Bibliothek '%s' zu laden ist ein "
-"Fehler aufgetreten."
 
-#: eeschema/libedit.cpp:303
-msgid "No library specified."
-msgstr "Keine Bibliothek angegeben."
-
-#: eeschema/libedit.cpp:307
-msgid "Include current symbol changes?"
-msgstr "Möchten Sie die Symboländerungen übernehmen?"
-
-#: eeschema/libedit.cpp:320
-msgid "Symbol Library Name"
-msgstr "Name Symbolbibliothek"
-
-#: eeschema/libedit.cpp:340
-#, c-format
-msgid "Modify symbol library file '%s' ?"
-msgstr "Möchten Sie die existierende Symbolbibliothek '%s' überschreiben?"
-
-#: eeschema/libedit.cpp:366
-msgid "Failed to rename old symbol library to file "
-msgstr "Konnte die alte Symbolbibliothek nicht umbenennen."
-
-#: eeschema/libedit.cpp:387
-msgid "Failed to save old library document to file "
-msgstr "Konnte die alte Symbol Dokumentationsbibliothek nicht speichern."
-
-#: eeschema/libedit.cpp:401
-msgid "Failed to copy symbol library file "
-msgstr "Konnte die Symbolbibliothek nicht kopieren "
-
-#: eeschema/libedit.cpp:410
-msgid "Failed to copy symbol library document file "
-msgstr "Konnte die Symbol Dokumentationsbibliothek nicht speichern "
-
-#: eeschema/libedit.cpp:428
-#, c-format
-msgid "Failed to save changes to symbol library file '%s'"
-msgstr "Konnte die Änderungen an der Symbolbibliothek '%s' nicht speichern."
-
-#: eeschema/libedit.cpp:437
-#, c-format
-msgid "Symbol library file '%s' saved"
-msgstr "Symbolbibliothek '%s' gespeichert."
-
-#: eeschema/libedit.cpp:439
-#, c-format
-msgid "Symbol library documentation file '%s' saved"
-msgstr "Symbol Dokumentationsdatei '%s' gespeichert."
-
-#: eeschema/libedit.cpp:464 eeschema/viewlibs.cpp:226
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:50
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:126
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:151
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:195
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:325
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:501
-#: pcbnew/dialogs/dialog_plot_base.cpp:141
-msgid "None"
-msgstr "Keine"
-
-#: eeschema/libedit.cpp:480 eeschema/onrightclick.cpp:456
-msgid "Convert"
-msgstr "Umwandeln"
-
-#: eeschema/libedit.cpp:484
-#: eeschema/widgets/widget_eeschema_color_config.cpp:71
-msgid "Body"
-msgstr "Gehäuse"
-
-#: eeschema/libedit.cpp:487
-msgid "Power Symbol"
-msgstr "Spannungsquellensymbol"
-
-#: eeschema/libedit.cpp:493 eeschema/viewlibs.cpp:242
-msgid "Key words"
-msgstr "Schlüsselwörter"
-
-#: eeschema/libedit.cpp:520
-msgid "Please select a symbol library."
-msgstr "Wähle bitte eine Symbolbibliothek."
-
-#: eeschema/libedit.cpp:533
-#, c-format
-msgid "Delete Symbol (%u items loaded)"
-msgstr "Symbol löschen (%u Elemente geladen)"
-
-#: eeschema/libedit.cpp:554
-#, c-format
-msgid "Delete symbol '%s' from library '%s'?"
-msgstr "Möchten Sie das Symbol '%s' aus Bibliothek '%s' entfernen?"
-
-#: eeschema/libedit.cpp:573
+#: eeschema/libedit.cpp:257
 msgid ""
-"The symbol being deleted has been modified. All changes will be lost. "
-"Discard changes?"
-msgstr ""
-"Das zu löschende Symbol wurde modifiziert. Alle Änderungen werden somit "
-"verloren gehen.\n"
-"Möchten Sie die Änderungen verwerfen?"
-
-#: eeschema/libedit.cpp:585
-#, c-format
-msgid "Error occurred deleting symbol '%s' from library '%s'"
-msgstr ""
-"Ein Fehler ist aufgetreten beim Löschen des Symbols '%s' in der Bibliothek "
-"'%s'."
-
-#: eeschema/libedit.cpp:602
-msgid ""
-"All changes to the current symbol will be lost!\n"
+"The revert operation cannot be undone!\n"
 "\n"
-"Clear the current symbol from the screen?"
+"Revert changes?"
 msgstr ""
-"Alle Änderungen werden am gegenwärtigen Symbol verloren gehen!\n"
-"\n"
-"Soll das Bauteil wirklich entfernt werden?"
 
-#: eeschema/libedit.cpp:621
+#: eeschema/libedit.cpp:292
 msgid "This new symbol has no name and cannot be created."
 msgstr ""
 "Dieses neue Symbol besitzt keinen Namen und kann somit nicht erstellt werden."
 
-#: eeschema/libedit.cpp:633
+#: eeschema/libedit.cpp:302
 #, c-format
-msgid "Symbol '%s' already exists in library '%s'"
-msgstr "Symbol '%s' existiert bereits in der Bibliothek '%s'."
+msgid "Symbol \"%s\" already exists in library \"%s\""
+msgstr ""
+
+#: eeschema/libedit.cpp:480
+#, c-format
+msgid "Part name \"%s\" not found in library \"%s\""
+msgstr ""
+
+#: eeschema/libedit.cpp:504
+msgid "No library specified."
+msgstr "Keine Bibliothek angegeben."
+
+#: eeschema/libedit.cpp:521
+#, c-format
+msgid "Save Library \"%s\" As..."
+msgstr ""
+
+#: eeschema/libedit.cpp:559
+#, c-format
+msgid "Failed to save changes to symbol library file \"%s\""
+msgstr ""
+
+#: eeschema/libedit.cpp:561
+msgid "Error saving library"
+msgstr ""
+
+#: eeschema/libedit.cpp:568
+#, c-format
+msgid "Symbol library file \"%s\" saved"
+msgstr ""
+
+#: eeschema/libedit.cpp:570
+#, c-format
+msgid "Symbol library documentation file \"%s\" saved"
+msgstr ""
+
+#: eeschema/libedit.cpp:601
+msgid "Save Libraries"
+msgstr ""
+
+#: eeschema/libedit.cpp:602
+msgid "Select libraries to save before closing"
+msgstr ""
+
+#: eeschema/libedit.cpp:603
+msgid ""
+"Some libraries could not be saved to their original files.\n"
+"\n"
+"Do you want to save them to a new file?"
+msgstr ""
+
+#: eeschema/libedit.cpp:636 eeschema/viewlibs.cpp:226
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:50
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:128
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:153
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:197
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:327
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:503
+#: pcbnew/dialogs/dialog_plot_base.cpp:141
+msgid "None"
+msgstr "Keine"
+
+#: eeschema/libedit.cpp:652 eeschema/onrightclick.cpp:456
+msgid "Convert"
+msgstr "Umwandeln"
+
+#: eeschema/libedit.cpp:656
+#: eeschema/widgets/widget_eeschema_color_config.cpp:71
+msgid "Body"
+msgstr "Gehäuse"
+
+#: eeschema/libedit.cpp:659
+msgid "Power Symbol"
+msgstr "Spannungsquellensymbol"
+
+#: eeschema/libedit.cpp:665 eeschema/viewlibs.cpp:242
+msgid "Key words"
+msgstr "Schlüsselwörter"
 
 #: eeschema/libedit_onrightclick.cpp:88 eeschema/onrightclick.cpp:162
 #: gerbview/onrightclick.cpp:63 pagelayout_editor/onrightclick.cpp:69
@@ -8939,7 +8650,7 @@ msgstr "Linienende"
 msgid "Edit Line Options"
 msgstr "Linien Optionen editieren"
 
-#: eeschema/libedit_onrightclick.cpp:303
+#: eeschema/libedit_onrightclick.cpp:303 eeschema/libeditframe.cpp:1641
 msgid "Global"
 msgstr "Global"
 
@@ -8987,19 +8698,19 @@ msgstr "Gruppe platzieren"
 msgid "Select Items"
 msgstr "Elemente auswählen"
 
-#: eeschema/libedit_onrightclick.cpp:340 eeschema/onrightclick.cpp:868
+#: eeschema/libedit_onrightclick.cpp:346 eeschema/onrightclick.cpp:868
 msgid "Duplicate Block"
 msgstr "Gruppe duplizieren"
 
-#: eeschema/libedit_onrightclick.cpp:341
+#: eeschema/libedit_onrightclick.cpp:348
 msgid "Flip Block Horizonal"
 msgstr "Gruppe Horizontal drehen"
 
-#: eeschema/libedit_onrightclick.cpp:344 eeschema/onrightclick.cpp:875
+#: eeschema/libedit_onrightclick.cpp:351 eeschema/onrightclick.cpp:875
 msgid "Flip Block Vertical"
 msgstr "Gruppe Vertikal drehen"
 
-#: eeschema/libedit_onrightclick.cpp:347 eeschema/onrightclick.cpp:378
+#: eeschema/libedit_onrightclick.cpp:354 eeschema/onrightclick.cpp:378
 #: eeschema/onrightclick.cpp:587 eeschema/onrightclick.cpp:621
 #: eeschema/onrightclick.cpp:787 eeschema/onrightclick.cpp:913
 #: pcbnew/modedit_onclick.cpp:294 pcbnew/onrightclick.cpp:494
@@ -9007,7 +8718,7 @@ msgstr "Gruppe Vertikal drehen"
 msgid "Rotate Counterclockwise"
 msgstr "Rotieren gegen den Uhrzeigersinn"
 
-#: eeschema/libedit_onrightclick.cpp:350 eeschema/onrightclick.cpp:873
+#: eeschema/libedit_onrightclick.cpp:357 eeschema/onrightclick.cpp:873
 msgid "Delete Block"
 msgstr "Gruppe entfernen"
 
@@ -9022,215 +8733,177 @@ msgstr "Dateiname:"
 
 #: eeschema/libedit_plot_component.cpp:137
 #, c-format
-msgid "Can't save file <%s>"
-msgstr "Konnte Datei <%s> nicht speichern."
-
-#: eeschema/libeditframe.cpp:328
-msgid "Save the changes in the library before closing?"
+msgid "Can't save file \"%s\""
 msgstr ""
-"Möchten Sie die Änderungen an der Bibliothek vor dem Beenden speichern?"
 
-#: eeschema/libeditframe.cpp:443 eeschema/onrightclick.cpp:467
+#: eeschema/libeditframe.cpp:456 eeschema/onrightclick.cpp:467
 #, c-format
 msgid "Unit %s"
 msgstr "Einheit %s"
 
-#: eeschema/libeditframe.cpp:685
-msgid "No part to save."
-msgstr "Kein Bauteil zum Speichern vorhanden"
-
-#: eeschema/libeditframe.cpp:698
-msgid "No valid library specified."
-msgstr "Keine gültige Bibliothek angegeben."
-
-#: eeschema/libeditframe.cpp:709
-#, c-format
-msgid "Unexpected error occured saving symbol '%s' to symbol library '%s'."
+#: eeschema/libeditframe.cpp:531
+msgid "Save [Read Only]"
 msgstr ""
-"Bei dem Versuch das Bauteil '%s' in die Symbolbibliothek '%s' zu speichern "
-"ist ein Fehler aufgetreten."
 
-#: eeschema/libeditframe.cpp:1141
+#: eeschema/libeditframe.cpp:531 eeschema/widgets/cmp_tree_pane.cpp:64
+#: eeschema/widgets/tuner_slider_base.cpp:66 pagelayout_editor/hotkeys.cpp:96
+msgid "Save"
+msgstr "Speichern"
+
+#: eeschema/libeditframe.cpp:581
+msgid "Save library [Read Only]"
+msgstr ""
+
+#: eeschema/libeditframe.cpp:581 eeschema/widgets/cmp_tree_pane.cpp:52
+msgid "Save library"
+msgstr ""
+
+#: eeschema/libeditframe.cpp:1183
 msgid "Add pin"
 msgstr "Pin hinzufügen"
 
-#: eeschema/libeditframe.cpp:1145
+#: eeschema/libeditframe.cpp:1187
 msgid "Set pin options"
 msgstr "Pinoptionen festlegen"
 
-#: eeschema/libeditframe.cpp:1156 eeschema/schedit.cpp:569 pcbnew/edit.cpp:1502
+#: eeschema/libeditframe.cpp:1198 eeschema/schedit.cpp:552 pcbnew/edit.cpp:1507
 #: pcbnew/modedit.cpp:952 pcbnew/tools/drawing_tool.cpp:331
 msgid "Add text"
 msgstr "Text hinzufügen"
 
-#: eeschema/libeditframe.cpp:1160
+#: eeschema/libeditframe.cpp:1202
 msgid "Add rectangle"
 msgstr "Rechteck hinzufügen"
 
-#: eeschema/libeditframe.cpp:1164 pcbnew/modedit.cpp:948
+#: eeschema/libeditframe.cpp:1206 pcbnew/modedit.cpp:948
 msgid "Add circle"
 msgstr "Kreis hinzufügen"
 
-#: eeschema/libeditframe.cpp:1168 pcbnew/modedit.cpp:944
+#: eeschema/libeditframe.cpp:1210 pcbnew/modedit.cpp:944
 msgid "Add arc"
 msgstr "Kreisbogen hinzufügen"
 
-#: eeschema/libeditframe.cpp:1172 pcbnew/modedit.cpp:940
+#: eeschema/libeditframe.cpp:1214 pcbnew/modedit.cpp:940
 msgid "Add line"
 msgstr "Linie hinzufügen"
 
-#: eeschema/libeditframe.cpp:1176
+#: eeschema/libeditframe.cpp:1218
 msgid "Set anchor position"
 msgstr "Lege Ankerposition fest"
 
-#: eeschema/libeditframe.cpp:1180
+#: eeschema/libeditframe.cpp:1222
 msgid "Import"
 msgstr "Importieren"
 
-#: eeschema/libfield.cpp:58
+#: eeschema/libeditframe.cpp:1240 eeschema/schedit.cpp:588 pcbnew/edit.cpp:1519
+#: pcbnew/modedit.cpp:977 pcbnew/tool_modedit.cpp:195
+#: pcbnew/tools/pcbnew_control.cpp:720 eeschema/help_common_strings.h:48
+msgid "Delete item"
+msgstr "Element entfernen"
+
+#: eeschema/libeditframe.cpp:1521
+#, c-format
+msgid "Library \"%s\" already exists"
+msgstr ""
+
+#: eeschema/libeditframe.cpp:1536
+msgid "Could not create the library file. Check write permission."
+msgstr ""
+
+#: eeschema/libeditframe.cpp:1543
+msgid "Could not open the library file."
+msgstr ""
+
+#: eeschema/libeditframe.cpp:1556
+msgid "New Library"
+msgstr "Neue Biblliothek"
+
+#: eeschema/libeditframe.cpp:1642
+msgid "Project"
+msgstr ""
+
+#: eeschema/libeditframe.cpp:1644
+msgid "Select Symbol Library Table"
+msgstr ""
+
+#: eeschema/libeditframe.cpp:1645
+msgid "Choose the Library Table to add the library:"
+msgstr ""
+
+#: eeschema/libeditframe.cpp:1667
+msgid "Failed to save backup document to file "
+msgstr ""
+
+#: eeschema/libfield.cpp:57
 msgid "Component Name"
 msgstr "Bauteilname"
 
-#: eeschema/libfield.cpp:59
+#: eeschema/libfield.cpp:58
 msgid "Enter a name to create a new component based on this one."
 msgstr ""
 "Vergebe einen Namen, um ein neues Bauteil, basierend auf diesem, zu "
 "erstellen."
 
-#: eeschema/libfield.cpp:63
+#: eeschema/libfield.cpp:62
 #, c-format
 msgid "Edit Field %s"
 msgstr "Editieren von Feld %s"
 
-#: eeschema/libfield.cpp:64
+#: eeschema/libfield.cpp:63
 #, c-format
 msgid "Enter a new value for the %s field."
 msgstr "Vergebe einen neuen Wert für das %s Feld."
 
-#: eeschema/libfield.cpp:91
+#: eeschema/libfield.cpp:92
 #, c-format
 msgid ""
-"The name '%s' conflicts with an existing entry in the component library "
-"'%s'.\n"
+"The name \"%s\" conflicts with an existing entry in the component library "
+"\"%s\".\n"
 "\n"
 "Do you wish to replace the current component in the library with this one?"
 msgstr ""
-"Der Name '%s' steht in Konflikt mit einem existierenden Eintrag in der "
-"Bauteilbibliothek '%s'.\n"
-"\n"
-"Möchten Sie das gegenwärtige Bauteil in der Bibliothek durch diesen ersetzen?"
 
-#: eeschema/libfield.cpp:97 eeschema/libfield.cpp:111 eeschema/libfield.cpp:147
+#: eeschema/libfield.cpp:98 eeschema/libfield.cpp:112 eeschema/libfield.cpp:148
 msgid "Confirm"
 msgstr "Bestätigung"
 
-#: eeschema/libfield.cpp:107
+#: eeschema/libfield.cpp:108
 #, c-format
 msgid ""
-"The current component already has an alias named '%s'.\n"
+"The current component already has an alias named \"%s\".\n"
 "\n"
 "Do you wish to remove this alias from the component?"
 msgstr ""
-"Das gegenwärtige Bauteil besitzt bereits einen Alias '%s'.\n"
-"\n"
-"Möchten Sie diesen Alias entfernen?"
 
-#: eeschema/libfield.cpp:141
+#: eeschema/libfield.cpp:142
 #, c-format
 msgid ""
 "The new symbol contains alias names that conflict with entries in the "
-"library '%s'.\n"
+"library \"%s\".\n"
 "\n"
 "Do you wish to remove all of the conflicting aliases from this symbol?"
 msgstr ""
-"Das neue Symbol besitzt einen Aliasnamen, der mit Einträgen in der "
-"Bibliothek %s in Konflikt steht.\n"
-"\n"
-"Möchten Sie alle in Konflikt stehenden Aliasnamen dieses Bauteils entfernen?"
 
-#: eeschema/load_one_schematic_file.cpp:94
-#, c-format
-msgid "Failed to open '%s'"
-msgstr "Es trat ein Fehler beim Öffnen von '%s' auf."
-
-#: eeschema/load_one_schematic_file.cpp:102
-#, c-format
-msgid "Loading '%s'"
-msgstr "Lade '%s'"
-
-#: eeschema/load_one_schematic_file.cpp:109
-#, c-format
-msgid "'%s' is NOT an Eeschema file!"
-msgstr "'%s' ist keine Eeschema Datei!"
-
-#: eeschema/load_one_schematic_file.cpp:128
-#, c-format
-msgid ""
-"'%s' was created by a more recent version of Eeschema and may not load "
-"correctly. Please consider updating!"
-msgstr ""
-"'%s' wurde von einer älteren Version von Eeschema erstellt und wird "
-"möglicherweise nicht korrekt eingelesen. Bitte erwägen Sie ein "
-"Aktualisierung durchzuführen!"
-
-#: eeschema/load_one_schematic_file.cpp:139
-msgid ""
-" was created by an older version of Eeschema. It will be stored in the new "
-"file format when you save this file again."
-msgstr ""
-" wurde von einer älteren Version von Eeschema erstellt. Wenn Sie die Datei "
-"erneut speichern wird diese im neuen Dateiformat angelegt."
-
-#: eeschema/load_one_schematic_file.cpp:225
-#, c-format
-msgid "Eeschema file text load error at line %d"
-msgstr "Fehler beim Einlesen der Eeschema-Datei in Zeile %d"
-
-#: eeschema/load_one_schematic_file.cpp:241
-#, c-format
-msgid "Eeschema file undefined object at line %d, aborted"
-msgstr "Undefiniertes Objekt in Zeile %d der Eeschema-Datei. Abbruch!"
-
-#: eeschema/load_one_schematic_file.cpp:264
-#, c-format
-msgid "Eeschema file object not loaded at line %d, aborted"
-msgstr ""
-"Das Objekt aus Zeile %d der Eeschema-Datei wurde nicht eingelesen. Abbruch!"
-
-#: eeschema/load_one_schematic_file.cpp:281
-#, c-format
-msgid "Done Loading <%s>"
-msgstr "<%s> geladen"
-
-#: eeschema/load_one_schematic_file.cpp:310
-#, c-format
-msgid ""
-"Eeschema file dimension definition error line %d,\n"
-"Abort reading file.\n"
-msgstr ""
-"Fehler in Eeschema-Datei bei der Definition von Abmessungen in Zeile %d,\n"
-"Einlesen der Datei wurde abgebrochen.\n"
-
-#: eeschema/menubar.cpp:119 eeschema/menubar_libedit.cpp:294
+#: eeschema/menubar.cpp:119 eeschema/menubar_libedit.cpp:353
 #: pagelayout_editor/menubar.cpp:243 pcbnew/menubar_modedit.cpp:390
 #: pcbnew/menubar_pcbframe.cpp:154
 msgid "&Edit"
 msgstr "&Bearbeiten"
 
-#: eeschema/menubar.cpp:120 eeschema/menubar_libedit.cpp:295
+#: eeschema/menubar.cpp:120 eeschema/menubar_libedit.cpp:354
 #: eeschema/tool_viewlib.cpp:242 kicad/menubar.cpp:478
 #: pagelayout_editor/menubar.cpp:244 pcbnew/menubar_modedit.cpp:391
 #: pcbnew/menubar_pcbframe.cpp:155 pcbnew/tool_modview.cpp:205
 msgid "&View"
 msgstr "&Ansicht"
 
-#: eeschema/menubar.cpp:121 eeschema/menubar_libedit.cpp:296
+#: eeschema/menubar.cpp:121 eeschema/menubar_libedit.cpp:356
 #: pagelayout_editor/menubar.cpp:245 pcbnew/menubar_modedit.cpp:392
 #: pcbnew/menubar_pcbframe.cpp:156
 msgid "&Place"
 msgstr "E&infügen"
 
-#: eeschema/menubar.cpp:122 eeschema/menubar_libedit.cpp:297
+#: eeschema/menubar.cpp:122 eeschema/menubar_libedit.cpp:357
 #: pagelayout_editor/menubar.cpp:246 pcbnew/menubar_modedit.cpp:393
 #: pcbnew/menubar_pcbframe.cpp:158
 msgid "P&references"
@@ -9241,25 +8914,25 @@ msgstr "&Einstellungen"
 msgid "&Tools"
 msgstr "&Werkzeuge"
 
-#: eeschema/menubar.cpp:155 eeschema/menubar_libedit.cpp:169
+#: eeschema/menubar.cpp:155 eeschema/menubar_libedit.cpp:164
 #: eeschema/tool_viewlib.cpp:192 pcbnew/menubar_modedit.cpp:230
 #: pcbnew/menubar_pcbframe.cpp:524 pcbnew/tool_modview.cpp:157
 msgid "Zoom &In"
 msgstr "Hin&ein zoomen"
 
-#: eeschema/menubar.cpp:159 eeschema/menubar_libedit.cpp:173
+#: eeschema/menubar.cpp:159 eeschema/menubar_libedit.cpp:168
 #: eeschema/tool_viewlib.cpp:196 pcbnew/menubar_modedit.cpp:234
 #: pcbnew/menubar_pcbframe.cpp:528 pcbnew/tool_modview.cpp:161
 msgid "Zoom &Out"
 msgstr "Her&aus zoomen"
 
-#: eeschema/menubar.cpp:163 eeschema/menubar_libedit.cpp:177
+#: eeschema/menubar.cpp:163 eeschema/menubar_libedit.cpp:172
 #: eeschema/tool_viewlib.cpp:200 pcbnew/menubar_modedit.cpp:238
 #: pcbnew/menubar_pcbframe.cpp:532 pcbnew/tool_modview.cpp:165
 msgid "&Fit on Screen"
 msgstr "An Bildschirm anpassen"
 
-#: eeschema/menubar.cpp:167 eeschema/menubar_libedit.cpp:184
+#: eeschema/menubar.cpp:167 eeschema/menubar_libedit.cpp:176
 #: eeschema/tool_viewlib.cpp:205 pcbnew/menubar_modedit.cpp:243
 #: pcbnew/menubar_pcbframe.cpp:537 pcbnew/tool_modview.cpp:170
 msgid "&Redraw"
@@ -9453,18 +9126,18 @@ msgstr "Schaltplan im HPGL, Postscript oder SVG Format plotten"
 msgid "Close Eeschema"
 msgstr "Eeschema schliesen"
 
-#: eeschema/menubar.cpp:419 eeschema/menubar_libedit.cpp:126
+#: eeschema/menubar.cpp:419 eeschema/menubar_libedit.cpp:131
 #: pcbnew/menubar_modedit.cpp:158 pcbnew/menubar_pcbframe.cpp:467
 msgid "&Undo"
 msgstr "&Rückgäng"
 
-#: eeschema/menubar.cpp:424 eeschema/menubar_libedit.cpp:135
+#: eeschema/menubar.cpp:424 eeschema/menubar_libedit.cpp:140
 #: pcbnew/menubar_modedit.cpp:164 pcbnew/menubar_pcbframe.cpp:470
 msgid "&Redo"
 msgstr "&Wiederherstellen"
 
-#: eeschema/menubar.cpp:431 eeschema/menubar_libedit.cpp:148
-#: pcbnew/menubar_modedit.cpp:171 pcbnew/menubar_pcbframe.cpp:474
+#: eeschema/menubar.cpp:431 pcbnew/menubar_modedit.cpp:171
+#: pcbnew/menubar_pcbframe.cpp:474
 msgid "&Delete"
 msgstr "&Entfernen"
 
@@ -9480,269 +9153,367 @@ msgstr "Importiere Footprint Assoziierungsdatei"
 msgid "Sets component fields to original library values"
 msgstr "Setze Felder auf Originalwerte der Bibliothek"
 
-#: eeschema/menubar.cpp:468
+#: eeschema/menubar.cpp:461
+msgid "Edit Components to Symbol Library Links"
+msgstr ""
+
+#: eeschema/menubar.cpp:462
+msgid ""
+"Edit components to symbols library links to switch to an other library link "
+"(library IDs)"
+msgstr ""
+
+#: eeschema/menubar.cpp:475
 msgid "Updates PCB design with current schematic (forward annotation)."
 msgstr ""
 "Aktualisiert das PCB Design mit dem aktuellen Schaltplan (Vorwärts "
 "Annotation)."
 
-#: eeschema/menubar.cpp:474
+#: eeschema/menubar.cpp:481
 msgid "&Open PCB Editor"
 msgstr "PCB Edit&or öffnen"
 
-#: eeschema/menubar.cpp:475 kicad/menubar.cpp:148
+#: eeschema/menubar.cpp:482 kicad/menubar.cpp:148
 msgid "Run Pcbnew"
 msgstr "Pcbnew starten"
 
-#: eeschema/menubar.cpp:482
+#: eeschema/menubar.cpp:489
 msgid "Library &Editor"
 msgstr "Bibliotheks&editor"
 
-#: eeschema/menubar.cpp:487
+#: eeschema/menubar.cpp:494
 msgid "Library &Browser"
 msgstr "Bibliotheks&browser"
 
-#: eeschema/menubar.cpp:492
+#: eeschema/menubar.cpp:499
 msgid "&Rescue Symbols"
 msgstr "Bauteile wiede&rherstellen"
 
-#: eeschema/menubar.cpp:493
+#: eeschema/menubar.cpp:500
 msgid "Find old symbols in project and rename/rescue them"
 msgstr "Alte Symbole im Projekt finden und diese umbenennen/sichern"
 
-#: eeschema/menubar.cpp:499
+#: eeschema/menubar.cpp:506
 msgid "Remap legacy library symbols to symbol library table"
 msgstr "Alte Bibliothekssymbole in die Symbolbibliothekstabelle neu zuordnen"
 
-#: eeschema/menubar.cpp:506
+#: eeschema/menubar.cpp:513
 msgid "&Annotate Schematic"
 msgstr "&Annotation des Schaltplans"
 
-#: eeschema/menubar.cpp:512
+#: eeschema/menubar.cpp:519
 msgid "Electrical Rules &Checker"
 msgstr "Electrical Rules &Checker"
 
-#: eeschema/menubar.cpp:513 eeschema/tool_sch.cpp:158
+#: eeschema/menubar.cpp:520 eeschema/tool_sch.cpp:152
 msgid "Perform electrical rules check"
 msgstr "Electrical Rules Check ausführen"
 
-#: eeschema/menubar.cpp:518
+#: eeschema/menubar.cpp:525
 msgid "Generate &Netlist File"
 msgstr "&Netzlistendatei erstellen"
 
-#: eeschema/menubar.cpp:519
+#: eeschema/menubar.cpp:526
 msgid "Generate component netlist file"
 msgstr "Netzlistendatei mit Bauteilen erstellen"
 
-#: eeschema/menubar.cpp:524
+#: eeschema/menubar.cpp:531
 msgid "Component Table &View"
 msgstr "A&nsicht Tabelle der Bauteile"
 
-#: eeschema/menubar.cpp:529
+#: eeschema/menubar.cpp:536
 msgid "Generate Bill of &Materials"
 msgstr "Stückliste (BO&M) erstellen"
 
-#: eeschema/menubar.cpp:540
+#: eeschema/menubar.cpp:547
 msgid "A&ssign Footprint"
 msgstr "Bauteilfootprint &zuweisen"
 
-#: eeschema/menubar.cpp:541
+#: eeschema/menubar.cpp:548
 msgid "Run CvPcb"
 msgstr "CvPcb starten"
 
-#: eeschema/menubar.cpp:550
+#: eeschema/menubar.cpp:557
 msgid "Simula&tor"
 msgstr "Simula&tor"
 
-#: eeschema/menubar.cpp:550
+#: eeschema/menubar.cpp:557
 msgid "Simulate circuit"
 msgstr "Schaltkreis simulieren"
 
-#: eeschema/menubar.cpp:561 eeschema/menubar_libedit.cpp:261
+#: eeschema/menubar.cpp:568 eeschema/menubar_libedit.cpp:320
 #: eeschema/tool_viewlib.cpp:218
 msgid "Eeschema &Manual"
 msgstr "Eeschema-&Benutzerhandbuch"
 
-#: eeschema/menubar.cpp:562
+#: eeschema/menubar.cpp:569
 msgid "Open Eeschema Manual"
 msgstr "Das Eeschema-Benutzerhandbuch öffnen"
 
-#: eeschema/menubar.cpp:574
+#: eeschema/menubar.cpp:581
 msgid "Displays current hotkeys list and corresponding commands"
 msgstr "Zeige aktuelle Tastenbelegung und zugehörige Befehle"
 
-#: eeschema/menubar.cpp:579 eeschema/menubar_libedit.cpp:279
+#: eeschema/menubar.cpp:586 eeschema/menubar_libedit.cpp:338
 #: eeschema/tool_viewlib.cpp:229 gerbview/menubar.cpp:289 kicad/menubar.cpp:464
 #: pagelayout_editor/menubar.cpp:227 pcbnew/menubar_modedit.cpp:377
 #: pcbnew/menubar_pcbframe.cpp:449
 msgid "Get &Involved"
 msgstr "&Bring Dich ein"
 
-#: eeschema/menubar.cpp:580 pcbnew/menubar_modedit.cpp:378
+#: eeschema/menubar.cpp:587 pcbnew/menubar_modedit.cpp:378
 msgid "Contribute to KiCad (open web browser)"
 msgstr "Zu KiCad beitragen (öffnet einen Webbrowser)"
 
-#: eeschema/menubar.cpp:586 eeschema/menubar_libedit.cpp:288
+#: eeschema/menubar.cpp:593 eeschema/menubar_libedit.cpp:347
 #: kicad/menubar.cpp:472 pcbnew/menubar_modedit.cpp:384
 #: pcbnew/menubar_pcbframe.cpp:456
 msgid "&About KiCad"
 msgstr "&Über KiCad"
 
-#: eeschema/menubar.cpp:596 pcbnew/menubar_pcbframe.cpp:235
+#: eeschema/menubar.cpp:603 pcbnew/menubar_pcbframe.cpp:235
 #: pcbnew/menubar_pcbframe.cpp:616
 msgid "&Save Preferences"
 msgstr "Einstellungen &speichern"
 
-#: eeschema/menubar.cpp:597 pcbnew/menubar_pcbframe.cpp:236
+#: eeschema/menubar.cpp:604 pcbnew/menubar_pcbframe.cpp:236
 msgid "Save application preferences"
 msgstr "Applikationseinstellungen speichern"
 
-#: eeschema/menubar.cpp:602 pcbnew/menubar_pcbframe.cpp:240
+#: eeschema/menubar.cpp:609 pcbnew/menubar_pcbframe.cpp:240
 msgid "Load Prefe&rences"
 msgstr "Einstellungen &laden"
 
-#: eeschema/menubar.cpp:603 pcbnew/menubar_pcbframe.cpp:241
+#: eeschema/menubar.cpp:610 pcbnew/menubar_pcbframe.cpp:241
 msgid "Load application preferences"
 msgstr "Applikationseinstellungen laden"
 
-#: eeschema/menubar.cpp:611
+#: eeschema/menubar.cpp:618
 msgid "Create hotkey configuration file with current hotkeys"
 msgstr "Datei mit den gegenwärtigen Tastaturbefehlen erstellen"
 
-#: eeschema/menubar.cpp:626 eeschema/menubar_libedit.cpp:238
-#: kicad/menubar.cpp:406
-msgid "Manage Symbol Libraries"
-msgstr "Verwalten Symbolbibliotheken"
-
-#: eeschema/menubar.cpp:627 eeschema/menubar_libedit.cpp:239
-msgid "Edit the global and project symbol library tables."
+#: eeschema/menubar.cpp:633
+msgid "Manage Symbol Library Tables"
 msgstr ""
-"Bearbeiten der globalen und der Projekt spezifischen Bibliothekstabellen."
 
-#: eeschema/menubar.cpp:636 eeschema/menubar_libedit.cpp:245
+#: eeschema/menubar.cpp:634
+msgid ""
+"Edit the global and project symbol library tables (list of active libraries)."
+msgstr ""
+
+#: eeschema/menubar.cpp:643 eeschema/menubar_libedit.cpp:304
 msgid "General &Options"
 msgstr "Allgemeine &Optionen"
 
-#: eeschema/menubar.cpp:637
+#: eeschema/menubar.cpp:644
 msgid "Edit Eeschema preferences"
 msgstr "Eeschema Einstellungen"
 
-#: eeschema/menubar.cpp:655
+#: eeschema/menubar.cpp:662
 msgid "&Import and Export"
 msgstr "&Import und Export"
 
-#: eeschema/menubar.cpp:656
+#: eeschema/menubar.cpp:663
 msgid "Import and export settings"
 msgstr "Einstellungen Import/Export"
 
-#: eeschema/menubar_libedit.cpp:70
-msgid "Select &Current Library"
-msgstr "&Aktive Bibliothek auswählen"
+#: eeschema/menubar_libedit.cpp:68
+msgid "&Create New Library"
+msgstr ""
 
-#: eeschema/menubar_libedit.cpp:71 eeschema/tool_lib.cpp:112
-msgid "Select working library"
-msgstr "Arbeitsbibliothek auswählen"
+#: eeschema/menubar_libedit.cpp:69
+msgid "Creates an empty library"
+msgstr ""
 
-#: eeschema/menubar_libedit.cpp:76
-msgid "&Save Current Library"
-msgstr "Aktuelle Bauteilbibliothek &speichern"
+#: eeschema/menubar_libedit.cpp:74
+msgid "&Add Existing Library"
+msgstr ""
 
-#: eeschema/menubar_libedit.cpp:79
+#: eeschema/menubar_libedit.cpp:75
+msgid "Adds a previously created library"
+msgstr ""
+
+#: eeschema/menubar_libedit.cpp:82
+msgid "&Save Library"
+msgstr ""
+
+#: eeschema/menubar_libedit.cpp:85
 msgid "Save the current active library"
 msgstr "Momentan aktive Bauteilbibliothek speichern"
 
-#: eeschema/menubar_libedit.cpp:85
-msgid "Save Current Library &As..."
-msgstr "A&ktuelle Bauteilbibliothek speichern unter ..."
-
-#: eeschema/menubar_libedit.cpp:86
-msgid "Save current active library as..."
-msgstr "Momentan aktive Bauteilbibliothek speichern unter ..."
+#: eeschema/menubar_libedit.cpp:90
+msgid "&Save Library As.."
+msgstr ""
 
 #: eeschema/menubar_libedit.cpp:91
-msgid "Create &New Library and Save Current Component"
-msgstr "&Neue Bibliothek erstellen und aktuelles Bauteil speichern"
+msgid "Save the current library to a new file"
+msgstr ""
 
-#: eeschema/menubar_libedit.cpp:92 eeschema/tool_lib.cpp:119
-msgid "Save current component to new library"
-msgstr "Gegenwärtiges Bauteil in einer neuen Bibliothek speichern"
+#: eeschema/menubar_libedit.cpp:96
+msgid "&Save All Libraries"
+msgstr ""
 
-#: eeschema/menubar_libedit.cpp:101
+#: eeschema/menubar_libedit.cpp:97
+msgid "Save all library changes"
+msgstr ""
+
+#: eeschema/menubar_libedit.cpp:106
 msgid "Create &PNG File from Screen..."
 msgstr "&PNG Datei vom aktuellen Bildschirm erstellen"
 
-#: eeschema/menubar_libedit.cpp:102
-msgid "Create a PNG file from the component displayed on screen"
-msgstr "Eine PNG-Datei vom gegenwärtigen Bauteil erstellen"
+#: eeschema/menubar_libedit.cpp:107
+msgid "Create a PNG file from the part displayed on screen"
+msgstr ""
 
-#: eeschema/menubar_libedit.cpp:108
+#: eeschema/menubar_libedit.cpp:113
 msgid "Create S&VG File..."
 msgstr "S&VG Datei erstellen"
 
-#: eeschema/menubar_libedit.cpp:109
-msgid "Create a SVG file from the current loaded component"
-msgstr "Eine SVG-Datei vom gegenwärtigen Bauteil erstellen"
+#: eeschema/menubar_libedit.cpp:114
+msgid "Create a SVG file from the current loaded part"
+msgstr ""
 
-#: eeschema/menubar_libedit.cpp:118
+#: eeschema/menubar_libedit.cpp:123
 msgid "&Quit"
 msgstr "&Beenden"
 
-#: eeschema/menubar_libedit.cpp:119
+#: eeschema/menubar_libedit.cpp:124
 msgid "Quit Library Editor"
 msgstr "Bauteilbibliothekseditor beenden"
 
-#: eeschema/menubar_libedit.cpp:131
+#: eeschema/menubar_libedit.cpp:136
 msgid "Undo last edit"
 msgstr "Letzte Änderung rückgängig machen"
 
-#: eeschema/menubar_libedit.cpp:139 pcbnew/help_common_strings.h:16
+#: eeschema/menubar_libedit.cpp:144 pcbnew/help_common_strings.h:16
 msgid "Redo the last undo command"
 msgstr "Wiederherstellen des letzten Rückgängigmachens"
 
+#: eeschema/menubar_libedit.cpp:184
+msgid "&Search tree"
+msgstr ""
+
+#: eeschema/menubar_libedit.cpp:185
+msgid "Toggles the search tree visibility"
+msgstr ""
+
 #: eeschema/menubar_libedit.cpp:193
+msgid "Create &New"
+msgstr ""
+
+#: eeschema/menubar_libedit.cpp:194
+msgid "Create a new empty part"
+msgstr ""
+
+#: eeschema/menubar_libedit.cpp:197
+msgid "&Save Part"
+msgstr ""
+
+#: eeschema/menubar_libedit.cpp:201
+msgid "Saves the current part to the library"
+msgstr ""
+
+#: eeschema/menubar_libedit.cpp:208 pcbnew/menubar_pcbframe.cpp:762
+msgid "&Import"
+msgstr "&Importieren"
+
+#: eeschema/menubar_libedit.cpp:209
+msgid "Import a part to the current library"
+msgstr ""
+
+#: eeschema/menubar_libedit.cpp:214
+msgid "&Export"
+msgstr ""
+
+#: eeschema/menubar_libedit.cpp:215
+msgid "Export the current part"
+msgstr ""
+
+#: eeschema/menubar_libedit.cpp:222
+msgid "&Properties"
+msgstr ""
+
+#: eeschema/menubar_libedit.cpp:223 eeschema/tool_lib.cpp:148
+msgid "Edit part properties"
+msgstr ""
+
+#: eeschema/menubar_libedit.cpp:228
+msgid "&Fields"
+msgstr ""
+
+#: eeschema/menubar_libedit.cpp:229 eeschema/tool_lib.cpp:152
+msgid "Edit field properties"
+msgstr "Feldeigenschaften bearbeiten"
+
+#: eeschema/menubar_libedit.cpp:236
+msgid "Pi&n Table"
+msgstr ""
+
+#: eeschema/menubar_libedit.cpp:237 eeschema/tool_lib.cpp:206
+msgid "Show pin table"
+msgstr "Zeige Pin-Tabelle"
+
+#: eeschema/menubar_libedit.cpp:243 eeschema/tool_lib.cpp:156
+msgid "Check duplicate and off grid pins"
+msgstr "Auf Pin-Duplikate und Pins außerhalb des Rasters prüfen"
+
+#: eeschema/menubar_libedit.cpp:252
 msgid "&Pin"
 msgstr "&Pin"
 
-#: eeschema/menubar_libedit.cpp:200
+#: eeschema/menubar_libedit.cpp:259
 msgid "Graphic &Text"
 msgstr "Grafischer &Text"
 
-#: eeschema/menubar_libedit.cpp:207
+#: eeschema/menubar_libedit.cpp:266
 msgid "&Rectangle"
 msgstr "&Rechteck"
 
-#: eeschema/menubar_libedit.cpp:214 pcbnew/menubar_modedit.cpp:293
+#: eeschema/menubar_libedit.cpp:273 pcbnew/menubar_modedit.cpp:293
 #: pcbnew/menubar_pcbframe.cpp:334
 msgid "&Circle"
 msgstr "&Kreis"
 
-#: eeschema/menubar_libedit.cpp:221 pcbnew/menubar_modedit.cpp:304
+#: eeschema/menubar_libedit.cpp:280 pcbnew/menubar_modedit.cpp:304
 #: pcbnew/menubar_pcbframe.cpp:331
 msgid "&Arc"
 msgstr "Kreis&bogen"
 
-#: eeschema/menubar_libedit.cpp:228 pcbnew/menubar_modedit.cpp:298
+#: eeschema/menubar_libedit.cpp:287 pcbnew/menubar_modedit.cpp:298
 msgid "&Line or Polygon"
 msgstr "&Linie oder Polygon"
 
-#: eeschema/menubar_libedit.cpp:246
-msgid "Set Component Editor default values and options"
-msgstr "Standardwerte und Optionen für den Bauteileditor einstellen"
+#: eeschema/menubar_libedit.cpp:297
+msgid "Manage Symbol Libraries"
+msgstr "Verwalten Symbolbibliotheken"
 
-#: eeschema/menubar_libedit.cpp:262
+#: eeschema/menubar_libedit.cpp:298
+msgid "Edit the global and project symbol library tables."
+msgstr ""
+"Bearbeiten der globalen und der Projekt spezifischen Bibliothekstabellen."
+
+#: eeschema/menubar_libedit.cpp:305
+msgid "Set Part Editor default values and options"
+msgstr ""
+
+#: eeschema/menubar_libedit.cpp:321
 msgid "Open the Eeschema Manual"
 msgstr "Das Eeschema-Benutzerhandbuch öffnen"
 
-#: eeschema/menubar_libedit.cpp:268 eeschema/tool_viewlib.cpp:224
+#: eeschema/menubar_libedit.cpp:327 eeschema/tool_viewlib.cpp:224
 #: pcbnew/menubar_modedit.cpp:366 pcbnew/tool_modview.cpp:192
 msgid "Open the \"Getting Started in KiCad\" guide for beginners"
 msgstr "Das Handbuch für Anfänger \"Erste Schritte mit KiCad\" öffnen"
 
-#: eeschema/menubar_libedit.cpp:280 eeschema/tool_viewlib.cpp:230
+#: eeschema/menubar_libedit.cpp:339 eeschema/tool_viewlib.cpp:230
 #: gerbview/menubar.cpp:290 kicad/menubar.cpp:465
 #: pagelayout_editor/menubar.cpp:228
 msgid "Contribute to KiCad (opens a web browser)"
 msgstr "Zu KiCad beitragen (öffnet einen Webbrowser)"
+
+#: eeschema/menubar_libedit.cpp:355
+msgid "&Part"
+msgstr ""
 
 #: eeschema/netform.cpp:111
 msgid "Run command:"
@@ -9779,11 +9550,11 @@ msgstr ""
 "Doppelt vergebener Schaltplanname.\n"
 "Möchten Sie trotzdem fortfahren?"
 
-#: eeschema/netlist.cpp:186
+#: eeschema/netlist.cpp:182
 msgid "No Objects"
 msgstr "Keine Objekte"
 
-#: eeschema/netlist.cpp:190
+#: eeschema/netlist.cpp:186
 #, c-format
 msgid "Net count = %d"
 msgstr "Netzanzahl = %d"
@@ -9791,10 +9562,10 @@ msgstr "Netzanzahl = %d"
 #: eeschema/netlist_exporters/netlist_exporter_cadstar.cpp:48
 #: eeschema/netlist_exporters/netlist_exporter_orcadpcb2.cpp:54
 #, c-format
-msgid "Failed to create file '%s'"
-msgstr "Konnte Datei '%s' nicht erstellen."
+msgid "Failed to create file \"%s\""
+msgstr ""
 
-#: eeschema/netlist_exporters/netlist_exporter_pspice.cpp:82
+#: eeschema/netlist_exporters/netlist_exporter_pspice.cpp:83
 #, c-format
 msgid "Could not find library file %s"
 msgstr "Konnte die Bibliothek %s nicht finden."
@@ -9887,7 +9658,7 @@ msgstr "%s Verschieben"
 #: eeschema/onrightclick.cpp:371 eeschema/onrightclick.cpp:507
 #: eeschema/onrightclick.cpp:544 eeschema/onrightclick.cpp:580
 #: eeschema/onrightclick.cpp:775 pcbnew/onrightclick.cpp:803
-#: pcbnew/tools/edit_tool.cpp:566
+#: pcbnew/tools/edit_tool.cpp:565
 msgid "Drag"
 msgstr "Ziehen"
 
@@ -9907,11 +9678,12 @@ msgstr "Rücksetzen auf Standardeinstellungen"
 
 #: eeschema/onrightclick.cpp:394 eeschema/onrightclick.cpp:510
 #: eeschema/onrightclick.cpp:582 eeschema/onrightclick.cpp:616
-#: pcbnew/modedit_onclick.cpp:366 pcbnew/modedit_onclick.cpp:409
-#: pcbnew/onrightclick.cpp:200 pcbnew/onrightclick.cpp:276
-#: pcbnew/onrightclick.cpp:307 pcbnew/onrightclick.cpp:492
-#: pcbnew/onrightclick.cpp:545 pcbnew/onrightclick.cpp:843
-#: pcbnew/tools/edit_tool.cpp:106 pcbnew/tools/edit_tool.cpp:110
+#: eeschema/widgets/cmp_tree_pane.cpp:69 pcbnew/modedit_onclick.cpp:366
+#: pcbnew/modedit_onclick.cpp:409 pcbnew/onrightclick.cpp:200
+#: pcbnew/onrightclick.cpp:276 pcbnew/onrightclick.cpp:307
+#: pcbnew/onrightclick.cpp:492 pcbnew/onrightclick.cpp:545
+#: pcbnew/onrightclick.cpp:843 pcbnew/tools/edit_tool.cpp:106
+#: pcbnew/tools/edit_tool.cpp:110
 msgid "Duplicate"
 msgstr "Duplizieren"
 
@@ -9932,8 +9704,8 @@ msgid "Edit with Library Editor"
 msgstr "Mit Bibliothekseditor bearbeiten"
 
 #: eeschema/onrightclick.cpp:493 pagelayout_editor/pl_editor_frame.cpp:141
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:293
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:234
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:295
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:236
 #: pcbnew/tools/edit_tool.cpp:156
 msgid "Properties"
 msgstr "Eigenschaften"
@@ -9958,8 +9730,8 @@ msgstr "Zu Text ändern"
 msgid "Change Type"
 msgstr "Typ ändern"
 
-#: eeschema/onrightclick.cpp:546 pcbnew/onrightclick.cpp:993
-#: pcbnew/tools/edit_tool.cpp:169
+#: eeschema/onrightclick.cpp:546 eeschema/widgets/cmp_tree_pane.cpp:68
+#: pcbnew/onrightclick.cpp:993 pcbnew/tools/edit_tool.cpp:169
 msgid "Copy"
 msgstr "Kopieren"
 
@@ -10076,9 +9848,9 @@ msgstr "Buseingang ändern zu \\"
 msgid "Delete Bus Entry"
 msgstr "Buseingang entfernen"
 
-#: eeschema/pin_shape.cpp:38 gerbview/class_gerber_draw_item.cpp:167
-#: pcbnew/class_board_item.cpp:42
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:236
+#: eeschema/pin_shape.cpp:38 gerbview/class_gerber_draw_item.cpp:233
+#: pcbnew/class_board_item.cpp:43
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:238
 #: pcbnew/dialogs/dialog_keepout_area_properties_base.cpp:52
 #: pcbnew/dialogs/dialog_non_copper_zones_properties_base.cpp:52
 msgid "Line"
@@ -10158,15 +9930,15 @@ msgstr ""
 "Diese Position ist bereits durch einen anderen Pin belegt.\n"
 "Möchten Sie trotzdem fortfahren?"
 
-#: eeschema/pinedit.cpp:710
+#: eeschema/pinedit.cpp:712
 msgid "No pins!"
 msgstr "Keine Pins vorhanden!"
 
-#: eeschema/pinedit.cpp:720
+#: eeschema/pinedit.cpp:722
 msgid "Marker Information"
 msgstr "Marker Information"
 
-#: eeschema/pinedit.cpp:742
+#: eeschema/pinedit.cpp:744
 #, c-format
 msgid ""
 "<b>Duplicate pin %s</b> \"%s\" at location <b>(%.3f, %.3f)</b> conflicts "
@@ -10175,26 +9947,26 @@ msgstr ""
 "<b>Pin-Duplikat %s</b> \"%s\" an Position <b>(%.3f, %.3f)</b> steht in "
 "Konflikt mit Pin %s \"%s\" an Position <b>(%.3f, %.3f)</b>"
 
-#: eeschema/pinedit.cpp:756 eeschema/pinedit.cpp:796
+#: eeschema/pinedit.cpp:758 eeschema/pinedit.cpp:798
 #, c-format
 msgid " in part %c"
 msgstr " in Bauteil %c"
 
-#: eeschema/pinedit.cpp:762 eeschema/pinedit.cpp:802
+#: eeschema/pinedit.cpp:764 eeschema/pinedit.cpp:804
 msgid "  of converted"
 msgstr "  in konvertierter Darstellung"
 
-#: eeschema/pinedit.cpp:764 eeschema/pinedit.cpp:804
+#: eeschema/pinedit.cpp:766 eeschema/pinedit.cpp:806
 msgid "  of normal"
 msgstr "  in normaler Darstellung"
 
-#: eeschema/pinedit.cpp:787
+#: eeschema/pinedit.cpp:789
 #, c-format
 msgid "<b>Off grid pin %s</b> \"%s\" at location <b>(%.3f, %.3f)</b>"
 msgstr ""
 "<b>Pin %s außerhalb des Rasters</b> \"%s\" an Position <b>(%.3f, %.3f)</b>"
 
-#: eeschema/pinedit.cpp:813
+#: eeschema/pinedit.cpp:815
 msgid "No off grid or duplicate pins were found."
 msgstr ""
 "Es wurden keine Pins außerhalb des Rasters und keine Pin-Duplikate gefunden."
@@ -10203,54 +9975,59 @@ msgstr ""
 #: eeschema/plot_schematic_PDF.cpp:126 eeschema/plot_schematic_PS.cpp:107
 #: eeschema/plot_schematic_SVG.cpp:83
 #, c-format
-msgid "Plot: '%s' OK.\n"
-msgstr "Plot: <%s> erstellt\n"
+msgid "Plot: \"%s\" OK.\n"
+msgstr ""
 
 #: eeschema/plot_schematic_DXF.cpp:85 eeschema/plot_schematic_HPGL.cpp:182
 #: eeschema/plot_schematic_PDF.cpp:91 eeschema/plot_schematic_PS.cpp:113
 #, c-format
-msgid "Unable to create file '%s'.\n"
-msgstr "Konnte Datei '%s' nicht erstellen.\n"
+msgid "Unable to create file \"%s\".\n"
+msgstr ""
 
 #: eeschema/plot_schematic_SVG.cpp:77
 #, c-format
-msgid "Cannot create file '%s'.\n"
-msgstr "Konnte Datei '%s' nicht erstellen.\n"
+msgid "Cannot create file \"%s\".\n"
+msgstr ""
 
 #: eeschema/project_rescue.cpp:189
 #, c-format
 msgid "Rename to %s"
 msgstr "Umbenennen zu %s"
 
-#: eeschema/project_rescue.cpp:290
+#: eeschema/project_rescue.cpp:291
 #, c-format
 msgid "Rescue %s as %s"
 msgstr "Wiederherstellen %s auf %s"
 
-#: eeschema/project_rescue.cpp:404
+#: eeschema/project_rescue.cpp:406
 #, c-format
 msgid "Rescue to %s"
 msgstr "Überführen zu %s"
 
-#: eeschema/project_rescue.cpp:516
+#: eeschema/project_rescue.cpp:517
 msgid "This project has nothing to rescue."
 msgstr "In diesem Projekt ist nichts wiederherzustellen."
 
-#: eeschema/project_rescue.cpp:532
+#: eeschema/project_rescue.cpp:518 eeschema/project_rescue.cpp:534
+#: eeschema/dialogs/dialog_rescue_each_base.h:64
+msgid "Project Rescue Helper"
+msgstr "Projekt Wiederherstellungs Helfer"
+
+#: eeschema/project_rescue.cpp:533
 msgid "No symbols were rescued."
 msgstr "Keine Symbole wiederhergestellt."
 
-#: eeschema/project_rescue.cpp:652
+#: eeschema/project_rescue.cpp:654
 #, c-format
-msgid "Failed to create symbol library file '%s'"
-msgstr "Konnte die Bauteilbibliothek '%s' nicht erstellen."
+msgid "Failed to create symbol library file \"%s\""
+msgstr ""
 
-#: eeschema/project_rescue.cpp:776
+#: eeschema/project_rescue.cpp:778
 #, c-format
 msgid "Failed to save rescue library %s."
 msgstr "Konnte die Sicherungsbibliothek '%s' nicht laden."
 
-#: eeschema/project_rescue.cpp:794
+#: eeschema/project_rescue.cpp:796
 msgid "Error occurred saving project specific symbol library table."
 msgstr ""
 "Bei dem Versuch die projektspezifische Symbolbibliothekstabelle zu speichern "
@@ -10258,10 +10035,10 @@ msgstr ""
 
 #: eeschema/sch_base_frame.cpp:61
 #, c-format
-msgid "Could not load symbol '%s' from library '%s'."
-msgstr "Konnte das Symbol %s aus der Bibliothek '%s' nicht laden."
+msgid "Could not load symbol \"%s\" from library \"%s\"."
+msgstr ""
 
-#: eeschema/sch_base_frame.cpp:279
+#: eeschema/sch_base_frame.cpp:325
 #, c-format
 msgid ""
 "Error occurred saving the global symbol library table:\n"
@@ -10273,7 +10050,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: eeschema/sch_base_frame.cpp:295
+#: eeschema/sch_base_frame.cpp:343
 #, c-format
 msgid ""
 "Error occurred saving project specific symbol library table:\n"
@@ -10285,74 +10062,74 @@ msgstr ""
 "\n"
 "%s"
 
-#: eeschema/sch_bitmap.h:131
-msgid "Image"
-msgstr "Bil&d"
-
-#: eeschema/sch_bus_entry.cpp:335
+#: eeschema/sch_bus_entry.cpp:337
 msgid "Bus to Wire Entry"
 msgstr "Bus an eine elektr. Verbindung führen"
 
-#: eeschema/sch_bus_entry.cpp:341
+#: eeschema/sch_bus_entry.cpp:343
 msgid "Bus to Bus Entry"
 msgstr "Bus zu Buseingang"
 
-#: eeschema/sch_collectors.cpp:442
+#: eeschema/sch_collectors.cpp:457
 #, c-format
 msgid "Child item %s of parent item %s found in sheet %s"
 msgstr "Unterelement %s von Elternelement %s wurde in Schaltplan %s gefunden"
 
-#: eeschema/sch_collectors.cpp:449
+#: eeschema/sch_collectors.cpp:464
 #, c-format
 msgid "Item %s found in sheet %s"
 msgstr "Element %s im Schaltplan %s gefunden"
 
-#: eeschema/sch_component.cpp:1771
+#: eeschema/sch_component.cpp:1436
 msgid "Power symbol"
 msgstr "Spannungsquelle Symbol"
 
-#: eeschema/sch_component.cpp:1776
+#: eeschema/sch_component.cpp:1441
 #: eeschema/widgets/widget_eeschema_color_config.cpp:102
 msgid "Component"
 msgstr "Komponente"
 
-#: eeschema/sch_component.cpp:1780
+#: eeschema/sch_component.cpp:1445
 msgid "Alias of"
 msgstr "Alias von"
 
-#: eeschema/sch_component.cpp:1788
+#: eeschema/sch_component.cpp:1453
 msgid "Undefined!!!"
 msgstr "Nicht spezifiziert!"
 
-#: eeschema/sch_component.cpp:1794
+#: eeschema/sch_component.cpp:1459
 msgid "<Unknown>"
 msgstr "<unbekannt>"
 
-#: eeschema/sch_component.cpp:1801
+#: eeschema/sch_component.cpp:1466
 msgid "Key Words"
 msgstr "Schlüsselwörter"
 
-#: eeschema/sch_component.cpp:1819
+#: eeschema/sch_component.cpp:1477
+msgid "Symbol"
+msgstr "Symbol"
+
+#: eeschema/sch_component.cpp:1484
 msgid "No library defined!!!"
 msgstr "Keine Bibliothek angegeben!"
 
-#: eeschema/sch_component.cpp:1823
+#: eeschema/sch_component.cpp:1488
 #, c-format
 msgid "Symbol not found in %s!!!"
 msgstr "Symbol %s nicht gefunden!!!"
 
-#: eeschema/sch_component.cpp:2075
+#: eeschema/sch_component.cpp:1724
 #, c-format
 msgid "Component %s, %s"
 msgstr "Bauteil %s, %s"
 
-#: eeschema/sch_eagle_plugin.cpp:339 pcbnew/eagle_plugin.cpp:203
-#: pcbnew/eagle_plugin.cpp:2131
+#: eeschema/sch_eagle_plugin.cpp:354 pcbnew/eagle_plugin.cpp:203
+#: pcbnew/eagle_plugin.cpp:2128
 #, c-format
-msgid "Unable to read file '%s'"
-msgstr "Konnte die Datei <%s> nicht öffnen."
+msgid "Unable to read file \"%s\""
+msgstr ""
 
-#: eeschema/sch_field.cpp:467
+#: eeschema/sch_field.cpp:419
 #, c-format
 msgid "Field %s"
 msgstr "Feld %s"
@@ -10360,128 +10137,113 @@ msgstr "Feld %s"
 #: eeschema/sch_io_mgr.cpp:32 eeschema/sch_plugin.cpp:27 pcbnew/io_mgr.cpp:42
 #: pcbnew/plugin.cpp:29
 #, c-format
-msgid "Plugin '%s' does not implement the '%s' function."
-msgstr "Das Plugin '%s' implementiert nicht die Funktion '%s'."
+msgid "Plugin \"%s\" does not implement the \"%s\" function."
+msgstr ""
 
 #: eeschema/sch_io_mgr.cpp:33 pcbnew/io_mgr.cpp:43
 #, c-format
-msgid "Plugin type '%s' is not found."
-msgstr "Plugintyp '%s' wurde nicht gefunden."
+msgid "Plugin type \"%s\" is not found."
+msgstr ""
 
-#: eeschema/sch_io_mgr.cpp:87
+#: eeschema/sch_io_mgr.cpp:85
 #, c-format
 msgid "Unknown SCH_FILE_T value: %d"
 msgstr "Unbekannter SCH_FILE_T Wert: %d"
 
-#: eeschema/sch_junction.h:86
-#: eeschema/widgets/widget_eeschema_color_config.cpp:61
-msgid "Junction"
-msgstr "Knotenpunkt"
-
-#: eeschema/sch_legacy_plugin.cpp:152 eeschema/sch_legacy_plugin.cpp:197
-#: eeschema/sch_legacy_plugin.cpp:245 eeschema/sch_legacy_plugin.cpp:291
-#: eeschema/sch_legacy_plugin.cpp:335 eeschema/sch_legacy_plugin.cpp:348
-#: eeschema/sch_legacy_plugin.cpp:399 eeschema/sch_legacy_plugin.cpp:412
-#: eeschema/sch_legacy_plugin.cpp:431 eeschema/sch_legacy_plugin.cpp:927
-#: eeschema/sch_legacy_plugin.cpp:2577
+#: eeschema/sch_legacy_plugin.cpp:153 eeschema/sch_legacy_plugin.cpp:196
+#: eeschema/sch_legacy_plugin.cpp:242 eeschema/sch_legacy_plugin.cpp:286
+#: eeschema/sch_legacy_plugin.cpp:328 eeschema/sch_legacy_plugin.cpp:341
+#: eeschema/sch_legacy_plugin.cpp:390 eeschema/sch_legacy_plugin.cpp:403
+#: eeschema/sch_legacy_plugin.cpp:422 eeschema/sch_legacy_plugin.cpp:949
+#: eeschema/sch_legacy_plugin.cpp:2673
 msgid "unexpected end of line"
 msgstr "Ungültiger Eintrag (unerwartetes Ende der Zeile)"
 
-#: eeschema/sch_legacy_plugin.cpp:359
+#: eeschema/sch_legacy_plugin.cpp:352
 msgid "expected unquoted string"
 msgstr "nicht gequotete Zeichenkette erwartet"
 
-#: eeschema/sch_legacy_plugin.cpp:727
+#: eeschema/sch_legacy_plugin.cpp:749
 #, c-format
-msgid "'%s' does not appear to be an Eeschema file"
-msgstr "'%s' ist anscheinend keine Eeschema-Datei!"
+msgid "\"%s\" does not appear to be an Eeschema file"
+msgstr ""
 
-#: eeschema/sch_legacy_plugin.cpp:755
+#: eeschema/sch_legacy_plugin.cpp:777
 msgid "Missing 'EELAYER END'"
 msgstr "'EELAYER END' fehlt"
 
-#: eeschema/sch_legacy_plugin.cpp:803 eeschema/sch_legacy_plugin.cpp:1065
-#: eeschema/sch_legacy_plugin.cpp:1073 eeschema/sch_legacy_plugin.cpp:2175
+#: eeschema/sch_legacy_plugin.cpp:825 eeschema/sch_legacy_plugin.cpp:1087
+#: eeschema/sch_legacy_plugin.cpp:1095 eeschema/sch_legacy_plugin.cpp:2279
 msgid "unexpected end of file"
 msgstr "Ungültiger Eintrag (unerwartetes Ende der Datei)"
 
-#: eeschema/sch_legacy_plugin.cpp:1032
+#: eeschema/sch_legacy_plugin.cpp:1054
 msgid "Unexpected end of file"
 msgstr "Ungültiger Eintrag (unerwartetes Ende der Datei)"
 
-#: eeschema/sch_legacy_plugin.cpp:1264
+#: eeschema/sch_legacy_plugin.cpp:1342
 msgid "expected 'Italics' or '~'"
 msgstr "'Italics' oder '~' erwartet"
 
-#: eeschema/sch_legacy_plugin.cpp:1481
+#: eeschema/sch_legacy_plugin.cpp:1565
 msgid "component field text attributes must be 3 characters wide"
 msgstr "Bauteil Textfeld Attribut muss 3 Buchstaben lang sein"
 
-#: eeschema/sch_legacy_plugin.cpp:2259
+#: eeschema/sch_legacy_plugin.cpp:2363
 #, c-format
-msgid "user does not have permission to read library document file '%s'"
-msgstr "Keine Berechtigung zum Lesen der Bibliotheksdatei '%s'."
+msgid "user does not have permission to read library document file \"%s\""
+msgstr ""
 
-#: eeschema/sch_legacy_plugin.cpp:2267
+#: eeschema/sch_legacy_plugin.cpp:2371
 msgid "symbol document library file is empty"
 msgstr "Bauteil Dokumentationsbibliothek ist leer."
 
-#: eeschema/sch_legacy_plugin.cpp:3347 eeschema/sch_legacy_plugin.cpp:3382
+#: eeschema/sch_legacy_plugin.cpp:3928 eeschema/sch_legacy_plugin.cpp:3963
 #, c-format
 msgid "library %s does not contain an alias %s"
 msgstr "Die Bibliothek %s enthält keinen Alias %s."
 
-#: eeschema/sch_legacy_plugin.cpp:3565
+#: eeschema/sch_legacy_plugin.cpp:4146
 #, c-format
-msgid "symbol library '%s' already exists, cannot create a new library"
+msgid "symbol library \"%s\" already exists, cannot create a new library"
 msgstr ""
-"Symbolbibliothek '%s' existiert bereits, neue Bibliothek kann nicht erstellt "
-"werden."
 
-#: eeschema/sch_legacy_plugin.cpp:3593 pcbnew/legacy_plugin.cpp:3460
+#: eeschema/sch_legacy_plugin.cpp:4174 pcbnew/legacy_plugin.cpp:3460
 #, c-format
-msgid "library '%s' cannot be deleted"
-msgstr "Die Bibliothek '%s' kann nicht gelöscht werden."
+msgid "library \"%s\" cannot be deleted"
+msgstr ""
 
-#: eeschema/sch_line.cpp:458
+#: eeschema/sch_line.cpp:594
 msgid "Vert."
 msgstr "Vert."
 
-#: eeschema/sch_line.cpp:460
+#: eeschema/sch_line.cpp:596
 msgid "Horiz."
 msgstr "Horiz."
 
-#: eeschema/sch_line.cpp:465
+#: eeschema/sch_line.cpp:601
 #, c-format
 msgid "%s Graphic Line from (%s,%s) to (%s,%s)"
 msgstr "%s grafische Linie von (%s,%s) nach (%s,%s) "
 
-#: eeschema/sch_line.cpp:469
+#: eeschema/sch_line.cpp:605
 #, c-format
 msgid "%s Wire from (%s,%s) to (%s,%s)"
 msgstr "%s elektr. Verbindung von (%s,%s) nach (%s,%s)"
 
-#: eeschema/sch_line.cpp:473
+#: eeschema/sch_line.cpp:609
 #, c-format
 msgid "%s Bus from (%s,%s) to (%s,%s)"
 msgstr "%s Bus von (%s,%s) nach (%s,%s)"
 
-#: eeschema/sch_line.cpp:477
+#: eeschema/sch_line.cpp:613
 #, c-format
 msgid "%s Line on Unknown Layer from (%s,%s) to (%s,%s)"
 msgstr "%s Linie auf unbekannter Lage von (%s,%s) nach (%s,%s)"
 
-#: eeschema/sch_marker.cpp:143
+#: eeschema/sch_marker.cpp:121
 msgid "Electronics Rule Check Error"
 msgstr "Electronic Rule Check Fehler"
-
-#: eeschema/sch_marker.h:100
-msgid "ERC Marker"
-msgstr "ERC Marker"
-
-#: eeschema/sch_no_connect.h:88
-msgid "No Connect"
-msgstr "Keine-Verbindung"
 
 #: eeschema/sch_plugin.cpp:154
 msgid "Enable <b>debug</b> logging for Symbol*() functions in this SCH_PLUGIN."
@@ -10517,19 +10279,19 @@ msgstr ""
 "Geben Sie das Python Symbol ein welches die SCH_PLUGIN::Symbol*() Funktionen "
 "beinhaltet."
 
-#: eeschema/sch_sheet.cpp:888
+#: eeschema/sch_sheet.cpp:653
 msgid "Sheet Name"
 msgstr "Name Schaltplan"
 
-#: eeschema/sch_sheet.cpp:889
+#: eeschema/sch_sheet.cpp:654
 msgid "File Name"
 msgstr "Dateiname"
 
-#: eeschema/sch_sheet.cpp:894
+#: eeschema/sch_sheet.cpp:659
 msgid "Time Stamp"
 msgstr "Zeitstempel"
 
-#: eeschema/sch_sheet.cpp:1106
+#: eeschema/sch_sheet.cpp:871
 #, c-format
 msgid "Hierarchical Sheet %s"
 msgstr "Hierarchischer Schaltplan %s"
@@ -10539,59 +10301,59 @@ msgstr "Hierarchischer Schaltplan %s"
 msgid "%8.8lX/"
 msgstr "%8.8lX/"
 
-#: eeschema/sch_sheet_pin.cpp:502
+#: eeschema/sch_sheet_pin.cpp:346
 #, c-format
 msgid "Hierarchical Sheet Pin %s"
 msgstr "Hierarchischer Schaltplanpin %s"
 
-#: eeschema/sch_text.cpp:731
+#: eeschema/sch_text.cpp:613
 msgid "Graphic Text"
 msgstr "Grafischer Text"
 
-#: eeschema/sch_text.cpp:735
+#: eeschema/sch_text.cpp:617
 #: eeschema/widgets/widget_eeschema_color_config.cpp:62
 msgid "Label"
 msgstr "Bezeichner"
 
-#: eeschema/sch_text.cpp:739
+#: eeschema/sch_text.cpp:621
 msgid "Global Label"
 msgstr "Globaler Bezeichner"
 
-#: eeschema/sch_text.cpp:743
+#: eeschema/sch_text.cpp:625
 msgid "Hierarchical Label"
 msgstr "Hierarchischer Bezeichner"
 
-#: eeschema/sch_text.cpp:747
+#: eeschema/sch_text.cpp:629
 msgid "Hierarchical Sheet Pin"
 msgstr "Hierarchischer Schaltplanpin"
 
-#: eeschema/sch_text.cpp:759 pcbnew/dialogs/dialog_pad_properties_base.cpp:208
+#: eeschema/sch_text.cpp:641 pcbnew/dialogs/dialog_pad_properties_base.cpp:210
 msgid "Horizontal"
 msgstr "horizontal"
 
-#: eeschema/sch_text.cpp:763
+#: eeschema/sch_text.cpp:645
 msgid "Vertical up"
 msgstr "vertikal oben"
 
-#: eeschema/sch_text.cpp:767
+#: eeschema/sch_text.cpp:649
 msgid "Horizontal invert"
 msgstr "horizontal invertiert"
 
-#: eeschema/sch_text.cpp:771
+#: eeschema/sch_text.cpp:653
 msgid "Vertical down"
 msgstr "vertikal unten"
 
-#: eeschema/sch_text.cpp:1015
+#: eeschema/sch_text.cpp:812
 #, c-format
 msgid "Label %s"
 msgstr "Bezeichner %s"
 
-#: eeschema/sch_text.cpp:1478
+#: eeschema/sch_text.cpp:1181
 #, c-format
 msgid "Global Label %s"
 msgstr "Globaler Bezeichner %s"
 
-#: eeschema/sch_text.cpp:1836
+#: eeschema/sch_text.cpp:1444
 #, c-format
 msgid "Hierarchical Label %s"
 msgstr "Hierarchischer Bezeichner %s"
@@ -10661,88 +10423,88 @@ msgstr "Das %s Feld darf keine %s Zeichen enthalten."
 msgid "Field Validation Error"
 msgstr "Fehler Feldüberprüfung"
 
-#: eeschema/schedit.cpp:270
+#: eeschema/schedit.cpp:253
 msgid "There are no undefined labels in this sheet to clean up."
 msgstr ""
 "Es gibt keine undefinierten Bezeichnungen in diesem Schaltplan zu bereinigen."
 
-#: eeschema/schedit.cpp:274
+#: eeschema/schedit.cpp:257
 msgid "Do you wish to cleanup this sheet?"
 msgstr "Möchten Sie den Schaltplan aufräumen lassen?"
 
-#: eeschema/schedit.cpp:525
+#: eeschema/schedit.cpp:508
 msgid "Highlight specific net"
 msgstr "Netz hervorheben"
 
-#: eeschema/schedit.cpp:537
+#: eeschema/schedit.cpp:520
 msgid "Add no connect"
 msgstr "'Keine-Verbindung' Symbol hinzufügen"
 
-#: eeschema/schedit.cpp:541
+#: eeschema/schedit.cpp:524
 msgid "Add wire"
 msgstr "Elektr. Verbindungen hinzufügen"
 
-#: eeschema/schedit.cpp:545
+#: eeschema/schedit.cpp:528
 msgid "Add bus"
 msgstr "Bus hinzufügen"
 
-#: eeschema/schedit.cpp:549
+#: eeschema/schedit.cpp:532
 msgid "Add lines"
 msgstr "Linien hinzufügen"
 
-#: eeschema/schedit.cpp:553
+#: eeschema/schedit.cpp:536
 msgid "Add junction"
 msgstr "Knotenpunkt hinzufügen"
 
-#: eeschema/schedit.cpp:557
+#: eeschema/schedit.cpp:540
 msgid "Add label"
 msgstr "Bezeichner hinzufügen"
 
-#: eeschema/schedit.cpp:561
+#: eeschema/schedit.cpp:544
 msgid "Add global label"
 msgstr "Globalen Bezeichner hinzufügen"
 
-#: eeschema/schedit.cpp:565
+#: eeschema/schedit.cpp:548
 msgid "Add hierarchical label"
 msgstr "Hierarchische Bezeichner hinzufügen"
 
-#: eeschema/schedit.cpp:573
+#: eeschema/schedit.cpp:556
 msgid "Add image"
 msgstr "Bild hinzufügen"
 
-#: eeschema/schedit.cpp:577
+#: eeschema/schedit.cpp:560
 msgid "Add wire to bus entry"
 msgstr "Elektr. Verbindung an Buseingang führen"
 
-#: eeschema/schedit.cpp:581
+#: eeschema/schedit.cpp:564
 msgid "Add bus to bus entry"
 msgstr "Bus an einen Buseingang führen"
 
-#: eeschema/schedit.cpp:585
+#: eeschema/schedit.cpp:568
 msgid "Add sheet"
 msgstr "Schaltplan hinzufügen"
 
-#: eeschema/schedit.cpp:589
+#: eeschema/schedit.cpp:572
 msgid "Add sheet pins"
 msgstr "Schaltplanpins hinzufügen"
 
-#: eeschema/schedit.cpp:593
+#: eeschema/schedit.cpp:576
 msgid "Import sheet pins"
 msgstr "Schaltplanpins importieren"
 
-#: eeschema/schedit.cpp:597
+#: eeschema/schedit.cpp:580
 msgid "Add component"
 msgstr "Bauteil hinzufügen"
 
-#: eeschema/schedit.cpp:601
+#: eeschema/schedit.cpp:584
 msgid "Add power"
 msgstr "Spannungsquelle hinzufügen"
 
-#: eeschema/schedit.cpp:610
+#: eeschema/schedit.cpp:593
 msgid "Add a simulator probe"
 msgstr "Füge Simulationssonde hinzu"
 
-#: eeschema/schedit.cpp:615
+#: eeschema/schedit.cpp:598
 msgid "Select a value to be tuned"
 msgstr "Abstimmungswert wählen"
 
@@ -10754,34 +10516,32 @@ msgstr "Nicht gefunden"
 msgid "The following libraries were not found:"
 msgstr "Die folgenden Bibliotheken konnten nicht gefunden werden:"
 
-#: eeschema/schframe.cpp:653 pcbnew/pcbframe.cpp:610
+#: eeschema/schframe.cpp:652 pagelayout_editor/pl_editor_frame.cpp:227
+#: pcbnew/pcbframe.cpp:610
 #, c-format
 msgid ""
 "Save the changes in\n"
-"'%s'\n"
+"\"%s\"\n"
 "before closing?"
 msgstr ""
-"Änderungen in\n"
-"'%s'\n"
-"vor dem Beenden speichern?"
 
-#: eeschema/schframe.cpp:802
+#: eeschema/schframe.cpp:793
 msgid "Draw wires and buses in any direction"
 msgstr "Zeichne elektr. Verbindungen und Busse in beliebiger Richtung"
 
-#: eeschema/schframe.cpp:803
+#: eeschema/schframe.cpp:794
 msgid "Draw horizontal and vertical wires and buses only"
 msgstr "Zeichne nur horizontale und vertikale elektr. Verbindungen und Busse"
 
-#: eeschema/schframe.cpp:812
+#: eeschema/schframe.cpp:803
 msgid "Do not show hidden pins"
 msgstr "Versteckte Pins ausblenden"
 
-#: eeschema/schframe.cpp:813 eeschema/tool_sch.cpp:299
+#: eeschema/schframe.cpp:804 eeschema/tool_sch.cpp:293
 msgid "Show hidden pins"
 msgstr "Versteckte Pins einblenden"
 
-#: eeschema/schframe.cpp:877
+#: eeschema/schframe.cpp:868
 msgid ""
 "Cannot update the PCB, because the Schematic Editor is opened in stand-alone "
 "mode. In order to create/update PCBs from schematics, you need to launch "
@@ -10792,29 +10552,32 @@ msgstr ""
 "erstellen oder auch zu aktualisieren starten Sie den KiCad Projekt Manager "
 "und erstellen ein neues KiCad Projekt."
 
-#: eeschema/schframe.cpp:1010
+#: eeschema/schframe.cpp:1001
 msgid "Schematic"
 msgstr "Schaltplan"
 
-#: eeschema/schframe.cpp:1044
+#: eeschema/schframe.cpp:1034
 msgid "New Schematic"
 msgstr "Neuer Schaltplan"
 
-#: eeschema/schframe.cpp:1057
+#: eeschema/schframe.cpp:1047
 #, c-format
-msgid "Schematic file '%s' already exists, use Open instead"
+msgid "Schematic file \"%s\" already exists, use Open instead"
 msgstr ""
-"Die Schaltplan Datei '%s' existiert bereits, statt dessen \"Öffnen\" benutzen"
 
-#: eeschema/schframe.cpp:1078
+#: eeschema/schframe.cpp:1068
 msgid "Open Schematic"
 msgstr "Schaltplan öffnen"
 
-#: eeschema/schframe.cpp:1208
+#: eeschema/schframe.cpp:1167
+msgid "Could not open CvPcb"
+msgstr ""
+
+#: eeschema/schframe.cpp:1204
 msgid "Error: not a component or no component"
 msgstr "Fehler: Dies ist entweder kein Bauteil oder es kein Bauteil vorhanden."
 
-#: eeschema/schframe.cpp:1469
+#: eeschema/schframe.cpp:1489
 msgid " [no file]"
 msgstr " [keine Datei]"
 
@@ -10836,9 +10599,8 @@ msgstr "Wähle Symbolbibliothek"
 
 #: eeschema/selpart.cpp:144
 #, c-format
-msgid "Error occurred loading symbol library '%s'."
+msgid "Error occurred loading symbol library \"%s\"."
 msgstr ""
-"Ein Fehler ist aufgetreten beim Laden eines Symbols aus der Bibliothek '%s'."
 
 #: eeschema/selpart.cpp:150
 msgid "Library:Symbol"
@@ -10848,28 +10610,26 @@ msgstr "Bibliothek:Symbol"
 msgid "Select Symbol"
 msgstr "Symbol auswählen"
 
-#: eeschema/sheet.cpp:84
+#: eeschema/sheet.cpp:85
 msgid "File name is not valid!"
 msgstr "Kein gültiger Dateiname!"
 
-#: eeschema/sheet.cpp:93
+#: eeschema/sheet.cpp:94
 #, c-format
 msgid "A sheet named \"%s\" already exists."
 msgstr "Eine Schaltplan mit dem Namen \"%s\" existiert bereits."
 
-#: eeschema/sheet.cpp:125
+#: eeschema/sheet.cpp:128 eeschema/sheet.cpp:172
 #, c-format
-msgid "A file named '%s' already exists in the current schematic hierarchy."
+msgid "A file named \"%s\" already exists in the current schematic hierarchy."
 msgstr ""
-"Eine Datei namens '%s' existiert bereits in der gegenwärtigen "
-"Schaltplanhierarchie."
 
-#: eeschema/sheet.cpp:130
+#: eeschema/sheet.cpp:133 eeschema/sheet.cpp:177
 #, c-format
-msgid "A file named '%s' already exists."
-msgstr "Eine Datei namens '%s' existiert bereits."
+msgid "A file named \"%s\" already exists."
+msgstr ""
 
-#: eeschema/sheet.cpp:133
+#: eeschema/sheet.cpp:136
 msgid ""
 "\n"
 "\n"
@@ -10879,24 +10639,12 @@ msgstr ""
 "\n"
 "Möchten Sie einen Schaltplan aus dem Inhalt dieser Datei erstellen?"
 
-#: eeschema/sheet.cpp:160
+#: eeschema/sheet.cpp:164
 msgid "Changing the sheet file name cannot be undone.  "
 msgstr ""
 "Eine Änderung des Schaltplandateinamens kann nicht rückgängig gemacht werden."
 
-#: eeschema/sheet.cpp:168
-#, c-format
-msgid "A file named <%s> already exists in the current schematic hierarchy."
-msgstr ""
-"Eine Datei namens <%s> existiert bereits in der gegenwärtigen "
-"Schaltplanhierarchie."
-
-#: eeschema/sheet.cpp:173
-#, c-format
-msgid "A file named <%s> already exists."
-msgstr "Eine Datei namens <%s> existiert bereits."
-
-#: eeschema/sheet.cpp:178
+#: eeschema/sheet.cpp:181
 msgid ""
 "\n"
 "\n"
@@ -10906,7 +10654,7 @@ msgstr ""
 "\n"
 "Möchten Sie den Schaltplan mit dem Inhalt dieser Datei ersetzen?"
 
-#: eeschema/sheet.cpp:190
+#: eeschema/sheet.cpp:193
 msgid ""
 "This sheet uses shared data in a complex hierarchy.\n"
 "\n"
@@ -10915,118 +10663,133 @@ msgstr ""
 "komplexen Hierarchie.\n"
 "\n"
 
-#: eeschema/sheet.cpp:191
+#: eeschema/sheet.cpp:194
 msgid "Do you wish to convert it to a simple hierarchical sheet?"
 msgstr ""
 "Möchten Sie es in einen einfachen hierarchischen Schaltplan konvertieren "
 "lassen?"
 
+#: eeschema/sheet.cpp:219
+#, c-format
+msgid "Error occurred saving schematic file \"%s\"."
+msgstr ""
+
+#: eeschema/sheet.cpp:222
+#, c-format
+msgid "Failed to save schematic \"%s\""
+msgstr ""
+
+#: eeschema/sheet.cpp:304
+#, c-format
+msgid ""
+"The schematic \"%s\" has not been remapped to the symbol library table. Most "
+"if not all of the symbol library links will be broken.  Do you want to "
+"continue?"
+msgstr ""
+
 #: eeschema/sheetlab.cpp:167
 msgid "No new hierarchical labels found."
 msgstr "Keine neuen hierarchischen Bezeichner gefunden."
 
-#: eeschema/sim/sim_plot_frame.cpp:155
+#: eeschema/sim/sim_plot_frame.cpp:156
 msgid "Run/Stop Simulation"
 msgstr "Starten/Stoppen Simulation"
 
-#: eeschema/sim/sim_plot_frame.cpp:156 eeschema/sim/sim_plot_frame_base.cpp:51
+#: eeschema/sim/sim_plot_frame.cpp:157 eeschema/sim/sim_plot_frame_base.cpp:51
 msgid "Run Simulation"
 msgstr "Starte Simulation"
 
-#: eeschema/sim/sim_plot_frame.cpp:157
+#: eeschema/sim/sim_plot_frame.cpp:158
 msgid "Add Signals"
 msgstr "Signale hinzufügen"
 
-#: eeschema/sim/sim_plot_frame.cpp:158
+#: eeschema/sim/sim_plot_frame.cpp:159
 msgid "Add signals to plot"
 msgstr "Signale dem Plot hinzufügen"
 
-#: eeschema/sim/sim_plot_frame.cpp:159
+#: eeschema/sim/sim_plot_frame.cpp:160
 msgid "Probe"
 msgstr "Sonde"
 
-#: eeschema/sim/sim_plot_frame.cpp:160
+#: eeschema/sim/sim_plot_frame.cpp:161
 msgid "Probe signals on the schematic"
 msgstr "Prüfe Signale auf dem Schaltplan"
 
-#: eeschema/sim/sim_plot_frame.cpp:161 eeschema/sim/sim_plot_frame_base.cpp:238
+#: eeschema/sim/sim_plot_frame.cpp:162 eeschema/sim/sim_plot_frame_base.cpp:238
 msgid "Tune"
 msgstr "Anpassen"
 
-#: eeschema/sim/sim_plot_frame.cpp:162
+#: eeschema/sim/sim_plot_frame.cpp:163
 msgid "Tune component values"
 msgstr "Bauteilwerte anpassen"
 
-#: eeschema/sim/sim_plot_frame.cpp:163
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:101
+#: eeschema/sim/sim_plot_frame.cpp:164
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:103
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: eeschema/sim/sim_plot_frame.cpp:185
+#: eeschema/sim/sim_plot_frame.cpp:165
+#: eeschema/dialogs/dialog_sim_settings_base.h:123
+msgid "Simulation settings"
+msgstr "Einstellungen für Simulationen"
+
+#: eeschema/sim/sim_plot_frame.cpp:186
 msgid "Welcome!"
 msgstr "Willkommen!"
 
-#: eeschema/sim/sim_plot_frame.cpp:277 eeschema/sim/sim_plot_frame.cpp:999
+#: eeschema/sim/sim_plot_frame.cpp:278 eeschema/sim/sim_plot_frame.cpp:1000
 msgid "There were errors during netlist export, aborted."
 msgstr "Es sind Fehler während des Netzlistenexports aufgetreten. Abbruch!"
 
-#: eeschema/sim/sim_plot_frame.cpp:283
+#: eeschema/sim/sim_plot_frame.cpp:284
 msgid "You need to select the simulation settings first."
 msgstr "Sie müssen zuerst die Einstellungen für die Simulation bearbeiten. "
 
-#: eeschema/sim/sim_plot_frame.cpp:547 eeschema/sim/sim_plot_frame.cpp:1086
+#: eeschema/sim/sim_plot_frame.cpp:548 eeschema/sim/sim_plot_frame.cpp:1087
 msgid "Signal"
 msgstr "Signal"
 
-#: eeschema/sim/sim_plot_frame.cpp:784
+#: eeschema/sim/sim_plot_frame.cpp:785
 msgid "Open simulation workbook"
 msgstr "Arbeitsmappe öffnen"
 
-#: eeschema/sim/sim_plot_frame.cpp:785 eeschema/sim/sim_plot_frame.cpp:803
-msgid "Workbook file (*.wbk)|*.wbk"
-msgstr "Workbook Datei (*.wbk)|*.wbk"
-
-#: eeschema/sim/sim_plot_frame.cpp:793
+#: eeschema/sim/sim_plot_frame.cpp:794
 msgid "There was an error while opening the workbook file"
 msgstr "Beim Öffnen der Workbook-Datei ist ein Fehler ist aufgetreten."
 
-#: eeschema/sim/sim_plot_frame.cpp:802
-msgid "Save simulation workbook"
-msgstr "Arbeitsmappe speichern"
+#: eeschema/sim/sim_plot_frame.cpp:803
+msgid "Save Simulation Workbook"
+msgstr ""
 
-#: eeschema/sim/sim_plot_frame.cpp:811
+#: eeschema/sim/sim_plot_frame.cpp:812
 msgid "There was an error while saving the workbook file"
 msgstr "Ein Fehler ist aufgetreten beim Speichern der Workbook-Datei."
 
-#: eeschema/sim/sim_plot_frame.cpp:820
-msgid "Save plot as image"
-msgstr "Speichert den Plot als Bilddatei."
-
 #: eeschema/sim/sim_plot_frame.cpp:821
-msgid "PNG file (*.png)|*.png"
-msgstr "PNG Datei (*.png)|*.png"
+msgid "Save Plot as Image"
+msgstr ""
 
-#: eeschema/sim/sim_plot_frame.cpp:837
-msgid "Save plot data"
-msgstr "Plotdaten speichern"
+#: eeschema/sim/sim_plot_frame.cpp:838
+msgid "Save Plot Data"
+msgstr ""
 
-#: eeschema/sim/sim_plot_frame.cpp:1033
+#: eeschema/sim/sim_plot_frame.cpp:1034
 msgid "You need to run simulation first."
 msgstr "Sie müssen die Simulation zuerst starten."
 
-#: eeschema/sim/sim_plot_frame.cpp:1215
+#: eeschema/sim/sim_plot_frame.cpp:1216
 msgid "Hide signal"
 msgstr "Signal ausblenden"
 
-#: eeschema/sim/sim_plot_frame.cpp:1216
+#: eeschema/sim/sim_plot_frame.cpp:1217
 msgid "Erase the signal from plot screen"
 msgstr "Löschen des Signals aus der Plotanzeige"
 
-#: eeschema/sim/sim_plot_frame.cpp:1222
+#: eeschema/sim/sim_plot_frame.cpp:1223
 msgid "Hide cursor"
 msgstr "Cursor ausblenden"
 
-#: eeschema/sim/sim_plot_frame.cpp:1225
+#: eeschema/sim/sim_plot_frame.cpp:1226
 msgid "Show cursor"
 msgstr "Cursor zeigen"
 
@@ -11108,157 +10871,118 @@ msgstr "Signale"
 msgid "Cursors"
 msgstr "Cursor"
 
-#: eeschema/sim/sim_plot_frame_base.h:108
-msgid "Spice Simulator"
-msgstr "Spice Simulator"
-
 #: eeschema/sim/spice_value.cpp:251
 msgid "Please, fill required fields"
 msgstr "Bitte benötigte Felder ausfüllen."
 
 #: eeschema/sim/spice_value.cpp:270
 #, c-format
-msgid "'%s' is not a valid Spice value"
-msgstr "'%s' ist kein gültiger Spice-Wert."
-
-#: eeschema/symbedit.cpp:64
-msgid "Import Symbol Drawings"
-msgstr "Zeichnungs-Symbole importieren"
-
-#: eeschema/symbedit.cpp:87
-#, c-format
-msgid "No parts found in part file '%s'."
-msgstr "Keine Bauteile in Symbolbibliothek '%s' gefunden."
-
-#: eeschema/symbedit.cpp:94
-#, c-format
-msgid "Error '%s' occurred loading part file '%s'."
+msgid "\"%s\" is not a valid Spice value"
 msgstr ""
-"Fehler '%s' ist aufgetreten beim Einlesen der Symbolbibliotheksdatei '%s'."
 
-#: eeschema/symbedit.cpp:102
+#: eeschema/symbedit.cpp:106
 #, c-format
-msgid "More than one part in part file '%s'."
-msgstr "Symboldatei '%s' enthält mehr als ein Element."
-
-#: eeschema/symbedit.cpp:156
-msgid "Export Symbol Drawings"
-msgstr "Zeichnungs Symbole exportieren"
-
-#: eeschema/symbedit.cpp:172
-#, c-format
-msgid "Saving symbol in '%s'"
-msgstr "Speichere Symbol in '%s'"
-
-#: eeschema/symbedit.cpp:238
-#, c-format
-msgid "An error occurred attempting to save symbol file '%s'"
+msgid "More than one symbol found in symbol file \"%s\"."
 msgstr ""
-"Bei dem Versuch die Symboldatei '%s' zu speichern ist ein Fehler aufgetreten."
 
-#: eeschema/symbol_lib_table.cpp:202
+#: eeschema/symbedit.cpp:194
+#, c-format
+msgid "Saving symbol in \"%s\""
+msgstr ""
+
+#: eeschema/symbedit.cpp:211
+#, c-format
+msgid "An error occurred attempting to save symbol file \"%s\""
+msgstr ""
+
+#: eeschema/symbol_lib_table.cpp:210
 #, c-format
 msgid ""
-"Duplicate library nickname '%s' found in symbol library table file line %d"
+"Duplicate library nickname \"%s\" found in symbol library table file line %d"
 msgstr ""
-"Doppelter Bibliotheken-Nickname '%s' in der Tabelle der Bauteilbibliotheken "
-"in Zeile '%d gefunden."
 
-#: eeschema/symbol_lib_table.cpp:283
+#: eeschema/symbol_lib_table.cpp:297
 #, c-format
-msgid "sym-lib-table files contain no library with nickname '%s'"
+msgid "sym-lib-table files contain no library with nickname \"%s\""
 msgstr ""
-"Die Symbol-Bibliotheks-Tabelle enthält keine Bibliothek mit dem Nicknamen "
-"'%s'"
 
-#: eeschema/tool_lib.cpp:63
+#: eeschema/tool_lib.cpp:58
 msgid "Deselect current tool"
 msgstr "Aktuelles Werkzeug abwählen"
 
-#: eeschema/tool_lib.cpp:84
+#: eeschema/tool_lib.cpp:79
 msgid "Move part anchor"
 msgstr "Bauteilanker verschieben"
 
-#: eeschema/tool_lib.cpp:87
+#: eeschema/tool_lib.cpp:82
 msgid "Import existing drawings"
 msgstr "Existierende Zeichnungen importieren"
 
-#: eeschema/tool_lib.cpp:90
+#: eeschema/tool_lib.cpp:85
 msgid "Export current drawing"
 msgstr "Aktuelle Zeichnung exportieren"
 
-#: eeschema/tool_lib.cpp:116
-msgid "Save into current library"
-msgstr "In momentan aktive Bauteilbibliothek speichern"
+#: eeschema/tool_lib.cpp:108
+msgid "Create a new library"
+msgstr ""
 
-#: eeschema/tool_lib.cpp:126
-msgid "Delete component in current library"
-msgstr "Bauteil in aktueller Bibliothek entfernen"
+#: eeschema/tool_lib.cpp:112
+msgid "Add an existing library"
+msgstr ""
+
+#: eeschema/tool_lib.cpp:116
+msgid "Save current library"
+msgstr ""
+
+#: eeschema/tool_lib.cpp:120
+msgid "Create new part"
+msgstr ""
+
+#: eeschema/tool_lib.cpp:124
+msgid "Save current part"
+msgstr ""
+
+#: eeschema/tool_lib.cpp:127
+msgid "Import part"
+msgstr ""
 
 #: eeschema/tool_lib.cpp:130
-msgid "Create new component"
-msgstr "Ein neues Bauteil erstellen"
+msgid "Export part"
+msgstr ""
 
-#: eeschema/tool_lib.cpp:134
-msgid "Load component from current library"
-msgstr "Bauteil zum Editieren aus der gegenwärtigen Bibliothek laden"
+#: eeschema/tool_lib.cpp:135 eeschema/tool_sch.cpp:84
+#: pcbnew/tools/pcbnew_control.cpp:231
+msgid "Paste"
+msgstr "Einfügen"
 
-#: eeschema/tool_lib.cpp:138
-msgid "Create new component from current component"
-msgstr "Aus dem gegenwärtigen Bauteil ein Neues erstellen"
-
-#: eeschema/tool_lib.cpp:142
-msgid "Update current component in current library"
-msgstr "Gegenwärtiges Bauteil in aktueller Bibliothek aktualisieren"
-
-#: eeschema/tool_lib.cpp:145
-msgid "Import component"
-msgstr "Bauteil importieren"
-
-#: eeschema/tool_lib.cpp:148
-msgid "Export component"
-msgstr "Bauteil exportieren"
-
-#: eeschema/tool_lib.cpp:159
-msgid "Edit component properties"
-msgstr "Eigenschaften des Bauteils editieren"
-
-#: eeschema/tool_lib.cpp:163
-msgid "Edit field properties"
-msgstr "Feldeigenschaften bearbeiten"
-
-#: eeschema/tool_lib.cpp:167
-msgid "Check duplicate and off grid pins"
-msgstr "Auf Pin-Duplikate und Pins außerhalb des Rasters prüfen"
-
-#: eeschema/tool_lib.cpp:187 eeschema/tool_viewlib.cpp:92
+#: eeschema/tool_lib.cpp:176 eeschema/tool_viewlib.cpp:92
 msgid "Show as \"De Morgan\" normal part"
 msgstr "Bauteil in \"De Morgan\" Normaldarstellung"
 
-#: eeschema/tool_lib.cpp:189 eeschema/tool_viewlib.cpp:97
+#: eeschema/tool_lib.cpp:178 eeschema/tool_viewlib.cpp:97
 msgid "Show as \"De Morgan\" convert part"
 msgstr "Bauteil in \"De Morgan\" Darstellung konvertieren"
 
-#: eeschema/tool_lib.cpp:193
+#: eeschema/tool_lib.cpp:182
 msgid "Show associated datasheet or document"
 msgstr "Zeige das verbundene Datenblatt oder Dokumentation"
 
-#: eeschema/tool_lib.cpp:213
+#: eeschema/tool_lib.cpp:202
 msgid "Edit pins per part or body style (Use carefully!)"
 msgstr "Pins nach Bauteil oder Gehäusetyp editieren (Mit Vorsichtig anwenden!)"
 
-#: eeschema/tool_lib.cpp:217
-msgid "Show pin table"
-msgstr "Zeige Pin-Tabelle"
-
-#: eeschema/tool_lib.cpp:233 eeschema/tool_sch.cpp:280
+#: eeschema/tool_lib.cpp:222 eeschema/tool_sch.cpp:274
 #: gerbview/toolbars_gerber.cpp:231
 msgid "Turn grid off"
 msgstr "Raster ausschalten"
 
-#: eeschema/tool_lib.cpp:251
+#: eeschema/tool_lib.cpp:240
 msgid "Show pins electrical type"
 msgstr "Elektrische Anschlusstypen anzeigen"
+
+#: eeschema/tool_lib.cpp:244
+msgid "Toggles the search tree"
+msgstr ""
 
 #: eeschema/tool_sch.cpp:59
 msgid "New schematic project"
@@ -11284,65 +11008,57 @@ msgstr "Schaltplan drucken"
 msgid "Plot schematic"
 msgstr "Schaltplan plotten"
 
-#: eeschema/tool_sch.cpp:84
-msgid "Cut selected item"
-msgstr "Gewähltes Element ausschneiden"
-
-#: eeschema/tool_sch.cpp:87
-msgid "Copy selected item"
-msgstr "Gewähltes Element kopieren"
-
-#: eeschema/tool_sch.cpp:90 pcbnew/tools/pcbnew_control.cpp:231
-msgid "Paste"
-msgstr "Einfügen"
-
-#: eeschema/tool_sch.cpp:108
+#: eeschema/tool_sch.cpp:102
 msgid "Find and replace text"
 msgstr "Text suchen und ersetzen"
 
-#: eeschema/tool_sch.cpp:133
+#: eeschema/tool_sch.cpp:127
 msgid "Navigate schematic hierarchy"
 msgstr "Navigation in der Schaltplanhierarchie"
 
-#: eeschema/tool_sch.cpp:137
+#: eeschema/tool_sch.cpp:131
 msgid "Leave sheet"
 msgstr "Schaltplan verlassen"
 
-#: eeschema/tool_sch.cpp:150
+#: eeschema/tool_sch.cpp:144
 msgid "Footprint Editor - Create/edit footprints"
 msgstr "Bibliothekseditor - Bauteile erstellen oder bearbeiten"
 
-#: eeschema/tool_sch.cpp:161
+#: eeschema/tool_sch.cpp:155
 msgid "Run CvPcb to associate footprints to components"
 msgstr ""
 "Starte CvPcb für eine Zuordnung von Schaltplansymbolen zu Footprintlayouts"
 
-#: eeschema/tool_sch.cpp:164
+#: eeschema/tool_sch.cpp:158
 msgid "Generate netlist"
 msgstr "Netzliste erstellen"
 
-#: eeschema/tool_sch.cpp:167
+#: eeschema/tool_sch.cpp:161
 msgid "Edit Components Fields"
 msgstr "Bauteileigenschaften editieren"
 
-#: eeschema/tool_sch.cpp:176
+#: eeschema/tool_sch.cpp:170
 msgid "Run Pcbnew to layout printed circuit board"
 msgstr "Starte Pcbnew zum Entwerfen gedruckter Leiterplatten"
 
-#: eeschema/tool_sch.cpp:202 pcbnew/edit.cpp:1518 pcbnew/tool_pcb.cpp:431
-#: pcbnew/tools/pcb_editor_control.cpp:1107
+#: eeschema/tool_sch.cpp:196 pcbnew/edit.cpp:1523 pcbnew/tool_pcb.cpp:431
+#: pcbnew/tools/pcb_editor_control.cpp:944
 msgid "Highlight net"
 msgstr "Netz hervorheben"
 
-#: eeschema/tool_sch.cpp:284
+#: eeschema/tool_sch.cpp:252 eeschema/help_common_strings.h:90
+msgid "Add bitmap image"
+msgstr "Bitmap Grafik hinzufügen"
+
+#: eeschema/tool_sch.cpp:278
 msgid "Set unit to inch"
 msgstr "Einheiten in Zoll"
 
-#: eeschema/tool_sch.cpp:288
+#: eeschema/tool_sch.cpp:282
 msgid "Set unit to mm"
 msgstr "Einheiten in Millimetern"
 
-#: eeschema/tool_sch.cpp:304
+#: eeschema/tool_sch.cpp:298
 msgid "HV orientation for wires and bus"
 msgstr "H-V Ausrichtung für elektr. Verbindungen und Busse"
 
@@ -11400,22 +11116,58 @@ msgstr "Über Eeschema Schaltplan Designer"
 msgid "Library Browser"
 msgstr "Bibliotheksbrowser"
 
-#: eeschema/viewlibs.cpp:65
+#: eeschema/viewlibs.cpp:59
 #, c-format
 msgid "Choose Component (%d items loaded)"
 msgstr "Bauteilauswahl (%d Elemente geladen)"
 
-#: eeschema/widgets/component_tree.cpp:99
+#: eeschema/widgets/cmp_tree_pane.cpp:50 eeschema/widgets/cmp_tree_pane.cpp:74
+msgid "New library..."
+msgstr ""
+
+#: eeschema/widgets/cmp_tree_pane.cpp:51 eeschema/widgets/cmp_tree_pane.cpp:75
+msgid "Add existing library..."
+msgstr ""
+
+#: eeschema/widgets/cmp_tree_pane.cpp:53
+msgid "Save library as..."
+msgstr ""
+
+#: eeschema/widgets/cmp_tree_pane.cpp:54
+msgid "Revert library"
+msgstr ""
+
+#: eeschema/widgets/cmp_tree_pane.cpp:56
+msgid "New part..."
+msgstr ""
+
+#: eeschema/widgets/cmp_tree_pane.cpp:57
+msgid "Import part..."
+msgstr ""
+
+#: eeschema/widgets/cmp_tree_pane.cpp:58
+msgid "Paste part"
+msgstr ""
+
+#: eeschema/widgets/cmp_tree_pane.cpp:63
+msgid "Export..."
+msgstr ""
+
+#: eeschema/widgets/cmp_tree_pane.cpp:65
+msgid "Revert"
+msgstr ""
+
+#: eeschema/widgets/cmp_tree_pane.cpp:67 pcbnew/tools/edit_tool.cpp:174
+msgid "Cut"
+msgstr "Ausschneiden"
+
+#: eeschema/widgets/component_tree.cpp:105
 msgid "Search"
 msgstr "Suchen"
 
 #: eeschema/widgets/tuner_slider_base.cpp:24
 msgid " X "
 msgstr " X "
-
-#: eeschema/widgets/tuner_slider_base.cpp:66 pagelayout_editor/hotkeys.cpp:96
-msgid "Save"
-msgstr "Speichern"
 
 #: eeschema/widgets/widget_eeschema_color_config.cpp:59
 msgid "Wire"
@@ -11424,6 +11176,11 @@ msgstr "Elektr. Verbindung"
 #: eeschema/widgets/widget_eeschema_color_config.cpp:60
 msgid "Bus"
 msgstr "Bus"
+
+#: eeschema/widgets/widget_eeschema_color_config.cpp:61
+#: eeschema/sch_junction.h:82
+msgid "Junction"
+msgstr "Knotenpunkt"
 
 #: eeschema/widgets/widget_eeschema_color_config.cpp:63
 msgid "Global label"
@@ -11502,71 +11259,71 @@ msgstr ""
 "sodass diese auf dem Bildschirm nicht sichtbar sein werden.\n"
 "Sind Sie sicher das Sie diese Farbe benutzen wollen?"
 
-#: gerbview/class_gerber_draw_item.cpp:612
+#: gerbview/class_gerber_draw_item.cpp:682
 #, c-format
 msgid "D Code %d"
 msgstr "Darstellungs-Code %d"
 
-#: gerbview/class_gerber_draw_item.cpp:616
+#: gerbview/class_gerber_draw_item.cpp:686
 msgid "No attribute"
 msgstr "Kein Attribute"
 
-#: gerbview/class_gerber_draw_item.cpp:624
+#: gerbview/class_gerber_draw_item.cpp:694
 msgid "Graphic Layer"
 msgstr "Grafische Lage"
 
-#: gerbview/class_gerber_draw_item.cpp:631
+#: gerbview/class_gerber_draw_item.cpp:701
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:350
 #: pcbnew/class_module.cpp:564
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:66
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:923
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:68
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:925
 msgid "Rotation"
 msgstr "Drehung"
 
-#: gerbview/class_gerber_draw_item.cpp:634
+#: gerbview/class_gerber_draw_item.cpp:704
 msgid "Clear"
 msgstr "hell"
 
-#: gerbview/class_gerber_draw_item.cpp:634
+#: gerbview/class_gerber_draw_item.cpp:704
 msgid "Dark"
 msgstr "dunkel"
 
-#: gerbview/class_gerber_draw_item.cpp:635
+#: gerbview/class_gerber_draw_item.cpp:705
 #: gerbview/class_gerber_file_image.cpp:354
 msgid "Polarity"
 msgstr "Polarität"
 
-#: gerbview/class_gerber_draw_item.cpp:641
+#: gerbview/class_gerber_draw_item.cpp:711
 #: gerbview/dialogs/dialog_print_using_printer_base.cpp:77
 #: pcbnew/class_pcb_text.cpp:138 pcbnew/class_pcb_text.cpp:140
-#: pcbnew/class_text_mod.cpp:381
-#: pcbnew/dialogs/dialog_dimension_editor_base.cpp:77
+#: pcbnew/class_text_mod.cpp:389
+#: pcbnew/dialogs/dialog_dimension_editor_base.cpp:78
 #: pcbnew/dialogs/dialog_print_using_printer_base.cpp:115
 #: pcbnew/modedit_onclick.cpp:296 pcbnew/tools/edit_tool.cpp:137
 #: pcbnew/tools/edit_tool.cpp:793
 msgid "Mirror"
 msgstr "Spiegeln"
 
-#: gerbview/class_gerber_draw_item.cpp:645
+#: gerbview/class_gerber_draw_item.cpp:715
 msgid "AB axis"
 msgstr "AB Achse"
 
-#: gerbview/class_gerber_draw_item.cpp:657 gerbview/toolbars_gerber.cpp:158
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:50
+#: gerbview/class_gerber_draw_item.cpp:727 gerbview/toolbars_gerber.cpp:158
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:52
 #: pcbnew/dialogs/dialog_track_via_properties_base.cpp:29
 msgid "Net:"
 msgstr "Netz:"
 
-#: gerbview/class_gerber_draw_item.cpp:668
+#: gerbview/class_gerber_draw_item.cpp:738
 #, c-format
 msgid "Cmp: %s;  Pad: %s"
 msgstr "Komp: %s; Pad: %s"
 
-#: gerbview/class_gerber_draw_item.cpp:675 gerbview/toolbars_gerber.cpp:148
+#: gerbview/class_gerber_draw_item.cpp:745 gerbview/toolbars_gerber.cpp:148
 msgid "Cmp:"
 msgstr "Komp:"
 
-#: gerbview/class_gerber_draw_item.cpp:813
+#: gerbview/class_gerber_draw_item.cpp:906
 #, c-format
 msgid "%s (D%d) on layer %d: %s"
 msgstr "%s (D%d) auf Lage %d: %s"
@@ -11603,24 +11360,24 @@ msgstr "Grafische Lage %d"
 #: gerbview/class_gerbview_layer_widget.cpp:95
 #: gerbview/dialogs/dialog_print_using_printer.cpp:163
 #: gerbview/dialogs/dialog_select_one_pcb_layer.cpp:163
-#: pcbnew/class_drawsegment.cpp:383 pcbnew/class_pad.cpp:701
-#: pcbnew/class_pcb_layer_widget.cpp:364 pcbnew/class_pcb_text.cpp:135
-#: pcbnew/class_text_mod.cpp:374 pcbnew/class_track.cpp:1161
-#: pcbnew/class_track.cpp:1188 pcbnew/class_zone.cpp:878
-#: pcbnew/dialogs/dialog_dimension_editor_base.cpp:83
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:111
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:140
+#: pcbnew/class_drawsegment.cpp:401 pcbnew/class_pad.cpp:701
+#: pcbnew/class_pcb_layer_widget.cpp:365 pcbnew/class_pcb_text.cpp:135
+#: pcbnew/class_text_mod.cpp:382 pcbnew/class_track.cpp:1161
+#: pcbnew/class_track.cpp:1188 pcbnew/class_zone.cpp:874
+#: pcbnew/dialogs/dialog_dimension_editor_base.cpp:84
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:113
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:142
 #: pcbnew/layer_widget.cpp:461
 msgid "Layer"
 msgstr "Lagen"
 
 #: gerbview/class_gerbview_layer_widget.cpp:96
-#: pcbnew/class_pcb_layer_widget.cpp:365 pcbnew/layer_widget.cpp:481
+#: pcbnew/class_pcb_layer_widget.cpp:366 pcbnew/layer_widget.cpp:481
 msgid "Render"
 msgstr "Elemente"
 
 #: gerbview/class_gerbview_layer_widget.cpp:116
-#: pcbnew/class_pcb_layer_widget.cpp:77
+#: pcbnew/class_pcb_layer_widget.cpp:78
 msgid "Show the (x,y) grid dots"
 msgstr "Rasterpunkte anzeigen"
 
@@ -11641,7 +11398,7 @@ msgid "Show negative objects in this color"
 msgstr "Zeige negative Objekte in dieser Farbe"
 
 #: gerbview/class_gerbview_layer_widget.cpp:141
-#: pcbnew/class_pcb_layer_widget.cpp:177
+#: pcbnew/class_pcb_layer_widget.cpp:178
 msgid "Show All Layers"
 msgstr "Alle Lagen einblenden"
 
@@ -11654,7 +11411,7 @@ msgid "Always Hide All Layers But Active"
 msgstr "Alle Lagen, außer der Aktiven, ausblenden"
 
 #: gerbview/class_gerbview_layer_widget.cpp:150
-#: pcbnew/class_pcb_layer_widget.cpp:175
+#: pcbnew/class_pcb_layer_widget.cpp:176
 msgid "Hide All Layers"
 msgstr "Alle Lagen ausblenden"
 
@@ -11719,11 +11476,6 @@ msgstr "Auswahl speichern"
 #: gerbview/dialogs/dialog_layers_select_to_pcb_base.cpp:82
 msgid "Get Stored Choice"
 msgstr "Auswahl laden"
-
-#: gerbview/dialogs/dialog_layers_select_to_pcb_base.h:83
-#: pcbnew/dialogs/dialog_non_copper_zones_properties_base.cpp:30
-msgid "Layer selection:"
-msgstr "Lagenauswahl:"
 
 #: gerbview/dialogs/dialog_print_using_printer.cpp:110
 #: pagelayout_editor/events_functions.cpp:533
@@ -11915,10 +11667,6 @@ msgstr "Seitenformat C"
 msgid "Show Page Limits:"
 msgstr "Zeige Seitenbegrenzungen:"
 
-#: gerbview/dialogs/dialog_show_page_borders_base.h:50
-msgid "Page Borders"
-msgstr "Seitenbegrenzung"
-
 #: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:24
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:25
 msgid "Cartesian coordinates"
@@ -11935,7 +11683,7 @@ msgid "Coordinates"
 msgstr "Koordinaten"
 
 #: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:30
-#: pcbnew/dialogs/dialog_export_idf_base.cpp:100
+#: pcbnew/dialogs/dialog_export_idf_base.cpp:102
 #: pcbnew/dialogs/dialog_gendrill_base.cpp:49
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:33
 #: pcbnew/dialogs/dialog_set_grid_base.cpp:25
@@ -11961,7 +11709,7 @@ msgid "Flashed items"
 msgstr "Hervorgehobene Elemente"
 
 #: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:50
-#: pcbnew/class_zone.cpp:886
+#: pcbnew/class_zone.cpp:882
 msgid "Polygons"
 msgstr "Polygone"
 
@@ -11982,19 +11730,15 @@ msgstr "Seite"
 msgid "Use touchpad to pan"
 msgstr "Benutzen des Touchpads zum Verschieben"
 
-#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.h:63
-msgid "Gerbview Options"
-msgstr "GerbView Optionen"
-
 #: gerbview/events_called_functions.cpp:243
-#: gerbview/events_called_functions.cpp:525 pcbnew/edit.cpp:1531
+#: gerbview/events_called_functions.cpp:525 pcbnew/edit.cpp:1536
 msgid "Unsupported tool in this canvas"
 msgstr "Nicht unterstütztes Werkzeug in dieser Darstellung"
 
 #: gerbview/events_called_functions.cpp:384
 #, c-format
-msgid "Source file '%s' is not available"
-msgstr "Quelldatei '%s' ist nicht vorhanden"
+msgid "Source file \"%s\" is not available"
+msgstr ""
 
 #: gerbview/events_called_functions.cpp:392
 msgid "No editor defined. Please select one"
@@ -12006,7 +11750,7 @@ msgid "No file loaded on the active layer %d"
 msgstr "Es wurde keine Datei für die aktive Lage %d geladen."
 
 #: gerbview/events_called_functions.cpp:442 gerbview/gerbview_frame.cpp:166
-#: pcbnew/moduleframe.cpp:313 pcbnew/pcbframe.cpp:413 pcbnew/pcbframe.cpp:967
+#: pcbnew/moduleframe.cpp:313 pcbnew/pcbframe.cpp:413 pcbnew/pcbframe.cpp:960
 msgid "Visibles"
 msgstr "Sichtbarkeit"
 
@@ -12068,18 +11812,18 @@ msgstr "Werkzeug %d ist nicht definiert"
 msgid "Unknown Excellon G Code: &lt;%s&gt;"
 msgstr "Unbekannter Excellon G-Code: &lt;%s&gt;"
 
-#: gerbview/export_to_pcbnew.cpp:170
+#: gerbview/export_to_pcbnew.cpp:171
 msgid "None of the Gerber layers contain any data"
 msgstr "Keine der Gerberlagen enthält Daten"
 
-#: gerbview/export_to_pcbnew.cpp:177
-msgid "Board file name:"
-msgstr "Dateiename der Platine:"
+#: gerbview/export_to_pcbnew.cpp:178
+msgid "Board File Name"
+msgstr ""
 
-#: gerbview/export_to_pcbnew.cpp:213
+#: gerbview/export_to_pcbnew.cpp:214
 #, c-format
-msgid "Cannot create file '%s'"
-msgstr "Konnte Datei '%s' nicht erstellen."
+msgid "Cannot create file \"%s\""
+msgstr ""
 
 #: gerbview/files.cpp:47
 msgid "<b>No more available free graphic layer</b> in Gerbview to load files"
@@ -12168,39 +11912,35 @@ msgstr "Lötaugenvorlage unten (*.GPB)|*.GPB;*.gpb|"
 msgid "Open Gerber File"
 msgstr "Gerberdatei öffnen"
 
-#: gerbview/files.cpp:311
+#: gerbview/files.cpp:312
 msgid "Open Drill File"
 msgstr "Bohrdatei öffnen"
 
-#: gerbview/files.cpp:410
+#: gerbview/files.cpp:411
 #, c-format
-msgid "Zip file '%s' cannot be opened"
-msgstr "Zip-Datei '%s' konnte nicht geöffnet werden"
+msgid "Zip file \"%s\" cannot be opened"
+msgstr ""
 
-#: gerbview/files.cpp:452
+#: gerbview/files.cpp:453
 #, c-format
-msgid "Info: skip file <i>'%s'</i> (unknown type)\n"
-msgstr "Info: Überspringe <i>%s</i> (unbekannter Typ)\n"
+msgid "Info: skip file <i>\"%s\"</i> (unknown type)\n"
+msgstr ""
 
-#: gerbview/files.cpp:494
+#: gerbview/files.cpp:495
 #, c-format
-msgid "<b>Unable to create temporary file '%s'</b>\n"
-msgstr "<b>Konnte temporäre Datei '%s' nicht erstellen.</b>\n"
+msgid "<b>Unable to create temporary file \"%s\"</b>\n"
+msgstr ""
 
-#: gerbview/files.cpp:524
+#: gerbview/files.cpp:525
 #, c-format
 msgid "<b>unzipped file %s read error</b>\n"
 msgstr "<b>Lesefehler entzippte Datei %s</b>\n"
 
-#: gerbview/files.cpp:548
-msgid "Zip file (*.zip)|*.zip;.zip"
-msgstr "Zip-Archivdatei  (*.zip)|*.zip;.zip"
-
-#: gerbview/files.cpp:561
+#: gerbview/files.cpp:562
 msgid "Open Zip File"
 msgstr "Zip-Archiv Datei öffnen"
 
-#: gerbview/files.cpp:598 gerbview/job_file_reader.cpp:236
+#: gerbview/files.cpp:599 gerbview/job_file_reader.cpp:236
 #: pcbnew/dialogs/dialog_footprint_wizard_list_base.cpp:91
 msgid "Messages"
 msgstr "Meldungen"
@@ -12220,8 +11960,8 @@ msgstr "(mit X2 Attributen)"
 
 #: gerbview/gerbview_frame.cpp:629
 #, c-format
-msgid "Image name: '%s'  Layer name: '%s'"
-msgstr "Bildname: '%s',  Lagenname: '%s'"
+msgid "Image name: \"%s\"  Layer name: \"%s\""
+msgstr ""
 
 #: gerbview/gerbview_frame.cpp:643
 msgid "X2 attr"
@@ -12274,10 +12014,6 @@ msgstr "Anzeige auf Canvas umschalten"
 #: gerbview/hotkeys.cpp:127
 msgid "Gerbview Hotkeys"
 msgstr "Gerbview Tastaturbefehle"
-
-#: gerbview/job_file_reader.cpp:144
-msgid "Gerber job file (*.gbrjob)|*.gbrjob;.gbrjob"
-msgstr "Gerber-Job Dateien (*.gbrjob)|*.gbrjob;.gbrjob"
 
 #: gerbview/job_file_reader.cpp:156
 msgid "Open Gerber Job File"
@@ -12465,27 +12201,27 @@ msgstr "&Sonstiges"
 
 #: gerbview/onrightclick.cpp:106 gerbview/tools/selection_tool.cpp:104
 #, c-format
-msgid "Highlight items of component '%s'"
-msgstr "Elemente vom Bauteil '%s' hervorheben"
+msgid "Highlight items of component \"%s\""
+msgstr ""
 
 #: gerbview/onrightclick.cpp:115 gerbview/tools/selection_tool.cpp:112
 #, c-format
-msgid "Highlight items of net '%s'"
-msgstr "Elemente vom Netz '%s' hervorheben"
+msgid "Highlight items of net \"%s\""
+msgstr ""
 
 #: gerbview/onrightclick.cpp:126 gerbview/tools/selection_tool.cpp:122
 #, c-format
-msgid "Highlight aperture type '%s'"
-msgstr "Öffnungstype '%s' hervorheben"
+msgid "Highlight aperture type \"%s\""
+msgstr ""
 
 #: gerbview/onrightclick.cpp:137
 msgid "Clear highlight"
 msgstr "Hervorhebung löschen"
 
-#: gerbview/readgerb.cpp:59
+#: gerbview/readgerb.cpp:59 pcbnew/librairi.cpp:64
 #, c-format
-msgid "File <%s> not found"
-msgstr "Datei <%s> nicht gefunden."
+msgid "File \"%s\" not found"
+msgstr ""
 
 #: gerbview/readgerb.cpp:77
 msgid ""
@@ -12575,7 +12311,7 @@ msgstr ""
 msgid "DCode:"
 msgstr "D-Codes"
 
-#: gerbview/toolbars_gerber.cpp:224 gerbview/tools/selection_tool.cpp:827
+#: gerbview/toolbars_gerber.cpp:224 gerbview/tools/selection_tool.cpp:829
 msgid "Measure distance between two points"
 msgstr "Messen des Abstandes zwischen zwei Punkten"
 
@@ -12682,45 +12418,9 @@ msgstr "Interaktives Messen des Abstandes zwischen Punkten"
 msgid "Highlight..."
 msgstr "Hervorhebung..."
 
-#: gerbview/tools/selection_tool.cpp:661 pcbnew/tools/selection_tool.cpp:1330
+#: gerbview/tools/selection_tool.cpp:663
 msgid "Clarify selection"
 msgstr "Auswahl klarstellen"
-
-#: include/base_units.h:209
-#, c-format
-msgid " (%s):"
-msgstr " (%s):"
-
-#: include/class_drc_item.h:164
-#, c-format
-msgid "ErrType(%d): <b>%s</b><ul><li> %s </li></ul>"
-msgstr "Fehler Type(%d): <b>%s</b><ul><li> %s </li></ul>"
-
-#: include/class_drc_item.h:177
-#, c-format
-msgid "ErrType(%d): <b>%s</b><ul><li> %s: %s </li><li> %s: %s </li></ul>"
-msgstr "Fehler Type(%d): <b>%s</b><ul><li> %s: %s </li><li> %s: %s </li></ul>"
-
-#: include/class_drc_item.h:185
-#, c-format
-msgid "ErrType(%d): <b>%s</b><ul><li> %s: %s </li></ul>"
-msgstr "Fehler Type(%d): <b>%s</b><ul><li> %s: %s </li></ul>"
-
-#: include/kiway_player.h:316
-msgid "This file is already open."
-msgstr "Die Datei ist bereits geöffnet."
-
-#: include/lib_table_grid.h:168 pcbnew/librairi.cpp:851
-msgid "Nickname"
-msgstr "Nickname"
-
-#: include/lib_table_grid.h:169
-msgid "Library Path"
-msgstr "Bibliothekspfad"
-
-#: include/lib_table_grid.h:172
-msgid "Plugin Type"
-msgstr "Plugintyp"
 
 #: kicad/class_treeproject_item.cpp:108
 msgid ""
@@ -12744,8 +12444,8 @@ msgstr "Möglicherweise aufgrund von fehlenden Zugriffsrechten?"
 
 #: kicad/class_treeproject_item.cpp:132
 #, c-format
-msgid "Do you really want to delete '%s'"
-msgstr "Möchten Sie wirklich '%s' löschen?"
+msgid "Do you really want to delete \"%s\""
+msgstr ""
 
 #: kicad/class_treeproject_item.cpp:137
 msgid "Delete File"
@@ -12803,94 +12503,82 @@ msgstr "Pfad Vorlagen"
 msgid "Project Template Title"
 msgstr "Projekt Vorlagenname"
 
-#: kicad/dialogs/dialog_template_selector_base.h:68
-msgid "Project Template Selector"
-msgstr "Projektvorlagenauswahl"
-
-#: kicad/files-io.cpp:44
-msgid "Zip file (*.zip)|*.zip"
-msgstr "Zip-Archivdatei (*.zip)|*.zip"
-
-#: kicad/files-io.cpp:49
+#: kicad/files-io.cpp:48
 msgid "KiCad project file"
 msgstr "KiCad-Projektdatei"
 
-#: kicad/files-io.cpp:64
+#: kicad/files-io.cpp:63
 msgid "Unzip Project"
 msgstr "Projektdateien entpacken"
 
-#: kicad/files-io.cpp:71
+#: kicad/files-io.cpp:70
 #, c-format
 msgid ""
 "\n"
-"Open '%s'\n"
+"Open \"%s\"\n"
 msgstr ""
-"\n"
-"Öffne '%s'\n"
 
-#: kicad/files-io.cpp:74
+#: kicad/files-io.cpp:73
 msgid "Target Directory"
 msgstr "Zielverzeichnis"
 
-#: kicad/files-io.cpp:81
+#: kicad/files-io.cpp:80
 #, c-format
-msgid "Unzipping project in '%s'\n"
-msgstr "Entpacke Projekt nach '%s'\n"
+msgid "Unzipping project in \"%s\"\n"
+msgstr ""
 
-#: kicad/files-io.cpp:105
+#: kicad/files-io.cpp:104
 #, c-format
-msgid "Extract file '%s'"
-msgstr "Extrahiere Datei '%s'"
+msgid "Extract file \"%s\""
+msgstr ""
 
-#: kicad/files-io.cpp:114
+#: kicad/files-io.cpp:113
 msgid " OK\n"
 msgstr " OK\n"
 
-#: kicad/files-io.cpp:117
+#: kicad/files-io.cpp:116
 msgid " *ERROR*\n"
 msgstr "*FEHLER*\n"
 
-#: kicad/files-io.cpp:145
+#: kicad/files-io.cpp:144
 msgid "Archive Project Files"
 msgstr "Projektdateien archivieren"
 
-#: kicad/files-io.cpp:169
+#: kicad/files-io.cpp:168
 #, c-format
-msgid "Unable to create zip archive file '%s'"
-msgstr "Konnte Zip-Archiv ''%s' nicht erstellen"
+msgid "Unable to create zip archive file \"%s\""
+msgstr ""
 
-#: kicad/files-io.cpp:196
+#: kicad/files-io.cpp:195
 #, c-format
-msgid "Archive file <%s>"
-msgstr "Archivdatei <%s>"
+msgid "Archive file \"%s\""
+msgstr ""
 
-#: kicad/files-io.cpp:210
+#: kicad/files-io.cpp:209
 #, c-format
 msgid "(%lu bytes, compressed %d bytes)\n"
 msgstr "(%lu Bytes, komprimiert %d Bytes)\n"
 
-#: kicad/files-io.cpp:216
+#: kicad/files-io.cpp:215
 msgid " >>Error\n"
 msgstr " >>Fehler\n"
 
-#: kicad/files-io.cpp:223
+#: kicad/files-io.cpp:222
 #, c-format
 msgid ""
 "\n"
-"Zip archive <%s> created (%d bytes)"
+"Zip archive \"%s\" created (%d bytes)"
 msgstr ""
-"\n"
-"Zip-Archiv <%s> wurde erstellt (%d Bytes)."
 
 #: kicad/import_project.cpp:65
 msgid "Import Eagle Project Files"
 msgstr "Importiere Eagle Projektdateien"
 
-#: kicad/import_project.cpp:83
-msgid "Kicad Project Destination"
-msgstr "Zielpfad KiCad Projekt"
+#: kicad/import_project.cpp:86
+msgid "KiCad Project Destination"
+msgstr ""
 
-#: kicad/import_project.cpp:97
+#: kicad/import_project.cpp:102
 msgid ""
 "The selected directory is not empty.  We recommend you create projects in "
 "their own clean directory.\n"
@@ -12902,17 +12590,17 @@ msgstr ""
 "\n"
 "Möchten Sie ein neues Verzeichnis für das Projekt anlegen?"
 
-#: kicad/import_project.cpp:142 kicad/mainframe.cpp:316
+#: kicad/import_project.cpp:147 kicad/mainframe.cpp:316
 msgid "Eeschema failed to load:\n"
 msgstr "Fehler beim Einlesen in Eeschema:\n"
 
-#: kicad/import_project.cpp:143 kicad/import_project.cpp:176
+#: kicad/import_project.cpp:148 kicad/import_project.cpp:181
 #: kicad/mainframe.cpp:317 kicad/mainframe.cpp:359 kicad/mainframe.cpp:384
 #: kicad/mainframe.cpp:431
 msgid "KiCad Error"
 msgstr "KiCad Fehler"
 
-#: kicad/import_project.cpp:176 kicad/mainframe.cpp:384
+#: kicad/import_project.cpp:181 kicad/mainframe.cpp:384
 msgid "Pcbnew failed to load:\n"
 msgstr "Fehler beim Einlesen in Pcbnew:\n"
 
@@ -12934,15 +12622,11 @@ msgstr "Fehler beim Laden in den Bauteil-Bibliothekseditor:\n"
 msgid "Footprint library editor failed to load:\n"
 msgstr "Fehler beim Laden in den Footprint-Bibliothekseditor:\n"
 
-#: kicad/mainframe.cpp:498
-msgid "Text file ("
-msgstr "Textdatei ("
-
-#: kicad/mainframe.cpp:501
+#: kicad/mainframe.cpp:497
 msgid "Load File to Edit"
 msgstr "Datei zum Editieren öffnen"
 
-#: kicad/mainframe.cpp:550
+#: kicad/mainframe.cpp:546
 #, c-format
 msgid ""
 "Project name:\n"
@@ -13152,13 +12836,17 @@ msgstr "Einstellungen für PDF-Betrachter"
 msgid "Edit Schematic"
 msgstr "Editiere Schaltplan"
 
+#: kicad/menubar.cpp:406
+msgid "Edit Schematic Symbols"
+msgstr ""
+
 #: kicad/menubar.cpp:410
 msgid "Edit PCB Layout"
 msgstr "Leiterplattenlayout bearbeiten"
 
 #: kicad/menubar.cpp:414
-msgid "Edit PCB Footprint"
-msgstr "Bearbeite Leiterplatten Footprint"
+msgid "Edit PCB Footprints"
+msgstr ""
 
 #: kicad/menubar.cpp:418
 msgid "View Gerber Files"
@@ -13239,14 +12927,10 @@ msgstr "Neues Projekt erstellen"
 #: kicad/prjconfig.cpp:213
 #, c-format
 msgid ""
-"Directory '%s' could not be created.\n"
+"Directory \"%s\" could not be created.\n"
 "\n"
 "Please make sure you have write permissions and try again."
 msgstr ""
-"Verzeichnis '%s' konnte nicht erstellt werden.\n"
-"\n"
-"Stellen Sie sicher das Sie Schreibrechte besitzen und wiederholen Sie den "
-"Vorgang."
 
 #: kicad/prjconfig.cpp:222
 msgid ""
@@ -13284,8 +12968,8 @@ msgstr ""
 
 #: kicad/prjconfig.cpp:339
 #, c-format
-msgid "Cannot write to folder '%s'."
-msgstr "Konnte nicht in den Ordner '%s' schreiben."
+msgid "Cannot write to folder \"%s\"."
+msgstr ""
 
 #: kicad/prjconfig.cpp:340
 msgid "Error!"
@@ -13337,15 +13021,15 @@ msgstr "Konnte keine HTML Metainformation für diese Vorlage finden!"
 
 #: kicad/project_template.cpp:205
 #, c-format
-msgid "Cannot create folder '%s'."
-msgstr "Konnte Ordner '%s' nicht erstellen."
+msgid "Cannot create folder \"%s\"."
+msgstr ""
 
 #: kicad/project_template.cpp:227
 #, c-format
-msgid "Cannot copy file '%s'."
-msgstr "Konnte Datei '%s' nicht kopieren."
+msgid "Cannot copy file \"%s\"."
+msgstr ""
 
-#: kicad/tree_project_frame.cpp:223
+#: kicad/tree_project_frame.cpp:220
 #, c-format
 msgid ""
 "Current project directory:\n"
@@ -13354,52 +13038,52 @@ msgstr ""
 "Aktuelles Projektverzeichnis:\n"
 "%s"
 
-#: kicad/tree_project_frame.cpp:224
+#: kicad/tree_project_frame.cpp:221
 msgid "Create New Directory"
 msgstr "Neues Verzeichnis erstellen"
 
-#: kicad/tree_project_frame.cpp:685 kicad/tree_project_frame.cpp:692
+#: kicad/tree_project_frame.cpp:682 kicad/tree_project_frame.cpp:689
 msgid "New D&irectory"
 msgstr "Neues &Verzeichnis"
 
-#: kicad/tree_project_frame.cpp:686 kicad/tree_project_frame.cpp:693
+#: kicad/tree_project_frame.cpp:683 kicad/tree_project_frame.cpp:690
 msgid "Create a New Directory"
 msgstr "Ein neues Verzeichnis erstellen"
 
-#: kicad/tree_project_frame.cpp:696
+#: kicad/tree_project_frame.cpp:693
 msgid "&Delete Directory"
 msgstr "Verzeichnis &löschen"
 
-#: kicad/tree_project_frame.cpp:697 kicad/tree_project_frame.cpp:712
+#: kicad/tree_project_frame.cpp:694 kicad/tree_project_frame.cpp:709
 msgid "Delete the Directory and its content"
 msgstr "Das Verzeichnis und seinen Inhalt löschen"
 
-#: kicad/tree_project_frame.cpp:703
+#: kicad/tree_project_frame.cpp:700
 msgid "&Edit in a text editor"
 msgstr "Im Texteditor &bearbeiten"
 
-#: kicad/tree_project_frame.cpp:704
+#: kicad/tree_project_frame.cpp:701
 msgid "Open the file in a Text Editor"
 msgstr "Datei in einem Texteditor öffnen"
 
-#: kicad/tree_project_frame.cpp:707
+#: kicad/tree_project_frame.cpp:704
 msgid "&Rename file"
 msgstr "Datei &umbennenen"
 
-#: kicad/tree_project_frame.cpp:708
+#: kicad/tree_project_frame.cpp:705
 msgid "Rename file"
 msgstr "Datei umbennenen"
 
-#: kicad/tree_project_frame.cpp:711
+#: kicad/tree_project_frame.cpp:708
 msgid "&Delete File"
 msgstr "Datei &löschen"
 
-#: kicad/tree_project_frame.cpp:761
+#: kicad/tree_project_frame.cpp:758
 #, c-format
-msgid "Change filename: '%s'"
-msgstr "Dateinamen ändern: '%s'"
+msgid "Change filename: \"%s\""
+msgstr ""
 
-#: kicad/tree_project_frame.cpp:764
+#: kicad/tree_project_frame.cpp:761
 msgid "Change filename"
 msgstr "Dateinamen ändern"
 
@@ -13461,10 +13145,6 @@ msgstr "X-Ende (mm)"
 msgid "End Y (mm)"
 msgstr "Y-Ende (mm)"
 
-#: pagelayout_editor/dialogs/dialog_new_dataitem_base.h:71
-msgid "New Item"
-msgstr "Neues Element"
-
 #: pagelayout_editor/dialogs/dialogs_for_printing.cpp:219
 msgid "Print Page Layout"
 msgstr "Seitenlayout drucken"
@@ -13518,9 +13198,9 @@ msgid "Comment"
 msgstr "Kommentar"
 
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:325
-#: pcbnew/class_pcb_text.cpp:146 pcbnew/class_text_mod.cpp:387
-#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:66
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:841
+#: pcbnew/class_pcb_text.cpp:146 pcbnew/class_text_mod.cpp:395
+#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:67
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:843
 msgid "Thickness"
 msgstr "Stärke"
 
@@ -13573,7 +13253,7 @@ msgid "Line Thickness (mm)"
 msgstr "Liniendicke (mm)"
 
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:513
-#: pcbnew/dialogs/dialog_dimension_editor_base.cpp:50
+#: pcbnew/dialogs/dialog_dimension_editor_base.cpp:51
 msgid "Text Thickness"
 msgstr "Textstärke"
 
@@ -13601,11 +13281,11 @@ msgstr "Oberer Rand (mm)"
 msgid "Bottom Margin (mm)"
 msgstr "Unterer Rand (mm)"
 
-#: pagelayout_editor/files.cpp:46
+#: pagelayout_editor/files.cpp:48
 msgid "Page Layout Description File"
 msgstr "Seitenlayoutbeschreibungsdatei"
 
-#: pagelayout_editor/files.cpp:51 pagelayout_editor/files.cpp:84
+#: pagelayout_editor/files.cpp:53 pagelayout_editor/files.cpp:88
 msgid ""
 "The current page layout has been modified.\n"
 "Do you wish to discard the changes?"
@@ -13613,52 +13293,53 @@ msgstr ""
 "Das derzeitige Layout der Seite wurde verändert.\n"
 "Möchten Sie die Veränderungen verwerfen?"
 
-#: pagelayout_editor/files.cpp:60 pagelayout_editor/files.cpp:146
+#: pagelayout_editor/files.cpp:63 pagelayout_editor/files.cpp:151
 #, c-format
-msgid "File <%s> loaded"
-msgstr "Datei <%s> geladen"
+msgid "File \"%s\" loaded"
+msgstr ""
 
-#: pagelayout_editor/files.cpp:105
+#: pagelayout_editor/files.cpp:108
 msgid "Append Existing Page Layout File"
 msgstr "Seitenlayoutbeschreibung aus Datei hinzufügen"
 
-#: pagelayout_editor/files.cpp:115 pagelayout_editor/files.cpp:140
+#: pagelayout_editor/files.cpp:119 pagelayout_editor/files.cpp:145
 #, c-format
 msgid "Unable to load %s file"
 msgstr "Datei %s kann nicht geladen werden"
 
-#: pagelayout_editor/files.cpp:123
+#: pagelayout_editor/files.cpp:127
 #, c-format
-msgid "File <%s> inserted"
-msgstr "Datei <%s> eingefügt"
+msgid "File \"%s\" inserted"
+msgstr ""
 
-#: pagelayout_editor/files.cpp:131 pagelayout_editor/hotkeys.cpp:95
+#: pagelayout_editor/files.cpp:135 pagelayout_editor/hotkeys.cpp:95
 msgid "Open"
 msgstr "Öffnen"
 
-#: pagelayout_editor/files.cpp:155
+#: pagelayout_editor/files.cpp:160
 #, c-format
-msgid "Unable to write <%s>"
-msgstr "Konnte '%s' nicht erstellen."
+msgid "Unable to write \"%s\""
+msgstr ""
 
-#: pagelayout_editor/files.cpp:160 pagelayout_editor/files.cpp:191
+#: pagelayout_editor/files.cpp:165 pagelayout_editor/files.cpp:196
 #, c-format
-msgid "File <%s> written"
-msgstr "Datei <%s> geschrieben"
+msgid "File \"%s\" written"
+msgstr ""
 
-#: pagelayout_editor/files.cpp:167 pagelayout_editor/hotkeys.cpp:97
+#: pagelayout_editor/files.cpp:172 pagelayout_editor/hotkeys.cpp:97
 #: pagelayout_editor/pl_editor_frame.cpp:246
 msgid "Save As"
 msgstr "Speichern unter"
 
-#: pagelayout_editor/files.cpp:185 pagelayout_editor/pl_editor_frame.cpp:257
+#: pagelayout_editor/files.cpp:190 pagelayout_editor/pl_editor_frame.cpp:257
 #: pcbnew/exporters/export_gencad.cpp:287
+#: pcbnew/exporters/gen_modules_placefile.cpp:632
 #, c-format
-msgid "Unable to create <%s>"
-msgstr "Konnte <%s> nicht erstellen"
+msgid "Unable to create \"%s\""
+msgstr ""
 
 #: pagelayout_editor/hotkeys.cpp:82 pagelayout_editor/onrightclick.cpp:104
-#: pcbnew/dialogs/dialog_move_exact_base.h:78 pcbnew/hotkeys.cpp:117
+#: pcbnew/hotkeys.cpp:117 pcbnew/dialogs/dialog_move_exact_base.h:79
 msgid "Move Item"
 msgstr "Element verschieben"
 
@@ -13676,11 +13357,11 @@ msgid "Move End Point"
 msgstr "Verschiebe Endpunkt"
 
 #: pagelayout_editor/hotkeys.cpp:94
-#: pcbnew/dialogs/wizard_3DShape_Libs_downloader.cpp:211
+#: pcbnew/dialogs/wizard_3DShape_Libs_downloader.cpp:212
 msgid "New"
 msgstr "Neu"
 
-#: pagelayout_editor/hotkeys.cpp:128 pagelayout_editor/pl_editor_frame.cpp:345
+#: pagelayout_editor/hotkeys.cpp:128 pagelayout_editor/pl_editor_frame.cpp:343
 msgid "Page Layout Editor"
 msgstr "Page Layout Editor"
 
@@ -13807,9 +13488,10 @@ msgid "pl_editor is already running. Continue?"
 msgstr "pl_editor ist bereits gestartet? Fortsetzen?"
 
 #: pagelayout_editor/pl_editor.cpp:186
+#: pagelayout_editor/pl_editor_frame.cpp:202
 #, c-format
-msgid "Error when loading file <%s>"
-msgstr "Fehler beim Laden von <%s>."
+msgid "Error when loading file \"%s\""
+msgstr ""
 
 #: pagelayout_editor/pl_editor_frame.cpp:116
 msgid "coord origin: Right Bottom page corner"
@@ -13819,53 +13501,37 @@ msgstr "Koordinatenbezug: Rechte untere Seitenecke"
 msgid "Design"
 msgstr "Design"
 
-#: pagelayout_editor/pl_editor_frame.cpp:202
-#, c-format
-msgid "Error when loading file '%s'"
-msgstr "Fehler beim Laden von Datei '%s'"
-
 #: pagelayout_editor/pl_editor_frame.cpp:225
 msgid "Save changes in a new file before closing?"
 msgstr "Änderungen in eine neue Datei schreiben vor dem Schließen?"
 
-#: pagelayout_editor/pl_editor_frame.cpp:227
-#, c-format
-msgid ""
-"Save the changes in\n"
-"<%s>\n"
-"before closing?"
-msgstr ""
-"Änderungen in\n"
-"<%s>\n"
-"speichern vor dem Schließen?"
-
-#: pagelayout_editor/pl_editor_frame.cpp:346
+#: pagelayout_editor/pl_editor_frame.cpp:344
 msgid "no file selected"
 msgstr "Keine Datei gewählt."
 
-#: pagelayout_editor/pl_editor_frame.cpp:460
+#: pagelayout_editor/pl_editor_frame.cpp:454
 #, c-format
 msgid "Page size: width %.4g height %.4g"
 msgstr "Papiergröße: Breite %.4g Höhe %.4g"
 
-#: pagelayout_editor/pl_editor_frame.cpp:505
+#: pagelayout_editor/pl_editor_frame.cpp:499
 #, c-format
 msgid "coord origin: %s"
 msgstr "Koordinatenbezug: %s"
 
-#: pagelayout_editor/pl_editor_frame.cpp:734
+#: pagelayout_editor/pl_editor_frame.cpp:728
 msgid "(start or end point)"
 msgstr "(Start oder Endpunkt)"
 
-#: pagelayout_editor/pl_editor_frame.cpp:738
+#: pagelayout_editor/pl_editor_frame.cpp:732
 msgid "(start point)"
 msgstr "(Startpunkt)"
 
-#: pagelayout_editor/pl_editor_frame.cpp:741
+#: pagelayout_editor/pl_editor_frame.cpp:735
 msgid "(end point)"
 msgstr "(Endpunkt)"
 
-#: pagelayout_editor/pl_editor_frame.cpp:750
+#: pagelayout_editor/pl_editor_frame.cpp:745
 msgid "Selection Clarification"
 msgstr "Klarstellung der Auswahl"
 
@@ -13959,9 +13625,9 @@ msgid "mil"
 msgstr "mil"
 
 #: pcb_calculator/UnitSelector.cpp:42 pcb_calculator/UnitSelector.cpp:74
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:191
-#: pcbnew/dialogs/dialog_export_idf_base.cpp:46
-#: pcbnew/dialogs/dialog_export_step_base.cpp:105
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:193
+#: pcbnew/dialogs/dialog_export_idf_base.cpp:48
+#: pcbnew/dialogs/dialog_export_step_base.cpp:107
 #: pcbnew/dialogs/dialog_export_vrml_base.cpp:63
 #: pcbnew/import_dxf/dialog_dxf_import_base.cpp:111
 msgid "inch"
@@ -14044,10 +13710,6 @@ msgstr "Iadj"
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:156
 msgid "uA"
 msgstr "µA"
-
-#: pcb_calculator/dialogs/dialog_regulator_data_base.h:63
-msgid "Regulator Parameters"
-msgstr "Parameter Spannungsregler"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:62
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1183
@@ -14226,7 +13888,7 @@ msgstr "Querschnittsfläche"
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1016
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1020
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1024
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:245
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:247
 #: pcbnew/dialogs/wizard_3DShape_Libs_downloader_base.cpp:170
 msgid "dummy"
 msgstr "Dummytext"
@@ -14532,11 +14194,11 @@ msgid "Z"
 msgstr "Z"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:945
-#: pcbnew/class_drawsegment.cpp:354 pcbnew/class_drawsegment.cpp:372
+#: pcbnew/class_drawsegment.cpp:372 pcbnew/class_drawsegment.cpp:390
 #: pcbnew/class_pad.cpp:736 pcbnew/class_pcb_text.cpp:143
-#: pcbnew/class_text_mod.cpp:384
+#: pcbnew/class_text_mod.cpp:392
 #: pcbnew/dialogs/dialog_pad_basicshapes_properties.cpp:100
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:821
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:823
 msgid "Angle"
 msgstr "Winkel"
 
@@ -14601,7 +14263,7 @@ msgid "Zout"
 msgstr "Zout"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1125
-#: pcbnew/class_pcb_layer_widget.cpp:80
+#: pcbnew/class_pcb_layer_widget.cpp:81
 msgid "Values"
 msgstr "Werte"
 
@@ -14702,10 +14364,6 @@ msgstr "nicht beschichtetes Pad: (Durchm. - Bohrung)"
 msgid "Board Classes"
 msgstr "Boardklassen"
 
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.h:311
-msgid "PCB Calculator"
-msgstr "PCB Kalkulator"
-
 #: pcb_calculator/pcb_calculator_frame.cpp:144
 msgid ""
 "Data modified, and no data filename to save modifications\n"
@@ -14722,11 +14380,9 @@ msgstr "Änderung in der Liste der Spannungsregler"
 #: pcb_calculator/pcb_calculator_frame.cpp:157
 #, c-format
 msgid ""
-"Unable to write file<%s>\n"
+"Unable to write file\"%s\"\n"
 "Do you want to exit and abandon your change?"
 msgstr ""
-"Datei <%s> kann nicht geschrieben werden.\n"
-"Möchten Sie beenden und die Veränderungen verwerfen?"
 
 #: pcb_calculator/pcb_calculator_frame.cpp:161
 msgid "Write Data File Error"
@@ -14739,12 +14395,12 @@ msgstr "Falsche oder fehlende Parameter!"
 
 #: pcb_calculator/regulators_funct.cpp:227
 #, c-format
-msgid "PCB Calculator data  file (*.%s)|*.%s"
-msgstr "PCB Kalkulationsdatendatei (*.%s)|*.%s"
+msgid "PCB Calculator data file (*.%s)|*.%s"
+msgstr ""
 
 #: pcb_calculator/regulators_funct.cpp:232
-msgid "Select a PCB Calculator data file"
-msgstr "Wählen Sie eine PCB Kalkulationsdatendatei"
+msgid "Select PCB Calculator Data File"
+msgstr ""
 
 #: pcb_calculator/regulators_funct.cpp:247
 msgid "Do you want to load this file and replace current regulator list?"
@@ -14754,8 +14410,8 @@ msgstr ""
 
 #: pcb_calculator/regulators_funct.cpp:263
 #, c-format
-msgid "Unable to read data file <%s>"
-msgstr "Konnte die Datei <%s> nicht öffnen."
+msgid "Unable to read data file \"%s\""
+msgstr ""
 
 #: pcb_calculator/regulators_funct.cpp:294
 msgid "This regulator is already in list. Aborted"
@@ -15265,7 +14921,7 @@ msgstr "Zoom "
 msgid "Block Operation"
 msgstr "Gruppierung"
 
-#: pcbnew/board_netlist_updater.cpp:108 pcbnew/class_board.cpp:2442
+#: pcbnew/board_netlist_updater.cpp:108 pcbnew/class_board.cpp:2429
 #, c-format
 msgid "Adding new component \"%s:%s\" footprint \"%s\".\n"
 msgstr "Füge neues Bauteil \"%s:%s\" mit Footprint \"%s\" hinzu.\n"
@@ -15281,7 +14937,7 @@ msgid "Cannot add component %s due to missing footprint %s.\n"
 msgstr ""
 "Bauteil %s konnte nicht hinzugefügt werden, wegen fehlendem Footprint %s.\n"
 
-#: pcbnew/board_netlist_updater.cpp:142 pcbnew/class_board.cpp:2451
+#: pcbnew/board_netlist_updater.cpp:142 pcbnew/class_board.cpp:2438
 #, c-format
 msgid "Cannot add new component \"%s:%s\" due to missing footprint \"%s\".\n"
 msgstr ""
@@ -15293,7 +14949,7 @@ msgstr ""
 msgid "Change component %s footprint from %s to %s.\n"
 msgstr "Ändere Bauteil-Footprint '%s (von '%s') nach '%s'.\n"
 
-#: pcbnew/board_netlist_updater.cpp:176 pcbnew/class_board.cpp:2485
+#: pcbnew/board_netlist_updater.cpp:176 pcbnew/class_board.cpp:2472
 #, c-format
 msgid "Replacing component \"%s:%s\" footprint \"%s\" with \"%s\".\n"
 msgstr "Ersetze von Bauteil \"%s:%s\" den Footprint \"%s\" mit \"%s\".\n"
@@ -15304,7 +14960,7 @@ msgid "Cannot change component %s footprint due to missing footprint %s.\n"
 msgstr ""
 "Bauteil %s konnte nicht verändert werden, wegen fehlenden Footprint %s.\n"
 
-#: pcbnew/board_netlist_updater.cpp:213 pcbnew/class_board.cpp:2496
+#: pcbnew/board_netlist_updater.cpp:213 pcbnew/class_board.cpp:2483
 #, c-format
 msgid "Cannot replace component \"%s:%s\" due to missing footprint \"%s\".\n"
 msgstr ""
@@ -15316,7 +14972,7 @@ msgstr ""
 msgid "Change component %s reference to %s.\n"
 msgstr "Ändere die Referenz von Bauteil %s zu %s.\n"
 
-#: pcbnew/board_netlist_updater.cpp:248 pcbnew/class_board.cpp:2549
+#: pcbnew/board_netlist_updater.cpp:248 pcbnew/class_board.cpp:2536
 #, c-format
 msgid "Changing component \"%s:%s\" reference to \"%s\".\n"
 msgstr "Ändere die Referenz von Bauteil \"%s:%s\" zu \"%s\".\n"
@@ -15326,12 +14982,12 @@ msgstr "Ändere die Referenz von Bauteil \"%s:%s\" zu \"%s\".\n"
 msgid "Change component %s value from %s to %s.\n"
 msgstr "Ändere Wert von Bauteil %s von %s zu %s.\n"
 
-#: pcbnew/board_netlist_updater.cpp:272 pcbnew/class_board.cpp:2565
+#: pcbnew/board_netlist_updater.cpp:272 pcbnew/class_board.cpp:2552
 #, c-format
 msgid "Changing component \"%s:%s\" value from \"%s\" to \"%s\".\n"
 msgstr "Ändere Wert von Bauteil \"%s:%s\" von \"%s\" zu \"%s\".\n"
 
-#: pcbnew/board_netlist_updater.cpp:290 pcbnew/class_board.cpp:2582
+#: pcbnew/board_netlist_updater.cpp:290 pcbnew/class_board.cpp:2569
 #, c-format
 msgid "Changing component path \"%s:%s\" to \"%s\".\n"
 msgstr "Ändere Bauteilpfad \"%s:%s\" zu \"%s\".\n"
@@ -15341,7 +14997,7 @@ msgstr "Ändere Bauteilpfad \"%s:%s\" zu \"%s\".\n"
 msgid "Disconnect component %s pin %s.\n"
 msgstr "Entferne vom Bauteil %s den Pin %s.\n"
 
-#: pcbnew/board_netlist_updater.cpp:335 pcbnew/class_board.cpp:2606
+#: pcbnew/board_netlist_updater.cpp:335 pcbnew/class_board.cpp:2593
 #, c-format
 msgid "Clearing component \"%s:%s\" pin \"%s\" net name.\n"
 msgstr "Bereinige Netznamen von Bauteil \"%s:%s\" Pin \"%s\".\n"
@@ -15361,7 +15017,7 @@ msgstr "Verbinde am Bauteil %s den Pin %s von Netz %s zu Netz %s.\n"
 msgid "Connect component %s pin %s to net %s.\n"
 msgstr "Verbinde am Bauteil %s den Pin %s zum Netz %s.\n"
 
-#: pcbnew/board_netlist_updater.cpp:396 pcbnew/class_board.cpp:2625
+#: pcbnew/board_netlist_updater.cpp:396 pcbnew/class_board.cpp:2612
 #, c-format
 msgid ""
 "Changing component \"%s:%s\" pin \"%s\" net name from \"%s\" to \"%s\".\n"
@@ -15378,7 +15034,7 @@ msgstr "Bauteil %s ist gesperrt, überspringe das Entfernen.\n"
 msgid "Remove component %s."
 msgstr "Entferne Bauteil %s."
 
-#: pcbnew/board_netlist_updater.cpp:452 pcbnew/class_board.cpp:2677
+#: pcbnew/board_netlist_updater.cpp:452 pcbnew/class_board.cpp:2664
 #, c-format
 msgid "Removing unused component \"%s:%s\".\n"
 msgstr "Entferne unbenutztes Baueteil \"%s:%s\".\n"
@@ -15388,10 +15044,10 @@ msgstr "Entferne unbenutztes Baueteil \"%s:%s\".\n"
 msgid "Remove single pad net %s."
 msgstr "Entferne einzelnes Pad Netz %s."
 
-#: pcbnew/board_netlist_updater.cpp:521 pcbnew/class_board.cpp:2740
+#: pcbnew/board_netlist_updater.cpp:521 pcbnew/class_board.cpp:2727
 #, c-format
-msgid "Remove single pad net \"%s\" on \"%s\" pad '%s'\n"
-msgstr "Entferne einzelnes Padnetz \"%s\" auf \"%s\" Pad '%s'\n"
+msgid "Remove single pad net \"%s\" on \"%s\" pad \"%s\"\n"
+msgstr ""
 
 #: pcbnew/board_netlist_updater.cpp:583
 #, c-format
@@ -15430,41 +15086,42 @@ msgstr ""
 msgid "Netlist update successful!"
 msgstr "Update der Netzliste erfolgreich."
 
-#: pcbnew/build_BOM_from_board.cpp:61
-msgid "Comma separated value files (*.csv)|*.csv"
-msgstr "Komma separierte Datei (*.csv)|*.csv"
-
-#: pcbnew/build_BOM_from_board.cpp:86
+#: pcbnew/build_BOM_from_board.cpp:85
 msgid "Cannot export BOM: there are no footprints in the PCB"
 msgstr ""
 "BOM kann nicht exportiert werden: Es gibt keine Footprints auf der Platine."
 
-#: pcbnew/build_BOM_from_board.cpp:96
+#: pcbnew/build_BOM_from_board.cpp:95
 msgid "Save Bill of Materials"
 msgstr "Stückliste speichern (BOM)"
 
-#: pcbnew/build_BOM_from_board.cpp:109
+#: pcbnew/build_BOM_from_board.cpp:108
+#: pcbnew/dialogs/dialog_export_vrml.cpp:253
 #, c-format
-msgid "Unable to create file <%s>"
-msgstr "Konnte Datei <%s> nicht erstellen"
+msgid "Unable to create file \"%s\""
+msgstr ""
 
-#: pcbnew/build_BOM_from_board.cpp:116
+#: pcbnew/build_BOM_from_board.cpp:115
 msgid "Id"
 msgstr "ID"
 
-#: pcbnew/build_BOM_from_board.cpp:117
+#: pcbnew/build_BOM_from_board.cpp:116
 msgid "Designator"
 msgstr "Bezeichner"
 
-#: pcbnew/build_BOM_from_board.cpp:118
+#: pcbnew/build_BOM_from_board.cpp:117
 msgid "Package"
 msgstr "Gehäuse"
 
-#: pcbnew/build_BOM_from_board.cpp:120
+#: pcbnew/build_BOM_from_board.cpp:118 eeschema/bom_table_column.h:38
+msgid "Quantity"
+msgstr "Stückzahl"
+
+#: pcbnew/build_BOM_from_board.cpp:119
 msgid "Designation"
 msgstr "Bezeichnung"
 
-#: pcbnew/build_BOM_from_board.cpp:121
+#: pcbnew/build_BOM_from_board.cpp:120
 msgid "Supplier and ref"
 msgstr "Anbieter und Ref."
 
@@ -15472,64 +15129,62 @@ msgstr "Anbieter und Ref."
 msgid "This is the default net class."
 msgstr "Dies ist die voreingestellte Netzklasse."
 
-#: pcbnew/class_board.cpp:1106 pcbnew/class_module.cpp:551
-#: pcbnew/class_netinfo_item.cpp:120 pcbnew/pcb_draw_panel_gal.cpp:326
+#: pcbnew/class_board.cpp:1107 pcbnew/class_module.cpp:551
+#: pcbnew/class_netinfo_item.cpp:120 pcbnew/pcb_draw_panel_gal.cpp:335
 #: pcbnew/tools/pad_tool.cpp:77
 msgid "Pads"
 msgstr "Pads"
 
-#: pcbnew/class_board.cpp:1109 pcbnew/class_netinfo_item.cpp:140
+#: pcbnew/class_board.cpp:1110 pcbnew/class_netinfo_item.cpp:140
 #: pcbnew/dialogs/dialog_global_deletion_base.cpp:68
 #: pcbnew/dialogs/dialog_track_via_properties_base.cpp:154
-#: pcbnew/pcb_draw_panel_gal.cpp:329
+#: pcbnew/pcb_draw_panel_gal.cpp:338
 msgid "Vias"
 msgstr "Durchkontaktierung"
 
-#: pcbnew/class_board.cpp:1112 pcbnew/pcb_draw_panel_gal.cpp:332
+#: pcbnew/class_board.cpp:1113 pcbnew/pcb_draw_panel_gal.cpp:341
 msgid "Track Segments"
 msgstr "Leiterbahn Segmenten folgen"
 
-#: pcbnew/class_board.cpp:1115 pcbnew/pcb_draw_panel_gal.cpp:335
+#: pcbnew/class_board.cpp:1116 pcbnew/pcb_draw_panel_gal.cpp:344
 msgid "Nodes"
 msgstr "Knoten"
 
-#: pcbnew/class_board.cpp:1118
+#: pcbnew/class_board.cpp:1119 pcbnew/pcb_draw_panel_gal.cpp:347
 #: pcbnew/dialogs/dialog_select_net_from_list_base.h:58
-#: pcbnew/pcb_draw_panel_gal.cpp:338
 msgid "Nets"
 msgstr "Netze"
 
-#: pcbnew/class_board.cpp:1121 pcbnew/dialogs/dialog_drc_base.cpp:266
-#: pcbnew/pcb_draw_panel_gal.cpp:341
+#: pcbnew/class_board.cpp:1122 pcbnew/dialogs/dialog_drc_base.cpp:266
+#: pcbnew/pcb_draw_panel_gal.cpp:350
 msgid "Unconnected"
 msgstr "Nicht verbunden"
 
-#: pcbnew/class_board.cpp:2424
+#: pcbnew/class_board.cpp:2411
 #, c-format
 msgid "Checking netlist component footprint \"%s:%s:%s\".\n"
 msgstr "Überprüfe aus der Netzliste den Bauteilfootprint \"%s:%s:%s\".\n"
 
-#: pcbnew/class_board.cpp:2784
+#: pcbnew/class_board.cpp:2771
 #, c-format
-msgid "Component '%s' pad '%s' not found in footprint '%s'\n"
+msgid "Component \"%s\" pad \"%s\" not found in footprint \"%s\"\n"
 msgstr ""
-"Bauteil '%s' mit Pad '%s' konnte nicht im Footprint '%s' gefunden werden.\n"
 
-#: pcbnew/class_board.cpp:2802
+#: pcbnew/class_board.cpp:2789
 #, c-format
-msgid "Copper zone (net name '%s'): net has no pads connected."
-msgstr "Kupferzone (Netz Name '%s'): Netz hat kein verbundenen Pads."
+msgid "Copper zone (net name \"%s\"): net has no pads connected."
+msgstr ""
 
-#: pcbnew/class_board_item.cpp:43 pcbnew/class_pad.cpp:1140
+#: pcbnew/class_board_item.cpp:44 pcbnew/class_pad.cpp:1140
 msgid "Rect"
 msgstr "Rechteck"
 
-#: pcbnew/class_board_item.cpp:46
+#: pcbnew/class_board_item.cpp:47
 msgid "Bezier Curve"
 msgstr "Bezierkurve"
 
-#: pcbnew/class_board_item.cpp:47
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:200
+#: pcbnew/class_board_item.cpp:48
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:202
 msgid "Polygon"
 msgstr "Polygon"
 
@@ -15538,27 +15193,27 @@ msgstr "Polygon"
 msgid "Dimension \"%s\" on %s"
 msgstr "Abmessungen\"%s\" auf %s"
 
-#: pcbnew/class_drawsegment.cpp:339
+#: pcbnew/class_drawsegment.cpp:357
 msgid "Drawing"
 msgstr "Zeichnung"
 
-#: pcbnew/class_drawsegment.cpp:343
+#: pcbnew/class_drawsegment.cpp:361
 msgid "Shape"
 msgstr "Form"
 
-#: pcbnew/class_drawsegment.cpp:358
+#: pcbnew/class_drawsegment.cpp:376
 msgid "Curve"
 msgstr "Bogen"
 
-#: pcbnew/class_drawsegment.cpp:363
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:200
+#: pcbnew/class_drawsegment.cpp:381
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:202
 #: pcbnew/dialogs/dialog_pad_basicshapes_properties.cpp:82
 #: pcbnew/dialogs/dialog_pad_properties.cpp:737
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1832
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1849
 msgid "Segment"
 msgstr "Segment"
 
-#: pcbnew/class_drawsegment.cpp:627
+#: pcbnew/class_drawsegment.cpp:645
 #, c-format
 msgid "Pcb Graphic: %s, length %s on %s"
 msgstr "PCB-Grafik: %s, Länge %s auf %s"
@@ -15751,7 +15406,7 @@ msgid "Netlist Path"
 msgstr "Netzlistenpfad"
 
 #: pcbnew/class_module.cpp:538
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:60
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:62
 msgid "Board Side"
 msgstr "Platinenseite"
 
@@ -15760,7 +15415,7 @@ msgid "Back (Flipped)"
 msgstr "Rückseite (gedreht)"
 
 #: pcbnew/class_module.cpp:539
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:58
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:60
 msgid "Front"
 msgstr "Vorderseite"
 
@@ -15831,7 +15486,7 @@ msgstr "Netz"
 
 #: pcbnew/class_pad.cpp:716 pcbnew/class_track.cpp:1256
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:305
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:265
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:267
 msgid "Drill"
 msgstr "Bohrung"
 
@@ -15843,7 +15498,7 @@ msgstr "Bohrung X / Y"
 msgid "Length in package"
 msgstr "Länge in Package"
 
-#: pcbnew/class_pad.cpp:1137 pcbnew/dialogs/dialog_pad_properties_base.cpp:66
+#: pcbnew/class_pad.cpp:1137 pcbnew/dialogs/dialog_pad_properties_base.cpp:68
 msgid "Oval"
 msgstr "Oval"
 
@@ -15863,7 +15518,7 @@ msgstr "Individualform"
 msgid "Std"
 msgstr "Std"
 
-#: pcbnew/class_pad.cpp:1165 pcbnew/dialogs/dialog_pad_properties_base.cpp:56
+#: pcbnew/class_pad.cpp:1165 pcbnew/dialogs/dialog_pad_properties_base.cpp:58
 msgid "SMD"
 msgstr "SMD"
 
@@ -15885,15 +15540,15 @@ msgstr "Pad auf %s von %s"
 msgid "Pad %s on %s of %s"
 msgstr "Pad %s auf %s von %s"
 
-#: pcbnew/class_pad.cpp:1307
+#: pcbnew/class_pad.cpp:1310
 msgid "No layers"
 msgstr "Keine Lagen"
 
-#: pcbnew/class_pad.cpp:1327
+#: pcbnew/class_pad.cpp:1330
 msgid "Internal"
 msgstr "Intern"
 
-#: pcbnew/class_pad.cpp:1330
+#: pcbnew/class_pad.cpp:1333
 msgid "Non-copper"
 msgstr "Keine Kupferfläche"
 
@@ -15958,214 +15613,222 @@ msgid "Show footprint pads on board's front"
 msgstr "Footprintpads auf Platinenvorderseite anzeigen"
 
 #: pcbnew/class_pcb_layer_widget.cpp:70
+msgid "Through Hole Pads"
+msgstr ""
+
+#: pcbnew/class_pcb_layer_widget.cpp:70
+msgid "Show through hole pads in specific color"
+msgstr ""
+
+#: pcbnew/class_pcb_layer_widget.cpp:71
 msgid "Pads Back"
 msgstr "Pads - rückseitig"
 
-#: pcbnew/class_pcb_layer_widget.cpp:70
+#: pcbnew/class_pcb_layer_widget.cpp:71
 msgid "Show footprint pads on board's back"
 msgstr "Zeige Footprintpads auf Platinenrückseite"
 
-#: pcbnew/class_pcb_layer_widget.cpp:72
+#: pcbnew/class_pcb_layer_widget.cpp:73
 msgid "Text Front"
 msgstr "Text - vorderseitig"
 
-#: pcbnew/class_pcb_layer_widget.cpp:72
+#: pcbnew/class_pcb_layer_widget.cpp:73
 msgid "Show footprint text on board's front"
 msgstr "Footprinttext auf Platinenvorderseite anzeigen"
 
-#: pcbnew/class_pcb_layer_widget.cpp:73
+#: pcbnew/class_pcb_layer_widget.cpp:74
 msgid "Text Back"
 msgstr "Text - rückseitig"
 
-#: pcbnew/class_pcb_layer_widget.cpp:73
+#: pcbnew/class_pcb_layer_widget.cpp:74
 msgid "Show footprint text on board's back"
 msgstr "Footprinttext auf Platinenrückseite anzeigen"
 
-#: pcbnew/class_pcb_layer_widget.cpp:74
+#: pcbnew/class_pcb_layer_widget.cpp:75
 msgid "Hidden Text"
 msgstr "Versteckter Text"
 
-#: pcbnew/class_pcb_layer_widget.cpp:74
+#: pcbnew/class_pcb_layer_widget.cpp:75
 msgid "Show footprint text marked as invisible"
 msgstr "Als unsichtbar markierten Footprinttext anzeigen"
 
-#: pcbnew/class_pcb_layer_widget.cpp:76
+#: pcbnew/class_pcb_layer_widget.cpp:77
 msgid "Anchors"
 msgstr "Anker"
 
-#: pcbnew/class_pcb_layer_widget.cpp:76
+#: pcbnew/class_pcb_layer_widget.cpp:77
 msgid "Show footprint and text origins as a cross"
 msgstr "Footprint- und Textbeginn mit Kreuz anzeigen"
 
-#: pcbnew/class_pcb_layer_widget.cpp:78
+#: pcbnew/class_pcb_layer_widget.cpp:79
 msgid "Footprints Front"
 msgstr "Footprints Vorderseite"
 
-#: pcbnew/class_pcb_layer_widget.cpp:78
+#: pcbnew/class_pcb_layer_widget.cpp:79
 msgid "Show footprints that are on board's front"
 msgstr "Footprints der Platinenvorderseite anzeigen"
 
-#: pcbnew/class_pcb_layer_widget.cpp:79
+#: pcbnew/class_pcb_layer_widget.cpp:80
 msgid "Footprints Back"
 msgstr "Footprints Rückseite"
 
-#: pcbnew/class_pcb_layer_widget.cpp:79
+#: pcbnew/class_pcb_layer_widget.cpp:80
 msgid "Show footprints that are on board's back"
 msgstr "Zeige Footprints, welche sich auf der Platinenrückseite befinden"
 
-#: pcbnew/class_pcb_layer_widget.cpp:80
+#: pcbnew/class_pcb_layer_widget.cpp:81
 msgid "Show footprint's values"
 msgstr "Zeige Footprintwerte"
 
-#: pcbnew/class_pcb_layer_widget.cpp:81
+#: pcbnew/class_pcb_layer_widget.cpp:82
 msgid "References"
 msgstr "Referenzen"
 
-#: pcbnew/class_pcb_layer_widget.cpp:81
+#: pcbnew/class_pcb_layer_widget.cpp:82
 msgid "Show footprint's references"
 msgstr "Zeige Footprintreferenzen"
 
-#: pcbnew/class_pcb_layer_widget.cpp:82
+#: pcbnew/class_pcb_layer_widget.cpp:83
 msgid "Worksheet"
 msgstr "Arbeitsblatt"
 
-#: pcbnew/class_pcb_layer_widget.cpp:82
+#: pcbnew/class_pcb_layer_widget.cpp:83
 msgid "Show worksheet"
 msgstr "Zeige Datenblatt"
 
-#: pcbnew/class_pcb_layer_widget.cpp:83
+#: pcbnew/class_pcb_layer_widget.cpp:84
 msgid "Cursor"
 msgstr "Cursor"
 
-#: pcbnew/class_pcb_layer_widget.cpp:83
+#: pcbnew/class_pcb_layer_widget.cpp:84
 msgid "PCB Cursor"
 msgstr "PCB Cursor"
 
-#: pcbnew/class_pcb_layer_widget.cpp:84
+#: pcbnew/class_pcb_layer_widget.cpp:85
 msgid "Aux items"
 msgstr "Hilfselemente"
 
-#: pcbnew/class_pcb_layer_widget.cpp:84
+#: pcbnew/class_pcb_layer_widget.cpp:85
 msgid "Auxillary items (rulers, assistants, axes, etc.)"
 msgstr "Hilfselemente (Lineale, Assistenten, Achsen, etc.)"
 
-#: pcbnew/class_pcb_layer_widget.cpp:85
+#: pcbnew/class_pcb_layer_widget.cpp:86
 msgid "Background"
 msgstr "Hintergrund"
 
-#: pcbnew/class_pcb_layer_widget.cpp:85
+#: pcbnew/class_pcb_layer_widget.cpp:86
 msgid "PCB Background"
 msgstr "PCB Hintergrund"
 
-#: pcbnew/class_pcb_layer_widget.cpp:152
+#: pcbnew/class_pcb_layer_widget.cpp:153
 msgid "Show All Copper Layers"
 msgstr "Alle Kupferlagen einblenden"
 
-#: pcbnew/class_pcb_layer_widget.cpp:155
+#: pcbnew/class_pcb_layer_widget.cpp:156
 msgid "Hide All Copper Layers But Active"
 msgstr "Alle Kupferlagen, außer der aktiven, ausblenden"
 
-#: pcbnew/class_pcb_layer_widget.cpp:158
+#: pcbnew/class_pcb_layer_widget.cpp:159
 msgid "Always Hide All Copper Layers But Active"
 msgstr "Alle Kupferlagen, außer der aktiven, ausblenden"
 
-#: pcbnew/class_pcb_layer_widget.cpp:161
+#: pcbnew/class_pcb_layer_widget.cpp:162
 msgid "Hide All Copper Layers"
 msgstr "Alle Kupferlagen ausblenden"
 
-#: pcbnew/class_pcb_layer_widget.cpp:167
+#: pcbnew/class_pcb_layer_widget.cpp:168
 msgid "Show All Non Copper Layers"
 msgstr "Alle Nicht-Kupferlagen einblenden"
 
-#: pcbnew/class_pcb_layer_widget.cpp:170
+#: pcbnew/class_pcb_layer_widget.cpp:171
 msgid "Hide All Non Copper Layers"
 msgstr "Alle Nicht-Kupferlagen ausblenden"
 
-#: pcbnew/class_pcb_layer_widget.cpp:182
+#: pcbnew/class_pcb_layer_widget.cpp:183
 msgid "Show All Front Layers"
 msgstr "Alle vorderen Lagen (Front) einblenden"
 
-#: pcbnew/class_pcb_layer_widget.cpp:185
+#: pcbnew/class_pcb_layer_widget.cpp:186
 msgid "Show All Back Layers"
 msgstr "Alle hinteren Lagen (Back) einblenden"
 
-#: pcbnew/class_pcb_layer_widget.cpp:455
+#: pcbnew/class_pcb_layer_widget.cpp:456
 msgid "Front copper layer"
 msgstr "Vorderseitige Kupferlage"
 
-#: pcbnew/class_pcb_layer_widget.cpp:459
+#: pcbnew/class_pcb_layer_widget.cpp:460
 msgid "Back copper layer"
 msgstr "Rückseitige Kupferlage"
 
-#: pcbnew/class_pcb_layer_widget.cpp:463
+#: pcbnew/class_pcb_layer_widget.cpp:464
 msgid "Inner copper layer"
 msgstr "Innere Kupferlage"
 
-#: pcbnew/class_pcb_layer_widget.cpp:487
+#: pcbnew/class_pcb_layer_widget.cpp:488
 msgid "Adhesive on board's front"
 msgstr "Kleber auf Platinenvorderseite"
 
-#: pcbnew/class_pcb_layer_widget.cpp:488
+#: pcbnew/class_pcb_layer_widget.cpp:489
 msgid "Adhesive on board's back"
 msgstr "Kleber auf Platinenrückseite"
 
-#: pcbnew/class_pcb_layer_widget.cpp:489
+#: pcbnew/class_pcb_layer_widget.cpp:490
 msgid "Solder paste on board's front"
 msgstr "Lötpaste auf Platinenvorderseite"
 
-#: pcbnew/class_pcb_layer_widget.cpp:490
+#: pcbnew/class_pcb_layer_widget.cpp:491
 msgid "Solder paste on board's back"
 msgstr "Lötpaste auf Platinenrückseite"
 
-#: pcbnew/class_pcb_layer_widget.cpp:491
+#: pcbnew/class_pcb_layer_widget.cpp:492
 msgid "Silkscreen on board's front"
 msgstr "Bestückungsdruck auf Platinenvorderseite"
 
-#: pcbnew/class_pcb_layer_widget.cpp:492
+#: pcbnew/class_pcb_layer_widget.cpp:493
 msgid "Silkscreen on board's back"
 msgstr "Bestückungsdruck auf Platinenrückseite"
 
-#: pcbnew/class_pcb_layer_widget.cpp:493
+#: pcbnew/class_pcb_layer_widget.cpp:494
 msgid "Solder mask on board's front"
 msgstr "Lötstoppmaske auf Platinenvorderseite"
 
-#: pcbnew/class_pcb_layer_widget.cpp:494
+#: pcbnew/class_pcb_layer_widget.cpp:495
 msgid "Solder mask on board's back"
 msgstr "Lötstoppmaske auf Platinenrückseite"
 
-#: pcbnew/class_pcb_layer_widget.cpp:495
+#: pcbnew/class_pcb_layer_widget.cpp:496
 msgid "Explanatory drawings"
 msgstr "Zeichnungen als Erklärungen"
 
-#: pcbnew/class_pcb_layer_widget.cpp:496
+#: pcbnew/class_pcb_layer_widget.cpp:497
 msgid "Explanatory comments"
 msgstr "Kommentare als Erklärungen"
 
-#: pcbnew/class_pcb_layer_widget.cpp:497 pcbnew/class_pcb_layer_widget.cpp:498
+#: pcbnew/class_pcb_layer_widget.cpp:498 pcbnew/class_pcb_layer_widget.cpp:499
 msgid "User defined meaning"
 msgstr "Benutzerspezifische Bedeutung"
 
-#: pcbnew/class_pcb_layer_widget.cpp:499
+#: pcbnew/class_pcb_layer_widget.cpp:500
 msgid "Board's perimeter definition"
 msgstr "Platinenumrisses"
 
-#: pcbnew/class_pcb_layer_widget.cpp:500
+#: pcbnew/class_pcb_layer_widget.cpp:501
 msgid "Board's edge setback outline"
 msgstr "Abstände"
 
-#: pcbnew/class_pcb_layer_widget.cpp:501
+#: pcbnew/class_pcb_layer_widget.cpp:502
 msgid "Footprint courtyards on board's front"
 msgstr "Footprint Umriss auf Platinenvorderseite"
 
-#: pcbnew/class_pcb_layer_widget.cpp:502
+#: pcbnew/class_pcb_layer_widget.cpp:503
 msgid "Footprint courtyards on board's back"
 msgstr "Footprint Umriss auf Platinenrückseite"
 
-#: pcbnew/class_pcb_layer_widget.cpp:503
+#: pcbnew/class_pcb_layer_widget.cpp:504
 msgid "Footprint assembly on board's front"
 msgstr "Footprint Montage auf Platinenvorderseite"
 
-#: pcbnew/class_pcb_layer_widget.cpp:504
+#: pcbnew/class_pcb_layer_widget.cpp:505
 msgid "Footprint assembly on board's back"
 msgstr "Footprint Montage auf Platinenrückseite"
 
@@ -16187,29 +15850,29 @@ msgstr "PCB Text"
 msgid "Pcb Text \"%s\" on %s"
 msgstr "PCB Text \"%s\" auf %s"
 
-#: pcbnew/class_text_mod.cpp:354
+#: pcbnew/class_text_mod.cpp:362
 msgid "Ref."
 msgstr "Ref."
 
-#: pcbnew/class_text_mod.cpp:377
+#: pcbnew/class_text_mod.cpp:385
 msgid " Yes"
 msgstr " Ja"
 
-#: pcbnew/class_text_mod.cpp:379
+#: pcbnew/class_text_mod.cpp:387
 msgid " No"
 msgstr " Nein"
 
-#: pcbnew/class_text_mod.cpp:405
+#: pcbnew/class_text_mod.cpp:413
 #, c-format
 msgid "Reference %s"
 msgstr "Referenz %s"
 
-#: pcbnew/class_text_mod.cpp:409
+#: pcbnew/class_text_mod.cpp:417
 #, c-format
 msgid "Value %s of %s"
 msgstr "Wert %s auf %s"
 
-#: pcbnew/class_text_mod.cpp:413
+#: pcbnew/class_text_mod.cpp:421
 #, c-format
 msgid "Text \"%s\" on %s of %s"
 msgstr "Text \"%s\" auf %s von %s"
@@ -16262,12 +15925,11 @@ msgstr "NC-DuKo-Größe"
 msgid "NC Via Drill"
 msgstr "NC-DuKo-Bohrung"
 
-#: pcbnew/class_track.cpp:1100 pcbnew/class_zone.cpp:863
-#: pcbnew/zones_by_polygon_fill_functions.cpp:116
+#: pcbnew/class_track.cpp:1100 pcbnew/class_zone.cpp:859
 msgid "NetName"
 msgstr "Netz-Name"
 
-#: pcbnew/class_track.cpp:1104 pcbnew/class_zone.cpp:867
+#: pcbnew/class_track.cpp:1104 pcbnew/class_zone.cpp:863
 msgid "NetCode"
 msgstr "Netz-Code"
 
@@ -16288,7 +15950,7 @@ msgid "Blind/Buried Via"
 msgstr "Blinde/Vergrabene Durchkontaktierungen"
 
 #: pcbnew/class_track.cpp:1243 pcbnew/dialogs/dialog_layers_setup_base.cpp:94
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:316
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:318
 msgid "Layers"
 msgstr "Lagen"
 
@@ -16313,60 +15975,60 @@ msgstr "Nicht gefunden."
 msgid "Track %s, net [%s] (%d) on layer %s, length: %s"
 msgstr "Leiterbahn %s, Netz [%s] (%d) auf Lage %s, Länge: %s"
 
-#: pcbnew/class_zone.cpp:824
+#: pcbnew/class_zone.cpp:820
 msgid "Zone Outline"
 msgstr "Flächenumriss"
 
-#: pcbnew/class_zone.cpp:830 pcbnew/class_zone.cpp:1058
+#: pcbnew/class_zone.cpp:826 pcbnew/class_zone.cpp:1058
 msgid "(Cutout)"
 msgstr "(Ausschnitt)"
 
-#: pcbnew/class_zone.cpp:839
+#: pcbnew/class_zone.cpp:835
 msgid "No via"
 msgstr "Keine DuKo"
 
-#: pcbnew/class_zone.cpp:842
+#: pcbnew/class_zone.cpp:838
 msgid "No track"
 msgstr "Keine Leiterbahn"
 
-#: pcbnew/class_zone.cpp:845
+#: pcbnew/class_zone.cpp:841
 #: pcbnew/dialogs/dialog_keepout_area_properties_base.cpp:67
 msgid "No copper pour"
 msgstr "Kein Auffüllen von Kupferflächen"
 
-#: pcbnew/class_zone.cpp:847
+#: pcbnew/class_zone.cpp:843
 msgid "Keepout"
 msgstr "Sperrfläche"
 
-#: pcbnew/class_zone.cpp:858
+#: pcbnew/class_zone.cpp:854
 msgid "<unknown>"
 msgstr "<unbekannt>"
 
-#: pcbnew/class_zone.cpp:871
+#: pcbnew/class_zone.cpp:867
 msgid "Priority"
 msgstr "Priorität"
 
-#: pcbnew/class_zone.cpp:875
+#: pcbnew/class_zone.cpp:871
 msgid "Non Copper Zone"
 msgstr "Keine Kupferfläche"
 
-#: pcbnew/class_zone.cpp:881
+#: pcbnew/class_zone.cpp:877
 msgid "Corners"
 msgstr "Ecken"
 
-#: pcbnew/class_zone.cpp:884
+#: pcbnew/class_zone.cpp:880
 msgid "Segments"
 msgstr "Segmente"
 
-#: pcbnew/class_zone.cpp:888
+#: pcbnew/class_zone.cpp:884
 msgid "Fill Mode"
 msgstr "Füllmodus"
 
-#: pcbnew/class_zone.cpp:892
+#: pcbnew/class_zone.cpp:888
 msgid "Hatch Lines"
 msgstr "Schraffurlinien"
 
-#: pcbnew/class_zone.cpp:897
+#: pcbnew/class_zone.cpp:893
 msgid "Corner Count"
 msgstr "Anzahl Löcher"
 
@@ -16424,8 +16086,8 @@ msgstr "%s nicht gefunden"
 
 #: pcbnew/cross-probing.cpp:82
 #, c-format
-msgid "Selecting all from sheet '%s'"
-msgstr "Wähle alles vom Blatt '%s'"
+msgid "Selecting all from sheet \"%s\""
+msgstr ""
 
 #: pcbnew/cross-probing.cpp:132
 #, c-format
@@ -16460,14 +16122,14 @@ msgstr ""
 
 #: pcbnew/dialogs/dialog_SVG_print.cpp:305
 #, c-format
-msgid "Plot: '%s' OK."
-msgstr "Plot: '%s' erstellt"
+msgid "Plot: \"%s\" OK."
+msgstr ""
 
 #: pcbnew/dialogs/dialog_SVG_print.cpp:311 pcbnew/dialogs/dialog_plot.cpp:876
 #: pcbnew/exporters/gen_modules_placefile.cpp:333
 #, c-format
-msgid "Unable to create file '%s'."
-msgstr "Konnte Datei '%s' nicht erstellen."
+msgid "Unable to create file \"%s\"."
+msgstr ""
 
 #: pcbnew/dialogs/dialog_SVG_print_base.cpp:29
 msgid ""
@@ -16562,10 +16224,6 @@ msgstr "Dateioptionen:"
 msgid "Plot"
 msgstr "Plotten"
 
-#: pcbnew/dialogs/dialog_SVG_print_base.h:76
-msgid "Export SVG file"
-msgstr "Als SVG exportieren"
-
 #: pcbnew/dialogs/dialog_block_options_base.cpp:25
 msgid "Include &footprints"
 msgstr "Inklusive &Footprints"
@@ -16640,36 +16298,32 @@ msgstr "&Entferne nicht verbundene Leiterbahnen"
 msgid "delete tracks having at least one dangling end"
 msgstr "Entfernt offene und nicht verbundene Leiterbahnsegmente."
 
-#: pcbnew/dialogs/dialog_cleaning_options_base.h:50
-msgid "Cleaning Options"
-msgstr "Optionen für das Aufräumen"
-
-#: pcbnew/dialogs/dialog_copper_zones.cpp:395
+#: pcbnew/dialogs/dialog_copper_zones.cpp:396
 #, c-format
 msgid "Clearance must be smaller than %f\" / %f mm."
 msgstr "Abstandsfläche muss kleiner sein als %f\" / %f mm."
 
-#: pcbnew/dialogs/dialog_copper_zones.cpp:407
+#: pcbnew/dialogs/dialog_copper_zones.cpp:408
 #, c-format
 msgid "Minimum width must be larger than %f\" / %f mm."
 msgstr "Minimalbreite muss größer sein als %f\" / %f mm."
 
-#: pcbnew/dialogs/dialog_copper_zones.cpp:447
+#: pcbnew/dialogs/dialog_copper_zones.cpp:448
 msgid "Thermal relief spoke must be greater than the minimum width."
 msgstr ""
 "Die Breite der Wärmeabführungsspeicher muss größer als die Minimalbreite "
 "sein."
 
-#: pcbnew/dialogs/dialog_copper_zones.cpp:460
+#: pcbnew/dialogs/dialog_copper_zones.cpp:461
 #: pcbnew/dialogs/dialog_print_using_printer.cpp:486
 msgid "No layer selected."
 msgstr "Keine Lage ausgewählt."
 
-#: pcbnew/dialogs/dialog_copper_zones.cpp:471
+#: pcbnew/dialogs/dialog_copper_zones.cpp:472
 msgid "No net selected."
 msgstr "Kein Netz ausgewählt."
 
-#: pcbnew/dialogs/dialog_copper_zones.cpp:477
+#: pcbnew/dialogs/dialog_copper_zones.cpp:478
 msgid ""
 "You have chosen the \"not connected\" option. This will create insulated "
 "copper islands. Are you sure ?"
@@ -16677,23 +16331,23 @@ msgstr ""
 "Die \"nicht verbunden\" Option wurde ausgewählt. Dies erzeugt isolierte "
 "Kupferinseln. Sind Sie sich sicher?"
 
-#: pcbnew/dialogs/dialog_copper_zones.cpp:512
+#: pcbnew/dialogs/dialog_copper_zones.cpp:513
 msgid "Chamfer distance"
 msgstr "Abfasungsabstand"
 
-#: pcbnew/dialogs/dialog_copper_zones.cpp:518
+#: pcbnew/dialogs/dialog_copper_zones.cpp:519
 msgid "Fillet radius"
 msgstr "Auskehlungsradius"
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:37
-#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:87
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:39
+#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:88
 #: pcbnew/dialogs/dialog_graphic_item_properties_base.cpp:122
-#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:54
+#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:55
 #: pcbnew/dialogs/dialog_track_via_properties_base.cpp:138
 msgid "Layer:"
 msgstr "Lage:"
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:61
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:63
 msgid "Net Filtering"
 msgstr "Netzfilter"
 
@@ -16702,32 +16356,32 @@ msgstr "Netzfilter"
 # 1) Darstellung
 # For dialog with options about polar coordinates...
 # 2) einblenden
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:63
-#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:58
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:65
+#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:59
 msgid "Display:"
 msgstr "Darstellung:"
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:67
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:69
 msgid "Show all (alphabetical)"
 msgstr "Zeige alles (alphabetisch)"
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:67
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:69
 msgid "Show all (pad count)"
 msgstr "Zeige alles (fortlaufend)"
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:67
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:69
 msgid "Filtered (alphabetical)"
 msgstr "Gefiltert (alphabetisch)"
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:67
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:69
 msgid "Filtered (pad count)"
 msgstr "Gefiltert (fortlaufend)"
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:73
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:75
 msgid "Hidden net filter:"
 msgstr "Versteckte Netzfilter:"
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:78
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:80
 msgid ""
 "Pattern to filter net names in filtered list.\n"
 "Net names matching this pattern are not displayed."
@@ -16735,15 +16389,15 @@ msgstr ""
 "Muster, um Netznamen innerhalb der Netzliste zu filtern.\n"
 "Netznamen, auf welche dieses Muster zutrifft, werden nicht angezeigt."
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:82
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:84
 msgid "Visible net filter:"
 msgstr "Sichtbare Netzfilter:"
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:86
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:88
 msgid "*"
 msgstr "*"
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:87
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:89
 msgid ""
 "Pattern to filter net names in filtered list.\n"
 "Only net names matching this pattern are displayed."
@@ -16751,45 +16405,45 @@ msgstr ""
 "Muster, um Netznamen innerhalb der Netzliste zu filtern.\n"
 "Nur Netznamen, auf welche dieses Muster zutrifft, werden angezeigt."
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:91
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:93
 msgid "Apply Filters"
 msgstr "Filter hinzufügen"
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:106
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:108
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:48
 #: pcbnew/dialogs/dialog_drc_base.cpp:48
 msgid "Clearance"
 msgstr "Abstandsmaß"
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:113
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:115
 msgid "Minimum width"
 msgstr "Minimalbreite"
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:115
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:117
 msgid "Minimum thickness of filled areas."
 msgstr "Mindeststärke von ausgefüllten Flächen."
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:122
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:124
 msgid "Corner smoothing:"
 msgstr "Glättung von Ecken:"
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:126
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:128
 msgid "Chamfer"
 msgstr "Abschrägung"
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:126
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:128
 msgid "Fillet"
 msgstr "Auskehlung"
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:132
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:134
 msgid "Chamfer distance (mm):"
 msgstr "Abfasungsabstand (mm):"
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:145
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:147
 msgid "Default pad connection:"
 msgstr "Standard Padverbindung:"
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:147
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:149
 msgid ""
 "Default pad connection type to zone.\n"
 "This setting can be overridden by local  pad settings"
@@ -16797,47 +16451,41 @@ msgstr ""
 "Der Standardtyp der Padverbindung zur Zone.\n"
 "Diese Einstellung kann durch lokale Pad-Einstellungen überschrieben werden."
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:151
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:195
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:501
-msgid "Solid"
-msgstr "Solide"
-
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:151
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:195
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:501
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:153
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:197
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:503
 msgid "Thermal relief"
 msgstr "Thermische Abführung [Alle]"
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:151
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:153
 msgid "THT thermal"
 msgstr "Therm. Abführung [Durchsteck]"
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:158
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:160
 msgid "Thermal Reliefs"
 msgstr "Thermische Abführungen"
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:160
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:162
 msgid "Antipad clearance"
 msgstr "Antipad Abstandsfläche"
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:165
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:167
 msgid "Clearance between pads in the same net and filled areas."
 msgstr "Abstandsfläche zwischen Pads im selben Netz und gefüllten Flächen."
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:169
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:171
 msgid "Spoke width"
 msgstr "Speichenbreite"
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:174
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:176
 msgid "Width of copper in thermal reliefs."
 msgstr "Kupferbreite der Wärmeabführung."
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:187
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:189
 msgid "Zone priority level:"
 msgstr "Zonen Prioritätsebene:"
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:189
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:191
 msgid ""
 "Zones are filled by priority level, level 3 has higher priority than level "
 "2.\n"
@@ -16853,53 +16501,53 @@ msgstr ""
 "entfernt.\n"
 "* Wenn ihre Prioritäten gleich sind: Ein DRC-Fehler wird gesetzt."
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:196
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:198
 msgid "Fill mode:"
 msgstr "Füllmodus:"
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:206
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:208
 msgid "Segments / 360 deg:"
 msgstr "Segmente / 360 Grad:"
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:210
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:212
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:45
 msgid "16"
 msgstr "16"
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:210
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:212
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:45
 msgid "32"
 msgstr "32"
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:222
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:224
 msgid "Outline slope:"
 msgstr "Flächenneigung:"
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:226
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:228
 msgid "Arbitrary"
 msgstr "Beliebig"
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:226
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:228
 msgid "H, V, and 45 deg only"
 msgstr "H, V und (nur) 45 Grad"
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:232
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:234
 msgid "Outline style:"
 msgstr "Flächendarstellung:"
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:236
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:238
 msgid "Hatched"
 msgstr "Schraffiert"
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:236
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:238
 msgid "Fully hatched"
 msgstr "Komplett schraffiert"
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:251
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:253
 msgid "Export Settings to Other Zones"
 msgstr "Einstellungen an andere Flächen exportieren"
 
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:252
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:254
 msgid ""
 "Export this zone setup (excluding layer and net selection) to all other "
 "copper zones."
@@ -16907,32 +16555,28 @@ msgstr ""
 "Exportiere Flächeneinstellungen (außer Lagen und Netzauswahl) an alle "
 "anderen Kupferflächen."
 
-#: pcbnew/dialogs/dialog_copper_zones_base.h:130
-msgid "Copper Zone Properties"
-msgstr "Eigenschaften von Kupferflächen"
-
-#: pcbnew/dialogs/dialog_create_array.cpp:56
+#: pcbnew/dialogs/dialog_create_array.cpp:57
 msgid "Numerals (0,1,2,...,9,10)"
 msgstr "Numerisch (0,1,2,...,9,10)"
 
-#: pcbnew/dialogs/dialog_create_array.cpp:57
+#: pcbnew/dialogs/dialog_create_array.cpp:58
 msgid "Hexadecimal (0,1,...,F,10,...)"
 msgstr "Hexadezimal (0,1,...,F,10,...)"
 
-#: pcbnew/dialogs/dialog_create_array.cpp:58
+#: pcbnew/dialogs/dialog_create_array.cpp:59
 msgid "Alphabet, minus IOSQXZ"
 msgstr "Alphabetisch, ohne IOSQXZ"
 
-#: pcbnew/dialogs/dialog_create_array.cpp:59
+#: pcbnew/dialogs/dialog_create_array.cpp:60
 msgid "Alphabet, full 26 characters"
 msgstr "Alphabet, alle 26 Buchstaben"
 
-#: pcbnew/dialogs/dialog_create_array.cpp:232
+#: pcbnew/dialogs/dialog_create_array.cpp:233
 #, c-format
 msgid "Unrecognised numbering scheme: %d"
 msgstr "Unbekanntes Nummerierungsschema: %d"
 
-#: pcbnew/dialogs/dialog_create_array.cpp:246
+#: pcbnew/dialogs/dialog_create_array.cpp:247
 #, c-format
 msgid ""
 "Could not determine numbering start from \"%s\": expected value consistent "
@@ -16941,171 +16585,171 @@ msgstr ""
 "Konnte den Start der Nummerierung von \"%s\" nicht ermitteln: Erwarteter "
 "Wert ist konsistent mit dem Alphabet \"%s\""
 
-#: pcbnew/dialogs/dialog_create_array.cpp:275
+#: pcbnew/dialogs/dialog_create_array.cpp:276
 #, c-format
 msgid "Bad numeric value for %s: %s"
 msgstr "Fehlerhafter Integralwert %s: %s"
 
-#: pcbnew/dialogs/dialog_create_array.cpp:298
+#: pcbnew/dialogs/dialog_create_array.cpp:299
 msgid "horizontal count"
 msgstr "Anzahl horizontal:"
 
-#: pcbnew/dialogs/dialog_create_array.cpp:300
+#: pcbnew/dialogs/dialog_create_array.cpp:301
 msgid "vertical count"
 msgstr "Anzahl vertikal:"
 
-#: pcbnew/dialogs/dialog_create_array.cpp:310
+#: pcbnew/dialogs/dialog_create_array.cpp:311
 msgid "stagger"
 msgstr "Staffelung"
 
-#: pcbnew/dialogs/dialog_create_array.cpp:359
+#: pcbnew/dialogs/dialog_create_array.cpp:360
 msgid "point count"
 msgstr "Anzahl Löcher"
 
-#: pcbnew/dialogs/dialog_create_array.cpp:372
+#: pcbnew/dialogs/dialog_create_array.cpp:373
 msgid "numbering start"
 msgstr "Start Nummerierung:"
 
-#: pcbnew/dialogs/dialog_create_array.cpp:398
+#: pcbnew/dialogs/dialog_create_array.cpp:399
 msgid "Bad parameters"
 msgstr "Ungültige Parameter"
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:29
+#: pcbnew/dialogs/dialog_create_array_base.cpp:31
 msgid "Horizontal count:"
 msgstr "Anzahl horizontal:"
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:33
-#: pcbnew/dialogs/dialog_create_array_base.cpp:40
-#: pcbnew/dialogs/dialog_create_array_base.cpp:47
-#: pcbnew/dialogs/dialog_create_array_base.cpp:58
+#: pcbnew/dialogs/dialog_create_array_base.cpp:35
+#: pcbnew/dialogs/dialog_create_array_base.cpp:42
+#: pcbnew/dialogs/dialog_create_array_base.cpp:49
+#: pcbnew/dialogs/dialog_create_array_base.cpp:60
 msgid "5"
 msgstr "5"
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:36
+#: pcbnew/dialogs/dialog_create_array_base.cpp:38
 msgid "Vertical count:"
 msgstr "Anzahl vertikal:"
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:43
+#: pcbnew/dialogs/dialog_create_array_base.cpp:45
 msgid "Horizontal spacing:"
 msgstr "Abstand horizontal:"
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:54
+#: pcbnew/dialogs/dialog_create_array_base.cpp:56
 msgid "Vertical spacing:"
 msgstr "Abstand vertikal:"
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:65
+#: pcbnew/dialogs/dialog_create_array_base.cpp:67
 msgid "Horizontal offset:"
 msgstr "Offset horizontal:"
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:76
+#: pcbnew/dialogs/dialog_create_array_base.cpp:78
 msgid "Vertical offset:"
 msgstr "Offset vertikal:"
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:87
+#: pcbnew/dialogs/dialog_create_array_base.cpp:89
 msgid "Stagger:"
 msgstr "Staffelung:"
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:91
-#: pcbnew/dialogs/dialog_create_array_base.cpp:155
-#: pcbnew/dialogs/dialog_create_array_base.cpp:158
-#: pcbnew/dialogs/dialog_create_array_base.cpp:261
+#: pcbnew/dialogs/dialog_create_array_base.cpp:93
+#: pcbnew/dialogs/dialog_create_array_base.cpp:157
+#: pcbnew/dialogs/dialog_create_array_base.cpp:160
+#: pcbnew/dialogs/dialog_create_array_base.cpp:263
 msgid "1"
 msgstr "1"
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:94
+#: pcbnew/dialogs/dialog_create_array_base.cpp:96
 msgid "Rows"
 msgstr "Zeilen"
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:94
+#: pcbnew/dialogs/dialog_create_array_base.cpp:96
 msgid "Columns"
 msgstr "Spalten"
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:96
+#: pcbnew/dialogs/dialog_create_array_base.cpp:98
 msgid "Stagger Type"
 msgstr "Staffelungstyp"
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:105
+#: pcbnew/dialogs/dialog_create_array_base.cpp:107
 msgid "Horizontal, then vertical"
 msgstr "Horizontal, dann Vertikal"
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:105
+#: pcbnew/dialogs/dialog_create_array_base.cpp:107
 msgid "Vertical, then horizontal"
 msgstr "Vertikal, dann Horizontal"
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:107
+#: pcbnew/dialogs/dialog_create_array_base.cpp:109
 msgid "Pad Numbering Direction"
 msgstr "Richtung Pad-Nummerierung"
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:111
+#: pcbnew/dialogs/dialog_create_array_base.cpp:113
 msgid "Reverse pad numbering on alternate rows or columns"
 msgstr "Umgekehrte Nummerierung mit abwechselnder Reihe oder Zeile"
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:114
-#: pcbnew/dialogs/dialog_create_array_base.cpp:248
+#: pcbnew/dialogs/dialog_create_array_base.cpp:116
+#: pcbnew/dialogs/dialog_create_array_base.cpp:250
 msgid "Use first free number"
 msgstr "Verwende erste freie Nummer"
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:114
-#: pcbnew/dialogs/dialog_create_array_base.cpp:248
+#: pcbnew/dialogs/dialog_create_array_base.cpp:116
+#: pcbnew/dialogs/dialog_create_array_base.cpp:250
 msgid "From start value"
 msgstr "Startwert"
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:116
-#: pcbnew/dialogs/dialog_create_array_base.cpp:250
+#: pcbnew/dialogs/dialog_create_array_base.cpp:118
+#: pcbnew/dialogs/dialog_create_array_base.cpp:252
 msgid "Initial pad number"
 msgstr "Initiale Pad-Nummer"
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:120
+#: pcbnew/dialogs/dialog_create_array_base.cpp:122
 msgid "Continuous (1, 2, 3...)"
 msgstr "Kontinuierlich (1, 2, 3 ...)"
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:120
+#: pcbnew/dialogs/dialog_create_array_base.cpp:122
 msgid "Coordinate (A1, A2, ... B1, ...)"
 msgstr "Koordinate (A1, A2, ... B1, ...)"
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:122
+#: pcbnew/dialogs/dialog_create_array_base.cpp:124
 msgid "Pad Numbering Scheme"
 msgstr "Schema Pad-Nummerierung"
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:126
+#: pcbnew/dialogs/dialog_create_array_base.cpp:128
 msgid "Primary axis numbering:"
 msgstr "Primäre Achsen-Nummerierung:"
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:135
+#: pcbnew/dialogs/dialog_create_array_base.cpp:137
 msgid "Secondary axis numbering:"
 msgstr "Sekundäre Achsen-Nummerierung:"
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:151
+#: pcbnew/dialogs/dialog_create_array_base.cpp:153
 msgid "Pad numbering start:"
 msgstr "Start Pad-Nummerierung:"
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:171
+#: pcbnew/dialogs/dialog_create_array_base.cpp:173
 msgid "Grid Array"
 msgstr "Raster Array"
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:181
+#: pcbnew/dialogs/dialog_create_array_base.cpp:183
 msgid "Horizontal center:"
 msgstr "Horizontal zentriert"
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:192
+#: pcbnew/dialogs/dialog_create_array_base.cpp:194
 msgid "Vertical center:"
 msgstr "Vertikal zentriert"
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:203
+#: pcbnew/dialogs/dialog_create_array_base.cpp:205
 msgid "Radius:"
 msgstr "Radius:"
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:207
+#: pcbnew/dialogs/dialog_create_array_base.cpp:209
 msgid "0 mm"
 msgstr "0 mm"
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:211
-#: pcbnew/dialogs/dialog_move_exact.cpp:236
-#: pcbnew/dialogs/dialog_position_relative.cpp:141
+#: pcbnew/dialogs/dialog_create_array_base.cpp:213
+#: pcbnew/dialogs/dialog_move_exact.cpp:237
+#: pcbnew/dialogs/dialog_position_relative.cpp:142
 msgid "Angle:"
 msgstr "Winkel:"
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:216
+#: pcbnew/dialogs/dialog_create_array_base.cpp:218
 msgid ""
 "Positive angles represent an anti-clockwise rotation. An angle of 0 will "
 "produce a full circle divided evenly into \"Count\" portions."
@@ -17113,24 +16757,24 @@ msgstr ""
 "Positive Winkel repräsentieren ein Rotation entgegen dem Uhrzeigersinn.\n"
 "Ein Winkel von 0 erstellt einen vollen Kreis geteilt in \"Teil\" Anteile."
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:224
+#: pcbnew/dialogs/dialog_create_array_base.cpp:226
 msgid "Count:"
 msgstr "Anzahl:"
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:228
+#: pcbnew/dialogs/dialog_create_array_base.cpp:230
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:45
 msgid "4"
 msgstr "4"
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:229
+#: pcbnew/dialogs/dialog_create_array_base.cpp:231
 msgid "How many items in the array."
 msgstr "Wie viele Elemente sind im Array."
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:233
+#: pcbnew/dialogs/dialog_create_array_base.cpp:235
 msgid "Rotate:"
 msgstr "Rotieren:"
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:239
+#: pcbnew/dialogs/dialog_create_array_base.cpp:241
 msgid ""
 "Rotate the item as well as move it - multi-selections will be rotated "
 "together"
@@ -17138,24 +16782,17 @@ msgstr ""
 "Rotiere das Element auch beim Bewegen, Multi-Selektionen werden gemeinsam "
 "rotiert"
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:246
+#: pcbnew/dialogs/dialog_create_array_base.cpp:248
 msgid "Pad Numbering Options"
 msgstr "Optionen Pad-Nummerierung"
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:257
+#: pcbnew/dialogs/dialog_create_array_base.cpp:259
 msgid "Pad numbering start value:"
 msgstr "Startwert für Pad-Nummerierung:"
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:274
+#: pcbnew/dialogs/dialog_create_array_base.cpp:276
 msgid "Circular Array"
 msgstr "Kreis Array"
-
-#: pcbnew/dialogs/dialog_create_array_base.h:115 pcbnew/hotkeys.cpp:123
-#: pcbnew/modedit_onclick.cpp:371 pcbnew/modedit_onclick.cpp:415
-#: pcbnew/onrightclick.cpp:210 pcbnew/onrightclick.cpp:848
-#: pcbnew/tools/edit_tool.cpp:119
-msgid "Create Array"
-msgstr "Array erstellen"
 
 #: pcbnew/dialogs/dialog_design_rules.cpp:52
 msgid "Class"
@@ -17165,30 +16802,30 @@ msgstr "Klasse"
 msgid "* (Any)"
 msgstr "* (Beliebig)"
 
-#: pcbnew/dialogs/dialog_design_rules.cpp:694
+#: pcbnew/dialogs/dialog_design_rules.cpp:698
 msgid "Design Rule Setting Error"
 msgstr "Design Regel Editor Fehler"
 
-#: pcbnew/dialogs/dialog_design_rules.cpp:714
+#: pcbnew/dialogs/dialog_design_rules.cpp:718
 msgid "New Net Class Name:"
 msgstr "Neuer Netzklassenname:"
 
-#: pcbnew/dialogs/dialog_design_rules.cpp:734
+#: pcbnew/dialogs/dialog_design_rules.cpp:738
 msgid "Duplicate net class names are not allowed."
 msgstr "Doppelte Netzklassennamen sind nicht zulässig."
 
-#: pcbnew/dialogs/dialog_design_rules.cpp:798
+#: pcbnew/dialogs/dialog_design_rules.cpp:802
 msgid "The default net class cannot be removed"
 msgstr "Die Default-Netzklasse kann nicht entfernt werden."
 
-#: pcbnew/dialogs/dialog_design_rules.cpp:1005
+#: pcbnew/dialogs/dialog_design_rules.cpp:1009
 #, c-format
 msgid " - <b>Track Size</b> (%f %s) &lt; <b>Min Track Size</b> (%f %s)<br>"
 msgstr ""
 " - <b>Leiterbahngröße</b> (%f %s) &lt; <b>Mindestleiterbahngröße</b> (%f "
 "%s)<br>"
 
-#: pcbnew/dialogs/dialog_design_rules.cpp:1018
+#: pcbnew/dialogs/dialog_design_rules.cpp:1022
 #, c-format
 msgid ""
 " - <b>Differential Pair Size</b> (%f %s) &lt; <b>Min Track Size</b> (%f "
@@ -17197,7 +16834,7 @@ msgstr ""
 " - <b>Größe Differenzielles Paar</b> (%f %s) &lt; <b>Mindestleiterbahngröße</"
 "b> (%f %s)<br>"
 
-#: pcbnew/dialogs/dialog_design_rules.cpp:1032
+#: pcbnew/dialogs/dialog_design_rules.cpp:1036
 #, c-format
 msgid ""
 " - <b>Via Diameter</b> (%f %s) &lt; <b>Minimum Via Diameter</b> (%f %s)<br>"
@@ -17205,21 +16842,21 @@ msgstr ""
 " - <b>Durchmesser Durchkontaktierung</b> (%f %s) &lt; <b>Mindestdurchmesser "
 "Durchkontaktierung</b> (%f %s)<br>"
 
-#: pcbnew/dialogs/dialog_design_rules.cpp:1044
+#: pcbnew/dialogs/dialog_design_rules.cpp:1048
 #, c-format
 msgid " - <b>Via Drill</b> (%f %s) &ge; <b>Via Dia</b> (%f %s)<br>"
 msgstr ""
 " - <b>Bohrdurchmesser Durchkontaktierung</b> (%f %s) &ge; <b>Durchmesser "
 "Durchkontaktierung</b> (%f %s)<br>"
 
-#: pcbnew/dialogs/dialog_design_rules.cpp:1053
+#: pcbnew/dialogs/dialog_design_rules.cpp:1057
 #, c-format
 msgid " - <b>Via Drill</b> (%f %s) &lt; <b>Min Via Drill</b> (%f %s)<br>"
 msgstr ""
 " - <b>Bohrdurchmesser Durchkontaktierung</b> (%f %s) &lt; "
 "<b>Mindestbohrdurchmesser Durchkontaktierung</b> (%f %s)<br>"
 
-#: pcbnew/dialogs/dialog_design_rules.cpp:1066
+#: pcbnew/dialogs/dialog_design_rules.cpp:1070
 #, c-format
 msgid ""
 " - <b>MicroVia Diameter</b> (%f %s) &lt; <b>MicroVia Min Diameter</b> (%f "
@@ -17228,14 +16865,14 @@ msgstr ""
 " - <b>Durchmesser Micro-Durchkontaktierung</b> (%f %s) &lt; "
 "<b>Mindestdurchmesser Micro-Durchkontaktierung</b> (%f %s)<br>"
 
-#: pcbnew/dialogs/dialog_design_rules.cpp:1078
+#: pcbnew/dialogs/dialog_design_rules.cpp:1082
 #, c-format
 msgid " - <b>MicroVia Drill</b> (%f %s) &ge; <b>MicroVia Dia</b> (%f %s)<br>"
 msgstr ""
 " - <b>Bohrdurchmesser Micro-Durchkontaktierung</b> (%f %s) &ge; "
 "<b>Durchmesser Micro-Durchkontaktierung</b> (%f %s)<br>"
 
-#: pcbnew/dialogs/dialog_design_rules.cpp:1087
+#: pcbnew/dialogs/dialog_design_rules.cpp:1091
 #, c-format
 msgid ""
 " - <b>MicroVia Drill</b> (%f %s) &lt; <b>MicroVia Min Drill</b> (%f %s)<br>"
@@ -17243,48 +16880,48 @@ msgstr ""
 " - <b>Bohrdurchmesser Micro-Durchkontaktierung</b> (%f %s) &ge; "
 "<b>Bohrdurchmesser Micro-Durchkontaktierung</b> (%f %s)<br>"
 
-#: pcbnew/dialogs/dialog_design_rules.cpp:1096
+#: pcbnew/dialogs/dialog_design_rules.cpp:1100
 #, c-format
 msgid "Netclass: <b>%s</b><br>"
 msgstr "Netzklasse: <b>%s</b><br>"
 
-#: pcbnew/dialogs/dialog_design_rules.cpp:1116
+#: pcbnew/dialogs/dialog_design_rules.cpp:1120
 #, c-format
 msgid "<b>Extra Track %d Size</b> %s &lt; <b>Min Track Size</b><br>"
 msgstr ""
 "<b>Extra Leiterbahn %d Größe</b> %s &lt; <b>Mindest Leiterbahngröße</b><br>"
 
-#: pcbnew/dialogs/dialog_design_rules.cpp:1125
+#: pcbnew/dialogs/dialog_design_rules.cpp:1129
 #, c-format
 msgid "<b>Extra Track %d Size</b> %s &gt; <b>1 inch!</b><br>"
 msgstr "<b>Extra Leiterbahn %d Größe</b> %s &gt; <b>1 Zoll!</b><br>"
 
-#: pcbnew/dialogs/dialog_design_rules.cpp:1145
+#: pcbnew/dialogs/dialog_design_rules.cpp:1149
 #, c-format
 msgid "<b>Extra Via %d Size</b> %s &lt; <b>Min Via Size</b><br>"
 msgstr ""
 "<b>Extra Durchkontaktierung %d Größe</b> %s &lt; <b>Mindest "
 "Durchkontaktierungsgröße</b><br>"
 
-#: pcbnew/dialogs/dialog_design_rules.cpp:1155
+#: pcbnew/dialogs/dialog_design_rules.cpp:1159
 #, c-format
 msgid "<b>No via drill size define in row %d</b><br>"
 msgstr "<b>Keine DoKu Bohrgröße definiert in  Zeile %d</b><br>"
 
-#: pcbnew/dialogs/dialog_design_rules.cpp:1165
+#: pcbnew/dialogs/dialog_design_rules.cpp:1169
 #, c-format
 msgid "<b>Extra Via %d Drill</b> %s &lt; <b>Min Via Drill %s</b><br>"
 msgstr ""
 "<b>Extra Durchkontaktierung %d Bohrgröße</b> %s &lt; <b>Mindest "
 "Durchkontaktierung Bohrgröße %s</b><br>"
 
-#: pcbnew/dialogs/dialog_design_rules.cpp:1174
+#: pcbnew/dialogs/dialog_design_rules.cpp:1178
 #, c-format
 msgid "<b>Extra Via %d Size</b> %s &le; <b> Drill Size</b> %s<br>"
 msgstr ""
 "<b>Extra Durchkontaktierung %d Größe</b> %s &le; <b>Bohrlochgröße</b> %s<br>"
 
-#: pcbnew/dialogs/dialog_design_rules.cpp:1183
+#: pcbnew/dialogs/dialog_design_rules.cpp:1187
 #, c-format
 msgid "<b>Extra Via %d Size</b>%s &gt; <b>1 inch!</b><br>"
 msgstr "<b>Extra Durchkontaktierung %d Größe</b>%s &gt; <b>1 Zoll!</b><br>"
@@ -17349,11 +16986,6 @@ msgstr "Die ausgewählte Netzklasse um eine Position nach oben verschieben"
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:97
 msgid "Net Class Membership"
 msgstr "Mitgliedschaft der Netzklassen"
-
-#: pcbnew/dialogs/dialog_design_rules_base.cpp:111
-#: pcbnew/dialogs/dialog_design_rules_base.cpp:153
-msgid "Select All"
-msgstr "Alles auswählen"
 
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:112
 msgid "Select all nets in the left list"
@@ -17536,29 +17168,21 @@ msgstr "Leiterbahn 12"
 msgid "Global Design Rules"
 msgstr "Globale Design Regeln"
 
-#: pcbnew/dialogs/dialog_design_rules_base.h:121
-msgid "Design Rules Editor"
-msgstr "Design Regel Editor"
-
-#: pcbnew/dialogs/dialog_dimension_editor_base.cpp:36
+#: pcbnew/dialogs/dialog_dimension_editor_base.cpp:37
 msgid "Text Width"
 msgstr "Textbreite"
 
-#: pcbnew/dialogs/dialog_dimension_editor_base.cpp:43
+#: pcbnew/dialogs/dialog_dimension_editor_base.cpp:44
 msgid "Text Height"
 msgstr "Texthöhe"
 
-#: pcbnew/dialogs/dialog_dimension_editor_base.cpp:57
+#: pcbnew/dialogs/dialog_dimension_editor_base.cpp:58
 msgid "Text Position X"
 msgstr "Textposition X"
 
-#: pcbnew/dialogs/dialog_dimension_editor_base.cpp:64
+#: pcbnew/dialogs/dialog_dimension_editor_base.cpp:65
 msgid "Text Position Y"
 msgstr "Textposition Y"
-
-#: pcbnew/dialogs/dialog_dimension_editor_base.h:69
-msgid "Dimension Properties"
-msgstr "Eigenschaften der Abmessungen"
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:28
 msgid "Routing Help:"
@@ -17638,7 +17262,7 @@ msgid "Show vias in sketch mode"
 msgstr "DoKu's als Umriss darstellen"
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:65
-#: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:64
+#: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:66
 msgid "Footprints:"
 msgstr "Footprints:"
 
@@ -17685,13 +17309,13 @@ msgstr "Erstellung der Protokolldatei durchgeführt"
 
 #: pcbnew/dialogs/dialog_drc.cpp:224
 #, c-format
-msgid "Unable to create report file '%s' "
-msgstr "Konnte Protokolldatei '%s' nicht erstellen"
+msgid "Unable to create report file \"%s\" "
+msgstr ""
 
 #: pcbnew/dialogs/dialog_drc.cpp:293
 #, c-format
-msgid "Unable to create report file '%s'"
-msgstr "Konnte Protokolldatei '%s' nicht erstellen"
+msgid "Unable to create report file \"%s\""
+msgstr ""
 
 #: pcbnew/dialogs/dialog_drc.cpp:313
 msgid "Save DRC Report File"
@@ -17805,11 +17429,7 @@ msgstr "Probleme / Marker"
 msgid "A list of unconnected pads, right click for popup menu"
 msgstr "Eine Liste mit nicht verbundenen Pads. Rechtsklick für PopUp-Menü"
 
-#: pcbnew/dialogs/dialog_drc_base.h:116
-msgid "DRC Control"
-msgstr "DRC Steuerung"
-
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor.cpp:329
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor.cpp:330
 msgid ""
 "Use this attribute for most non SMD components\n"
 "Components with this option are not put in the footprint position list file"
@@ -17819,8 +17439,8 @@ msgstr ""
 "Nur Bauteile mit dieser Option werden nicht in die Datei mit der "
 "Positionsliste für Footprints aufgenommen."
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor.cpp:332
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit.cpp:183
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor.cpp:333
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit.cpp:184
 msgid ""
 "Use this attribute for SMD components.\n"
 "Only components with this option are put in the footprint position list file"
@@ -17829,8 +17449,8 @@ msgstr ""
 "Nur Bauteile mit dieser Option werden in die Datei mit der Positionsliste "
 "für Footprints aufgenommen."
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor.cpp:335
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit.cpp:186
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor.cpp:336
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit.cpp:187
 msgid ""
 "Use this attribute for \"virtual\" components drawn on board\n"
 "like an edge connector (old ISA PC bus for instance)"
@@ -17839,7 +17459,7 @@ msgstr ""
 "\" Bauteile\n"
 "(wie z.B. einen Steckverbinder eines alten ISA PC Bus)."
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor.cpp:366
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor.cpp:367
 msgid ""
 "Component can be freely moved and auto placed. User can arbitrarily select "
 "and edit component's pads."
@@ -17847,7 +17467,7 @@ msgstr ""
 "Bauteil kann frei bewegt und autoplatziert werden. Der Benutzer kann die "
 "Bauteilpads selektieren und verändern."
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor.cpp:369
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor.cpp:370
 msgid ""
 "Component can be freely moved and auto placed, but its pads cannot be "
 "selected or edited."
@@ -17855,80 +17475,81 @@ msgstr ""
 "Bauteil kann frei bewegt und autoplatziert werden, aber die Pads können "
 "nicht gewählt oder editiert werden."
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor.cpp:372
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor.cpp:373
 msgid "Component is locked: it cannot be freely moved or auto placed."
 msgstr ""
 "Bauteil ist gesperrt: Es kann nicht frei bewegt oder autoplatziert werden."
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor.cpp:497
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit.cpp:355
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor.cpp:498
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit.cpp:356
 msgid "Invalid filename: "
 msgstr "Ungültiger Dateiname:"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor.cpp:499
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit.cpp:357
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor.cpp:500
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit.cpp:358
 msgid "Edit 3D file name"
 msgstr "3D-Dateiname editieren"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor.cpp:589
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor.cpp:590
 msgid "Error: invalid footprint parameter"
 msgstr "Fehler: Ungültiger Footprint-Parameter!"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor.cpp:595
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor.cpp:596
 msgid "Error: invalid 3D parameter"
 msgstr "Fehler: Ungültiger 3D-Parameter!"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor.cpp:615
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor.cpp:616
 msgid "Error: invalid or missing footprint parameter"
 msgstr "Fehler: Ungültiger oder fehlender Footprint-Parameter!"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor.cpp:621
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor.cpp:622
 msgid "Error: invalid or missing 3D parameter"
 msgstr "Fehler: Ungültiger oder fehlende 3D-Parameter!"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor.cpp:744
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit.cpp:529
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor.cpp:745
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit.cpp:530
 msgid "Modify module properties"
 msgstr "Eigenschaften des Moduls editieren"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:58
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:60
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:1393
 msgid "Back"
 msgstr "Rückseite"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:64
-#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:118
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:66
+#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:119
 msgid "0.0"
 msgstr "0.0"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:64
-#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:118
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:66
+#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:119
 msgid "+90.0"
 msgstr "+90.0"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:64
-#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:118
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:66
+#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:119
 msgid "-90.0"
 msgstr "-90.0"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:64
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:66
+#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:119
 msgid "180.0"
 msgstr "180.0"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:64
-#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:118
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:66
+#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:119
 msgid "Other"
 msgstr "Andere"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:70
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:72
 msgid "Rotation (-360 to 360):"
 msgstr "Drehung (-360 bis 360):"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:112
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:114
 msgid "Sheet path:"
 msgstr "Schaltplanpfad:"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:117
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:119
 msgid ""
 "An unique ID (a time stamp) to identify the component.\n"
 "This is an alternate identifier to the reference."
@@ -17936,74 +17557,74 @@ msgstr ""
 "Eine einheitliche Id (Zeitstempel), zur Identifikation des Bauteils.\n"
 "Dies ist ein alternativer Identifikator für die Referenz."
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:126
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:128
 msgid "Change Footprint(s)"
 msgstr "Footprint(s) ändern"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:129
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:131
 #: pcbnew/hotkeys.cpp:335 pcbnew/moduleframe.cpp:822
 msgid "Footprint Editor"
 msgstr "Footprinteditor"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:137
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:102
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:139
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:104
 msgid "Placement type"
 msgstr "Platzierungstyp"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:141
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:106
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:143
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:108
 msgid "Free"
 msgstr "Frei"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:141
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:143
 msgid "Lock pads"
 msgstr "Pads sperren"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:141
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:143
 msgid "Lock footprint"
 msgstr "Footprints sperren"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:143
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:108
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:145
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:110
 msgid "Move and Place"
 msgstr "Verschieben und Platzieren"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:151
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:116
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:153
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:118
 msgid "Auto Place"
 msgstr "Auto Platzierung"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:156
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:158
 msgid "Rotate 90 degrees"
 msgstr "Rotation um 90 Grad"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:169
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:171
 msgid "Rotate 180 degrees"
 msgstr "Rotation um 180 Grad"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:183
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:185
 msgid "Local Settings"
 msgstr "Lokale Einstellungen"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:191
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:193
 msgid "Pad connection to zones:"
 msgstr "Padverbindung zu Flächen:"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:195
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:197
 msgid "Use zone setting"
 msgstr "Verwende Flächeneinstellungen"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:204
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:150
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:206
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:152
 msgid "Set clearances to 0 to use global values"
 msgstr "Setze Abstandswerte auf 0, um globale Werte zu verwenden"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:219
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:162
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:221
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:164
 msgid "Pad clearance:"
 msgstr "Padabstandsfläche:"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:221
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:223
 msgid ""
 "This is the local net clearance for all pad of this footprint\n"
 "If 0, the Netclass values are used\n"
@@ -18013,15 +17634,15 @@ msgstr ""
 "Wenn auf 0 gesetzt werden die Werte der Netzklasse verwendet.\n"
 "Dieser Wert kann durch den lokalen Wert eines Pads ersetzt werden."
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:241
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:182
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:243
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:184
 #: pcbnew/dialogs/dialog_mask_clearance_base.cpp:40
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:444
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:446
 msgid "Solder mask clearance:"
 msgstr "Abstand Lötstoppmaske:"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:243
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:184
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:245
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:186
 msgid ""
 "This is the local clearance between pads and the solder mask\n"
 "for this footprint\n"
@@ -18033,15 +17654,15 @@ msgstr ""
 "Dieser Wert kann durch den lokalen Wert eines Pads ersetzt werden.\n"
 "Wenn auf 0 gesetzt wird der globale Wert verwendet."
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:254
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:195
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:256
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:197
 #: pcbnew/dialogs/dialog_mask_clearance_base.cpp:77
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:457
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:459
 msgid "Solder paste clearance:"
 msgstr "Abstand Lötpaste:"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:256
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:197
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:258
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:199
 msgid ""
 "This is the local clearance between pads and the solder paste\n"
 "for this footprint.\n"
@@ -18058,15 +17679,15 @@ msgstr ""
 "Ein negativer Wert bedeutet, dass die Maskengröße kleiner als die Padgröße "
 "ist."
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:267
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:208
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:269
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:210
 #: pcbnew/dialogs/dialog_mask_clearance_base.cpp:91
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:470
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:472
 msgid "Solder paste ratio clearance:"
 msgstr "Abstandsverhältnis der Lötstoppmaske:"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:269
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:210
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:271
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:212
 msgid ""
 "This is the local clearance ratio in per cent between pads and the solder "
 "paste\n"
@@ -18087,146 +17708,139 @@ msgstr ""
 "Ein negativer Wert bedeutet, dass die Maskengröße kleiner als die Padgröße "
 "ist."
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:276
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:217
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:278
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:219
 #: pcbnew/dialogs/dialog_mask_clearance_base.cpp:101
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:235
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:479
-#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:136
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:237
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:481
+#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:138
 msgid "%"
 msgstr "%"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:298
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:300
 msgid "3D Shape Name"
 msgstr "Name der 3D-Form"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:318
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:260
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:320
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:262
 msgid "Add 3D Shape"
 msgstr "3D-Form hinzufügen"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:321
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:263
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:323
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:265
 msgid "Remove 3D Shape"
 msgstr "3D-Form entfernen"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:324
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:266
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:326
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:268
 msgid "Edit Filename"
 msgstr "Editiere Dateiname"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:327
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:269
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:329
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:271
 msgid "Configure Paths"
 msgstr "Pfade konfigurieren"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:348
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:290
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:350
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:292
 msgid "3D Settings"
 msgstr "3D-Einstellungen"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.h:133
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.h:116
-msgid "Footprint Properties"
-msgstr "Footprint Eigenschaften"
-
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit.cpp:181
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit.cpp:182
 msgid "Use this attribute for most non SMD components"
 msgstr "Verwende dieses Attribut für die meisten Nicht-SMD-Bauteile"
 
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit.cpp:210
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit.cpp:211
 msgid "Enable hotkey move commands and Auto Placement"
 msgstr "Aktiviere Tasten-Befehle zum Verschieben und automatischen Platzieren"
 
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit.cpp:211
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit.cpp:212
 msgid "Disable hotkey move commands and Auto Placement"
 msgstr ""
 "Deaktiviere Tasten-Befehle zum Verschieben und automatischen Platzieren"
 
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit.cpp:450
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit.cpp:451
+#: pcbnew/librairi.cpp:698
 #, c-format
 msgid ""
 "Error:\n"
-"one of invalid chars <%s> found\n"
-"in <%s>"
+"one of invalid chars \"%s\" found\n"
+"in \"%s\""
 msgstr ""
-"Fehler:\n"
-"Unzulässiges Zeichen <%s> gefunden\n"
-"in <%s>"
 
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:26
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:28
 msgid "Doc"
 msgstr "Typenbeschreibung"
 
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:75
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:77
 msgid "Footprint name in library"
 msgstr "Footprintname in Bibliothek"
 
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:82
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:84
 msgid "Library nickname"
 msgstr "Nickname Bibliotheksdatei"
 
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:106
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:108
 #: pcbnew/dialogs/dialog_track_via_properties_base.cpp:47
 msgid "Locked"
 msgstr "Gesperrt"
 
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:121
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:123
 msgid "Rotation 90 degree"
 msgstr "Rotation um 90 Grad"
 
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:134
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:136
 msgid "Rotation 180 degree"
 msgstr "Rotation um 180 Grad"
 
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:148
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:150
 msgid "Local Clearance Values"
 msgstr "Lokales Flächenabstandsmaß"
 
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:169
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:204
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:171
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:206
 #: pcbnew/dialogs/dialog_export_vrml_base.cpp:111
 #: pcbnew/dialogs/dialog_mask_clearance_base.cpp:50
 #: pcbnew/dialogs/dialog_mask_clearance_base.cpp:64
 #: pcbnew/dialogs/dialog_mask_clearance_base.cpp:87
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:88
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:99
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:110
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:121
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:156
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:167
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:180
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:200
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:294
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:305
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:440
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:453
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:466
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:517
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:528
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:90
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:101
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:112
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:123
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:158
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:169
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:182
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:202
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:296
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:307
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:442
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:455
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:468
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:519
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:530
 msgid "Inch"
 msgstr "Zoll"
 
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:240
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:242
 msgid "3D Shape Names"
 msgstr "Name der 3D-Form"
 
-#: pcbnew/dialogs/dialog_edit_module_text.cpp:121
+#: pcbnew/dialogs/dialog_edit_module_text.cpp:122
 msgid "Value:"
 msgstr "Wert:"
 
-#: pcbnew/dialogs/dialog_edit_module_text.cpp:125
-#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:24
+#: pcbnew/dialogs/dialog_edit_module_text.cpp:126
+#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:25
 msgid "Text:"
 msgstr "Text:"
 
-#: pcbnew/dialogs/dialog_edit_module_text.cpp:129
-#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:45
+#: pcbnew/dialogs/dialog_edit_module_text.cpp:130
+#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:46
 #: pcbnew/dialogs/dialog_get_footprint_by_name_base.cpp:27
 msgid "Reference:"
 msgstr "Referenz:"
 
-#: pcbnew/dialogs/dialog_edit_module_text.cpp:199
+#: pcbnew/dialogs/dialog_edit_module_text.cpp:206
 msgid ""
 "This item has an illegal layer id.\n"
 "Now, forced on the front silk screen layer. Please, fix it"
@@ -18235,35 +17849,41 @@ msgstr ""
 "und wurde somit auf die vordere Siebdrucklage verschoben.\n"
 "Bitte dies entsprechend beheben."
 
-#: pcbnew/dialogs/dialog_edit_module_text.cpp:259
-#: pcbnew/dialogs/dialog_pcb_text_properties.cpp:268
+#: pcbnew/dialogs/dialog_edit_module_text.cpp:266
+#: pcbnew/dialogs/dialog_pcb_text_properties.cpp:269
 msgid "The text thickness is too large for the text size. It will be clamped"
 msgstr "Die Textstärke ist für diesen Text zu groß. Text wird eingepasst."
 
-#: pcbnew/dialogs/dialog_edit_module_text.cpp:330
+#: pcbnew/dialogs/dialog_edit_module_text.cpp:348
 msgid "Modify module text"
 msgstr "Modultext modifizieren"
 
-#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:24
+#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:25
 #, c-format
 msgid "Footprint %s (%s) orientation %.1f"
 msgstr "Footprint %s (%s) Ausrichtung %.1f"
 
-#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:73
+#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:74
 msgid "Offset X"
 msgstr "Offset X"
 
-#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:80
+#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:81
 msgid "Offset Y"
 msgstr "Offset Y"
 
-#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:124
-msgid "Rotation (-90.0 to 90.0)"
-msgstr "Drehung (-90.0 bis 90.0)"
+#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:125
+msgid "Rotation (-180.0 to 180.0)"
+msgstr ""
 
-#: pcbnew/dialogs/dialog_edit_module_text_base.h:76
-msgid "Footprint Text Properties"
-msgstr "Footprint Texteigenschaften"
+#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:132
+msgid "Unlock text orientation"
+msgstr ""
+
+#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:133
+msgid ""
+"If orientation is locked, the text will always face near the bottom or right "
+"edge of the board."
+msgstr ""
 
 #: pcbnew/dialogs/dialog_enum_pads_base.cpp:19
 msgid "Pad names are restricted to 4 characters (including number)."
@@ -18277,65 +17897,61 @@ msgstr "Prefix für Padnamen:"
 msgid "First pad number:"
 msgstr "Erste Pad-Nummer:"
 
-#: pcbnew/dialogs/dialog_enum_pads_base.h:53
-msgid "Pad enumeration settings"
-msgstr "Einstellungen Pad-Aufzählung"
-
-#: pcbnew/dialogs/dialog_exchange_modules.cpp:83
+#: pcbnew/dialogs/dialog_exchange_modules.cpp:82
 #, c-format
-msgid "Change footprint of '%s'"
-msgstr "Footprint von '%s' ändern"
+msgid "Change footprint of \"%s\""
+msgstr ""
 
-#: pcbnew/dialogs/dialog_exchange_modules.cpp:91
+#: pcbnew/dialogs/dialog_exchange_modules.cpp:90
 #, c-format
-msgid "Change footprints '%s'"
-msgstr "Footprints '%s' ändern"
+msgid "Change footprints \"%s\""
+msgstr ""
 
-#: pcbnew/dialogs/dialog_exchange_modules.cpp:175
+#: pcbnew/dialogs/dialog_exchange_modules.cpp:174
 #, c-format
-msgid "File '%s' created\n"
-msgstr "Die Datei '%s' wurde erstellt.\n"
+msgid "File \"%s\" created\n"
+msgstr ""
 
-#: pcbnew/dialogs/dialog_exchange_modules.cpp:180
+#: pcbnew/dialogs/dialog_exchange_modules.cpp:179
 #, c-format
-msgid "** Could not create file '%s' ***\n"
-msgstr "** Konnte die Datei '%s' nicht erstellen. **\n"
+msgid "** Could not create file \"%s\" ***\n"
+msgstr ""
 
-#: pcbnew/dialogs/dialog_exchange_modules.cpp:222
+#: pcbnew/dialogs/dialog_exchange_modules.cpp:221
 #, c-format
 msgid "Change footprint %s -> %s (for value = %s)?"
 msgstr "Möchten Sie Footprint %s -> %s (auf den Wert = %s) ändern?"
 
-#: pcbnew/dialogs/dialog_exchange_modules.cpp:229
+#: pcbnew/dialogs/dialog_exchange_modules.cpp:228
 #, c-format
 msgid "Change footprint %s -> %s ?"
 msgstr "Ändere Footprint %s -> %s ?"
 
-#: pcbnew/dialogs/dialog_exchange_modules.cpp:277
+#: pcbnew/dialogs/dialog_exchange_modules.cpp:276
 msgid "Are you sure you want to change all footprints?"
 msgstr "Sind Sie sicher, dass Sie alle Footprints ändern möchten?"
 
-#: pcbnew/dialogs/dialog_exchange_modules.cpp:319
+#: pcbnew/dialogs/dialog_exchange_modules.cpp:318
 #, c-format
-msgid "Change footprint '%s' (from '%s') to '%s'"
-msgstr "Ändere Footprint '%s' (von '%s') nach '%s'"
+msgid "Change footprint \"%s\" (from \"%s\") to \"%s\""
+msgstr ""
 
-#: pcbnew/dialogs/dialog_exchange_modules.cpp:328
+#: pcbnew/dialogs/dialog_exchange_modules.cpp:327
 msgid "footprint not found"
 msgstr "Footprint nicht gefunden"
 
-#: pcbnew/dialogs/dialog_exchange_modules.cpp:423
+#: pcbnew/dialogs/dialog_exchange_modules.cpp:422
 msgid "No footprints!"
 msgstr "Keine Footprints!"
 
-#: pcbnew/dialogs/dialog_exchange_modules.cpp:434
+#: pcbnew/dialogs/dialog_exchange_modules.cpp:433
 msgid "Save Footprint Association File"
 msgstr "Footprints Assoziierungsdatei speichern"
 
-#: pcbnew/dialogs/dialog_exchange_modules.cpp:445
+#: pcbnew/dialogs/dialog_exchange_modules.cpp:444
 #, c-format
-msgid "Could not create file '%s'"
-msgstr "Konnte die Datei '%s' nicht erstellen."
+msgid "Could not create file \"%s\""
+msgstr ""
 
 #: pcbnew/dialogs/dialog_exchange_modules_base.cpp:27
 msgid "Component value"
@@ -18385,68 +18001,60 @@ msgstr "Neuer Footprintname (FPID)"
 msgid "Apply"
 msgstr "Anwenden"
 
-#: pcbnew/dialogs/dialog_exchange_modules_base.h:72
-msgid "Change Footprint"
-msgstr "Ändere Footprint"
-
-#: pcbnew/dialogs/dialog_export_idf.cpp:168
+#: pcbnew/dialogs/dialog_export_idf.cpp:169
 msgid "Are you sure you want to overwrite the exiting file?"
 msgstr "Möchten Sie wirklich die vorhandene Datei überschreiben?"
 
-#: pcbnew/dialogs/dialog_export_idf.cpp:222
-#: pcbnew/exporters/export_d356.cpp:373
+#: pcbnew/dialogs/dialog_export_idf.cpp:223
+#: pcbnew/exporters/export_d356.cpp:374
 msgid "Unable to create "
 msgstr "Konnte die folgende Datei nicht erstellen"
 
-#: pcbnew/dialogs/dialog_export_idf_base.cpp:19
-#: pcbnew/dialogs/dialog_export_step_base.cpp:19
+#: pcbnew/dialogs/dialog_export_idf_base.cpp:21
+#: pcbnew/dialogs/dialog_export_step_base.cpp:21
 msgid "File name:"
 msgstr "Dateiname:"
 
-#: pcbnew/dialogs/dialog_export_idf_base.cpp:23
+#: pcbnew/dialogs/dialog_export_idf_base.cpp:25
 msgid "Select an IDF export filename"
 msgstr "Wähle einen IDF-Export Dateinamen"
 
-#: pcbnew/dialogs/dialog_export_idf_base.cpp:32
+#: pcbnew/dialogs/dialog_export_idf_base.cpp:34
 #: pcbnew/dialogs/dialog_export_vrml_base.cpp:49
 msgid "Grid Reference Point:"
 msgstr "Raster Referenzpunkt:"
 
-#: pcbnew/dialogs/dialog_export_idf_base.cpp:36
+#: pcbnew/dialogs/dialog_export_idf_base.cpp:38
 msgid "Adjust automatically"
 msgstr "Automatisch anpassen"
 
-#: pcbnew/dialogs/dialog_export_idf_base.cpp:42
-#: pcbnew/dialogs/dialog_export_step_base.cpp:101
+#: pcbnew/dialogs/dialog_export_idf_base.cpp:44
+#: pcbnew/dialogs/dialog_export_step_base.cpp:103
 #: pcbnew/dialogs/dialog_export_vrml_base.cpp:59
 #: pcbnew/dialogs/dialog_gen_module_position_file_base.cpp:62
 msgid "Units:"
 msgstr "Einheiten:"
 
-#: pcbnew/dialogs/dialog_export_idf_base.cpp:58
+#: pcbnew/dialogs/dialog_export_idf_base.cpp:60
 #: pcbnew/import_dxf/dialog_dxf_import_base.cpp:67
 msgid "X Position:"
 msgstr "X Position:"
 
-#: pcbnew/dialogs/dialog_export_idf_base.cpp:79
+#: pcbnew/dialogs/dialog_export_idf_base.cpp:81
 #: pcbnew/import_dxf/dialog_dxf_import_base.cpp:87
 msgid "Y Position:"
 msgstr "Y Position:"
 
-#: pcbnew/dialogs/dialog_export_idf_base.cpp:100
+#: pcbnew/dialogs/dialog_export_idf_base.cpp:102
 msgid "Mils"
 msgstr "Mil"
 
-#: pcbnew/dialogs/dialog_export_idf_base.cpp:102
+#: pcbnew/dialogs/dialog_export_idf_base.cpp:104
 #: pcbnew/dialogs/dialog_export_vrml_base.cpp:113
 msgid "Output Units:"
 msgstr "Ausgabeeinheiten:"
 
-#: pcbnew/dialogs/dialog_export_idf_base.h:62
-msgid "Export IDFv3"
-msgstr "Export IDFv3"
-
-#: pcbnew/dialogs/dialog_export_step.cpp:172
+#: pcbnew/dialogs/dialog_export_step.cpp:173
 #, c-format
 msgid ""
 "File: %s\n"
@@ -18456,15 +18064,15 @@ msgstr ""
 "\n"
 "Möchten Sie diese überschreiben?"
 
-#: pcbnew/dialogs/dialog_export_step.cpp:176
+#: pcbnew/dialogs/dialog_export_step.cpp:177
 msgid "STEP Export"
 msgstr "STEP Export"
 
-#: pcbnew/dialogs/dialog_export_step.cpp:236
+#: pcbnew/dialogs/dialog_export_step.cpp:237
 msgid "STEP export failed!  Please save the PCB and try again"
 msgstr "STEP Export nicht möglich, bitte PCB speichern und erneut versuchen."
 
-#: pcbnew/dialogs/dialog_export_step.cpp:337
+#: pcbnew/dialogs/dialog_export_step.cpp:338
 msgid ""
 "Unable to create STEP file.  Check that the board has a valid outline and "
 "models."
@@ -18472,19 +18080,19 @@ msgstr ""
 "Konnte die STEP Datei nicht erstellen, prüfen Sie den Platinenumriss und die "
 "Modelle."
 
-#: pcbnew/dialogs/dialog_export_step_base.cpp:23
+#: pcbnew/dialogs/dialog_export_step_base.cpp:25
 msgid "Select a STEP export filename"
 msgstr "Wähle einen STEP-Export Dateinamen"
 
-#: pcbnew/dialogs/dialog_export_step_base.cpp:35
+#: pcbnew/dialogs/dialog_export_step_base.cpp:37
 msgid "Coordinate origin options:"
 msgstr "Optionen Ursprungspunkt:"
 
-#: pcbnew/dialogs/dialog_export_step_base.cpp:49
+#: pcbnew/dialogs/dialog_export_step_base.cpp:51
 msgid "Drill and plot axis origin"
 msgstr "Bohrloch- und Plot-Ursprungspunkt:"
 
-#: pcbnew/dialogs/dialog_export_step_base.cpp:50
+#: pcbnew/dialogs/dialog_export_step_base.cpp:52
 msgid ""
 "Use the auxiliary axis origin (used in plot and drill geneation) as STEP "
 "coordinates origin."
@@ -18492,67 +18100,58 @@ msgstr ""
 "Benutzt einen zusätzlichen Ursprungspunkt, der bei der Generation von Plot "
 "und Bohrlochdaten benutzt wird als Ursprungspunkt für die STEP Koordinaten."
 
-#: pcbnew/dialogs/dialog_export_step_base.cpp:57
+#: pcbnew/dialogs/dialog_export_step_base.cpp:59
 msgid "Grid origin"
 msgstr "Raster Ursprungspunkt"
 
-#: pcbnew/dialogs/dialog_export_step_base.cpp:58
+#: pcbnew/dialogs/dialog_export_step_base.cpp:60
 msgid "Use the grid origin as STEP coordinates origin."
 msgstr ""
 "Benutzt den Rasterursprungspunkt als Ursprungspunkt für die STEP Koordinaten."
 
-#: pcbnew/dialogs/dialog_export_step_base.cpp:65
+#: pcbnew/dialogs/dialog_export_step_base.cpp:67
 msgid "User defined origin"
 msgstr "Benutzerdefinierter Ursprungspunkt"
 
-#: pcbnew/dialogs/dialog_export_step_base.cpp:66
+#: pcbnew/dialogs/dialog_export_step_base.cpp:68
 msgid ""
 "Use this option if you want to define a specific coordinate origin value."
 msgstr ""
 "Definieren Sie mit dieser Option einen benutzerspezifischen Ursprungspunkt. "
 
-#: pcbnew/dialogs/dialog_export_step_base.cpp:73
+#: pcbnew/dialogs/dialog_export_step_base.cpp:75
 msgid "Board center origin"
 msgstr "Zentrum Platinenursprung"
 
-#: pcbnew/dialogs/dialog_export_step_base.cpp:74
+#: pcbnew/dialogs/dialog_export_step_base.cpp:76
 msgid ""
 "Use this option if you want to define coordinate origin at board center."
 msgstr ""
 "Definieren Sie mit dieser Option einen benutzerspezifischen Ursprungspunkt. "
 
-#: pcbnew/dialogs/dialog_export_step_base.cpp:87
+#: pcbnew/dialogs/dialog_export_step_base.cpp:89
 msgid "User defined origin:"
 msgstr "Benutzerdefinierter Ursprungspunkt:"
 
-#: pcbnew/dialogs/dialog_export_step_base.cpp:114
+#: pcbnew/dialogs/dialog_export_step_base.cpp:116
 msgid "X position:"
 msgstr "X Position:"
 
-#: pcbnew/dialogs/dialog_export_step_base.cpp:132
+#: pcbnew/dialogs/dialog_export_step_base.cpp:134
 msgid "Y position:"
 msgstr "Y Position:"
 
-#: pcbnew/dialogs/dialog_export_step_base.cpp:156
+#: pcbnew/dialogs/dialog_export_step_base.cpp:158
 msgid "Other options:"
 msgstr "Andere Optionen:"
 
-#: pcbnew/dialogs/dialog_export_step_base.cpp:170
+#: pcbnew/dialogs/dialog_export_step_base.cpp:172
 msgid "Ignore virtual components"
 msgstr "Virtuelle Bauteile ignorieren"
-
-#: pcbnew/dialogs/dialog_export_step_base.h:71
-msgid "Export STEP"
-msgstr "STEP-Export"
 
 #: pcbnew/dialogs/dialog_export_vrml.cpp:177
 msgid "Are you sure you want to overwrite the exiting file(s)?"
 msgstr "Möchten Sie wirklich die vorhandene Datei(en) überschreiben?"
-
-#: pcbnew/dialogs/dialog_export_vrml.cpp:253
-#, c-format
-msgid "Unable to create file '%s'"
-msgstr "Konnte Datei '%s' nicht erstellen"
 
 #: pcbnew/dialogs/dialog_export_vrml_base.cpp:22
 msgid "File Name:"
@@ -18600,19 +18199,15 @@ msgstr ""
 msgid "Plain PCB (no copper or silk)"
 msgstr "Platine ohne Kupfer oder Siebdruck"
 
-#: pcbnew/dialogs/dialog_export_vrml_base.h:72
-msgid "VRML Export Options"
-msgstr "VRML-Exportoptionen"
-
 #: pcbnew/dialogs/dialog_find.cpp:131
 #, c-format
-msgid "<%s> found"
-msgstr "<%s> gefunden"
+msgid "\"%s\" found"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_find.cpp:139
 #, c-format
-msgid "<%s> not found"
-msgstr "<%s> nicht gefunden"
+msgid "\"%s\" not found"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_find.cpp:169
 msgid "Marker found"
@@ -18658,14 +18253,6 @@ msgstr "Zeige Trace"
 msgid "Update Python Modules"
 msgstr "Python-Module aktualisieren"
 
-#: pcbnew/dialogs/dialog_footprint_wizard_list_base.h:68
-msgid "Footprint Generators"
-msgstr "Footprint-Generatoren"
-
-#: pcbnew/dialogs/dialog_footprint_wizard_list_base.h:87
-msgid "Traceback of errors in not loadable python scripts"
-msgstr "Traceback der Fehler in Python-Skripten die sich nicht laden lassen"
-
 #: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:133
 msgid "Append with Wizard"
 msgstr "Mit Wizard hinzufügen"
@@ -18678,10 +18265,6 @@ msgstr "Editor für Optionen"
 msgid "Zoom into the options table for current row"
 msgstr "Zoome in die Optionstabelle für die aktuelle Zeile"
 
-#: pcbnew/dialogs/dialog_fp_lib_table_base.h:81
-msgid "PCB Library Tables"
-msgstr "PCB Bibliothekstabelle"
-
 #: pcbnew/dialogs/dialog_fp_plugin_options.cpp:35
 msgid ""
 "Select an <b>Option Choice</b> in the listbox above, and then click the "
@@ -18692,8 +18275,8 @@ msgstr ""
 
 #: pcbnew/dialogs/dialog_fp_plugin_options.cpp:64
 #, c-format
-msgid "Options for Library '%s'"
-msgstr "Optionen für Bibliothek '%s'"
+msgid "Options for Library \"%s\""
+msgstr ""
 
 #: pcbnew/dialogs/dialog_fp_plugin_options_base.cpp:23
 msgid "Plugin Options:"
@@ -18739,11 +18322,11 @@ msgstr "<< Ausgewählte Option hinzufügen"
 msgid "Option Specific Help:"
 msgstr "Optionsspezifische Hilfe:"
 
-#: pcbnew/dialogs/dialog_freeroute_exchange.cpp:90
+#: pcbnew/dialogs/dialog_freeroute_exchange.cpp:92
 msgid "Freeroute Help"
 msgstr "FreeRoute Hilfe"
 
-#: pcbnew/dialogs/dialog_freeroute_exchange.cpp:149
+#: pcbnew/dialogs/dialog_freeroute_exchange.cpp:151
 msgid ""
 "It appears that the Java run time environment is not installed on this "
 "computer.  Java is required to use FreeRoute."
@@ -18751,14 +18334,14 @@ msgstr ""
 "Es scheint, dass die Java Laufzeitumgebung (JRE) auf ihrem PC nicht "
 "installiert ist. Java wird benötigt, um FreeRoute nutzen zu können."
 
-#: pcbnew/dialogs/dialog_freeroute_exchange.cpp:152
+#: pcbnew/dialogs/dialog_freeroute_exchange.cpp:154
 msgid "Pcbnew Error"
 msgstr "Pcbnew Fehler"
 
-#: pcbnew/dialogs/dialog_freeroute_exchange.cpp:188
-#: pcbnew/specctra_export.cpp:87
-msgid "Specctra DSN file:"
-msgstr "Specctra DSN Datei:"
+#: pcbnew/dialogs/dialog_freeroute_exchange.cpp:190
+#: pcbnew/specctra_export.cpp:84
+msgid "Specctra DSN File"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_freeroute_exchange_base.cpp:25
 msgid "Export/Import to/from FreeRoute:"
@@ -18858,49 +18441,41 @@ msgstr ""
 "besitzen.\n"
 "Achtung: Diese Option wird die Platine modifizieren."
 
-#: pcbnew/dialogs/dialog_gen_module_position_file_base.h:61
-msgid "Generate Component Position Files"
-msgstr "Bauteilplatzierungsdatei erstellen"
-
-#: pcbnew/dialogs/dialog_gencad_export_options.cpp:36
+#: pcbnew/dialogs/dialog_gencad_export_options.cpp:37
 msgid "Export to GenCAD settings"
 msgstr "Im GenCAD Format exportieren"
 
-#: pcbnew/dialogs/dialog_gencad_export_options.cpp:120
+#: pcbnew/dialogs/dialog_gencad_export_options.cpp:121
 #, c-format
 msgid "File %s already exists. Overwrite?"
 msgstr "Datei %s existiert bereits, überschreiben?"
 
-#: pcbnew/dialogs/dialog_gencad_export_options.cpp:130
+#: pcbnew/dialogs/dialog_gencad_export_options.cpp:131
 msgid "Flip bottom components padstacks"
 msgstr "Wenden des Padstacks der Bauteile von der Unterseite"
 
-#: pcbnew/dialogs/dialog_gencad_export_options.cpp:131
+#: pcbnew/dialogs/dialog_gencad_export_options.cpp:132
 msgid "Generate unique pin names"
 msgstr "Eindeutige Pinnamen generieren"
 
-#: pcbnew/dialogs/dialog_gencad_export_options.cpp:132
+#: pcbnew/dialogs/dialog_gencad_export_options.cpp:133
 msgid "Generate a new shape for each component instance (do not reuse shapes)"
 msgstr ""
 "Erstelle eine neue Form für jede Instanz einer Komponente (kein "
 "wiederverwenden von Formen)."
 
-#: pcbnew/dialogs/dialog_gencad_export_options.cpp:133
+#: pcbnew/dialogs/dialog_gencad_export_options.cpp:134
 #: pcbnew/dialogs/dialog_plot_base.cpp:126
 msgid "Use auxiliary axis as origin"
 msgstr "Verwende Hilfsachsen als Ursprungspunkt"
 
-#: pcbnew/dialogs/dialog_gencad_export_options.cpp:134
+#: pcbnew/dialogs/dialog_gencad_export_options.cpp:135
 msgid "Save the origin coordinates in the file"
 msgstr "Speichert den Rasterursprungspunkt in eine Datei."
 
-#: pcbnew/dialogs/dialog_gencad_export_options.cpp:148
+#: pcbnew/dialogs/dialog_gencad_export_options.cpp:149
 msgid "Save GenCAD Board File"
 msgstr "Speichere GenCAD Platine"
-
-#: pcbnew/dialogs/dialog_gencad_export_options.cpp:151
-msgid "GenCAD 1.4 board files (.cad)|*.cad"
-msgstr "GenCAD 1.4 Platinen Dateien (.cad)|*.cad"
 
 #: pcbnew/dialogs/dialog_gendrill.cpp:138
 #: pcbnew/dialogs/dialog_gendrill.cpp:139
@@ -19109,10 +18684,6 @@ msgstr "Bohrplandatei"
 msgid "Report File"
 msgstr "Protokolldatei"
 
-#: pcbnew/dialogs/dialog_gendrill_base.h:83
-msgid "Drill Files Generation"
-msgstr "Bohrdatei Generator"
-
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:29
 msgid ""
 "Set display of relative (dx/dy) coordinates to Cartesian (rectangular) or "
@@ -19281,10 +18852,6 @@ msgstr ""
 msgid "Available:"
 msgstr "Verfügbar:"
 
-#: pcbnew/dialogs/dialog_get_footprint_by_name_base.h:57
-msgid "Search for footprint"
-msgstr "Suche Footprint"
-
 #: pcbnew/dialogs/dialog_global_deletion.cpp:109
 msgid "Are you sure you want to delete the entire board?"
 msgstr "Möchten Sie wirklich die gesamte Platine entfernen?"
@@ -19298,7 +18865,7 @@ msgid "Items to Delete"
 msgstr "Elemente zum Entfernen"
 
 #: pcbnew/dialogs/dialog_global_deletion_base.cpp:25
-#: pcbnew/onrightclick.cpp:716 pcbnew/tools/pcb_editor_control.cpp:163
+#: pcbnew/onrightclick.cpp:716 pcbnew/tools/pcb_editor_control.cpp:153
 msgid "Zones"
 msgstr "Flächen"
 
@@ -19362,10 +18929,6 @@ msgstr "Lagenfilter"
 #: pcbnew/dialogs/dialog_global_deletion_base.cpp:100
 msgid "Current layer:"
 msgstr "Aktuelle Lage:"
-
-#: pcbnew/dialogs/dialog_global_deletion_base.h:75
-msgid "Delete Items"
-msgstr "Elemente entfernen"
 
 #: pcbnew/dialogs/dialog_global_edit_tracks_and_vias.cpp:177
 #: pcbnew/dialogs/dialog_select_net_from_list.cpp:153
@@ -19480,10 +19043,6 @@ msgstr ""
 "Alle Leiterbahnen (bis auf Durchkontaktierungen) auf Wert von Netzklasse "
 "setzen"
 
-#: pcbnew/dialogs/dialog_global_edit_tracks_and_vias_base.h:73
-msgid "Global Edition of Tracks and Vias"
-msgstr "Globale Einstellung für Leiterbahnen und Durchkontaktierungen"
-
 #: pcbnew/dialogs/dialog_global_modules_fields_edition_base.cpp:26
 msgid "Footprint Fields"
 msgstr "Footprintfelder"
@@ -19515,14 +19074,10 @@ msgid "Current Text Dimensions"
 msgstr "Aktuelle Textabmessungen"
 
 #: pcbnew/dialogs/dialog_global_modules_fields_edition_base.cpp:86
-#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:111
+#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:112
 #: pcbnew/dialogs/dialog_target_properties_base.cpp:39
 msgid "Thickness:"
 msgstr "Stärke:"
-
-#: pcbnew/dialogs/dialog_global_modules_fields_edition_base.h:67
-msgid "Set Text Size"
-msgstr "Einstellungen der Textgröße"
 
 #: pcbnew/dialogs/dialog_global_pads_edition_base.cpp:23
 msgid "Pad Filter :"
@@ -19552,52 +19107,48 @@ msgstr "Ändere Pads im Footprint"
 msgid "Change Pads on Identical Footprints"
 msgstr "Ändere Pads an gleichen Footprints"
 
-#: pcbnew/dialogs/dialog_global_pads_edition_base.h:58
-msgid "Global Pads Edition"
-msgstr "Globale Pad-Einstellungen"
-
-#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:145
+#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:146
 #: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:149
 msgid "Circle Properties"
 msgstr "Kreiseigenschaften"
 
-#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:146
-#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:157
+#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:147
+#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:158
 msgid "Center X:"
 msgstr "Mittelpunkt X:"
 
-#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:147
-#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:158
+#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:148
+#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:159
 msgid "Center Y:"
 msgstr "Mittelpunkt Y:"
 
-#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:148
+#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:149
 msgid "Point X:"
 msgstr "Punkt X:"
 
-#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:149
+#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:150
 msgid "Point Y:"
 msgstr "Punkt Y:"
 
-#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:156
+#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:157
 #: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:160
 msgid "Arc Properties"
 msgstr "Eigenschaften Kreisbogen"
 
-#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:159
+#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:160
 msgid "Start Point X:"
 msgstr "Startpunkt X:"
 
-#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:160
+#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:161
 msgid "Start Point Y:"
 msgstr "Startpunkt Y:"
 
-#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:166
+#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:167
 #: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:170
 msgid "Line Segment Properties"
 msgstr "Liniensegmenteigenschaften:"
 
-#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:203
+#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:204
 msgid ""
 "This item was on an unknown layer.\n"
 "It has been moved to the drawings layer. Please fix it."
@@ -19606,35 +19157,35 @@ msgstr ""
 "Es wurde auf der Lage für Symbole und Zeichnungen platziert.\n"
 "Bitte korrigieren Sie dies ggfs."
 
-#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:268
+#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:269
 msgid "Modify drawing properties"
 msgstr "Darstellungs Eigenschaften"
 
-#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:301
+#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:302
 msgid "The arc angle must be greater than zero."
 msgstr "Der Winkel des Bogens muss größer als 0 sein."
 
-#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:310
+#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:311
 #: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:305
 msgid "The radius must be greater than zero."
 msgstr "Der Radius muss größer als 0 sein."
 
-#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:323
+#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:324
 #: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:313
 msgid "The start and end points cannot be the same."
 msgstr "Der Startpunkt und der Endpunkt müssen verschieden sein."
 
-#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:333
+#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:334
 #: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:322
 msgid "The item thickness must be greater than zero."
 msgstr "Die Breite des Elements muss größer als 0 sein."
 
-#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:339
+#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:340
 #: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:328
 msgid "The default thickness must be greater than zero."
 msgstr "Die Standardbreite muss größer als 0 sein."
 
-#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:343
+#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:344
 msgid "Error List"
 msgstr "Fehlerliste"
 
@@ -19669,10 +19220,6 @@ msgstr "Elementstärke:"
 #: pcbnew/dialogs/dialog_graphic_item_properties_base.cpp:111
 msgid "Default thickness:"
 msgstr "Voreinstellung für Stärke:"
-
-#: pcbnew/dialogs/dialog_graphic_item_properties_base.h:78
-msgid "Graphic Item Properties"
-msgstr "Eigenschaften grafischer Elemente"
 
 #: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:150
 #: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:161
@@ -19730,39 +19277,39 @@ msgstr "Der Bogenwinkel darf nicht Null sein."
 msgid "Error list"
 msgstr "Fehlerliste"
 
-#: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:23
+#: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:25
 msgid "Graphics:"
 msgstr "Grafische Elemente:"
 
-#: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:25
+#: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:27
 msgid "Graphic segment width:"
 msgstr "Linienbreite grafischer Elemente:"
 
-#: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:32
+#: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:34
 msgid "Board edge width:"
 msgstr "Linienbreite Platinenumriss:"
 
-#: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:39
+#: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:41
 msgid "Copper text thickness:"
 msgstr "Kupfer-Text Stärke:"
 
-#: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:66
+#: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:68
 msgid "Edge width:"
 msgstr "Linienbreite Umriss"
 
-#: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:73
+#: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:75
 msgid "Text thickness:"
 msgstr "Schrift Stärke:"
 
-#: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:98
+#: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:100
 msgid "General:"
 msgstr "Allgemein:"
 
-#: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:100
+#: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:102
 msgid "Default pen size:"
 msgstr "Voreinstellung für Stiftgröße:"
 
-#: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:102
+#: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:104
 #: pcbnew/dialogs/dialog_plot_base.cpp:169
 #: pcbnew/dialogs/dialog_print_using_printer_base.cpp:102
 msgid ""
@@ -19772,10 +19319,6 @@ msgstr ""
 "Stiftgröße die verwendet wird um Elemente darzustellen, obwohl keine "
 "Stiftgröße spezifiziert wurde.\n"
 "Wird hauptsächlich verwendet um Elemente im Umriss-Modus darzustellen."
-
-#: pcbnew/dialogs/dialog_graphic_items_options_base.h:72
-msgid "Text and Drawings"
-msgstr "Texte und Zeichnungen"
 
 #: pcbnew/dialogs/dialog_keepout_area_properties.cpp:247
 msgid "Tracks, vias, and pads are allowed. The keepout is useless"
@@ -19833,10 +19376,6 @@ msgstr "Keine Leiterbahnen"
 msgid "No vias"
 msgstr "Keine Durchkontaktierungen"
 
-#: pcbnew/dialogs/dialog_keepout_area_properties_base.h:67
-msgid "Keepout Area Properties"
-msgstr "Eigenschaften von Sperrflächen"
-
 #: pcbnew/dialogs/dialog_layer_selection_base.cpp:116
 msgid "Top/Front Layer"
 msgstr "Ober-/Frontseite"
@@ -19844,10 +19383,6 @@ msgstr "Ober-/Frontseite"
 #: pcbnew/dialogs/dialog_layer_selection_base.cpp:154
 msgid "Bottom/Back Layer"
 msgstr "Unter-/Rückseite"
-
-#: pcbnew/dialogs/dialog_layer_selection_base.h:81
-msgid "Select Copper Layer Pair:"
-msgstr "Auswahl eines Kupferlagenpaares:"
 
 #: pcbnew/dialogs/dialog_layers_setup.cpp:339
 msgid "Enabled"
@@ -20461,10 +19996,6 @@ msgstr "Drawings_later"
 msgid "If you want a layer for documentation drawings"
 msgstr "Wenn eine Lage für Dokumentationszeichnungen benötigt wird"
 
-#: pcbnew/dialogs/dialog_layers_setup_base.h:417
-msgid "Layer Setup"
-msgstr "Lagen Einstellungen"
-
 #: pcbnew/dialogs/dialog_mask_clearance_base.cpp:27
 msgid ""
 "Note: For clearance values:\n"
@@ -20529,45 +20060,47 @@ msgstr ""
 "Das endgültige Abstandsmaß ist die Summe aus diesem Wert und dem "
 "Abstandsverhältnis."
 
-#: pcbnew/dialogs/dialog_mask_clearance_base.h:74
-msgid "Pads Mask Clearance"
-msgstr "Pads Abstandsmaske"
+#: pcbnew/dialogs/dialog_modedit_display_options.cpp:45
+#: cvpcb/dialogs/dialog_display_options_base.h:60
+#: pcbnew/dialogs/dialog_display_options_base.h:64
+msgid "Display Options"
+msgstr "Anzeigeoptionen"
 
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:22
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:24
 msgid "On new graphic item creation:"
 msgstr "Beim Erstellen neuer Grafikelemente:"
 
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:34
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:36
 msgid "&Graphic line width"
 msgstr "Linienbreite &grafischer Elemente"
 
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:45
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:47
 msgid "&Text line width"
 msgstr "&Text Linienbreite"
 
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:56
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:58
 msgid "Text &height"
 msgstr "Text&höhe"
 
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:67
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:69
 msgid "Text &width"
 msgstr "Text&breite"
 
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:84
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:86
 msgid "Default values on new footprint creation:"
 msgstr "Standardwerte beim Erstellen neuer Footprints:"
 
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:90
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:92
 msgid ""
 "Leave reference or value blank to use the footprint name as default text"
 msgstr ""
 "Benutze den Footprintnamen als Standard Text bei leerer Referenz oder Wert"
 
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:102
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:104
 msgid "&Reference"
 msgstr "&Referenz"
 
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:107
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:109
 msgid ""
 "Default text for reference\n"
 "Leave blank to use the footprint name"
@@ -20575,21 +20108,21 @@ msgstr ""
 "Referenz Standardtext\n"
 "Leer lassen um den Footprintnamen zu benutzen"
 
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:115
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:144
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:117
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:146
 msgid "SilkScreen"
 msgstr "Bestückungsdruck"
 
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:115
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:144
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:117
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:146
 msgid "Fab. Layer"
 msgstr "Fabrikationslage auswählen"
 
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:131
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:133
 msgid "V&alue"
 msgstr "&Wert"
 
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:136
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:138
 msgid ""
 "Default text for value\n"
 "Leave blank to use the footprint name"
@@ -20597,78 +20130,74 @@ msgstr ""
 "Werte Standardtext\n"
 "Leer lassen um den Footprintnamen zu benutzen"
 
-#: pcbnew/dialogs/dialog_modedit_options_base.h:80
-msgid "Footprint Editor Options"
-msgstr "Footprinteditor Optionen"
-
-#: pcbnew/dialogs/dialog_move_exact.cpp:235
-#: pcbnew/dialogs/dialog_position_relative.cpp:140
+#: pcbnew/dialogs/dialog_move_exact.cpp:236
+#: pcbnew/dialogs/dialog_position_relative.cpp:141
 msgid "Distance:"
 msgstr "Abstand:"
 
-#: pcbnew/dialogs/dialog_move_exact.cpp:242
-#: pcbnew/dialogs/dialog_position_relative.cpp:147
+#: pcbnew/dialogs/dialog_move_exact.cpp:243
+#: pcbnew/dialogs/dialog_position_relative.cpp:148
 msgid "Move vector X:"
 msgstr "Verschiebe Vektor X:"
 
-#: pcbnew/dialogs/dialog_move_exact.cpp:243
-#: pcbnew/dialogs/dialog_position_relative.cpp:148
+#: pcbnew/dialogs/dialog_move_exact.cpp:244
+#: pcbnew/dialogs/dialog_position_relative.cpp:149
 msgid "Move vector Y:"
 msgstr "Verschiebe Vektor Y:"
 
-#: pcbnew/dialogs/dialog_move_exact_base.cpp:18
-#: pcbnew/dialogs/dialog_position_relative_base.cpp:19
+#: pcbnew/dialogs/dialog_move_exact_base.cpp:20
+#: pcbnew/dialogs/dialog_position_relative_base.cpp:21
 msgid "Use polar coordinates"
 msgstr "Polarkoordinaten benutzen"
 
-#: pcbnew/dialogs/dialog_move_exact_base.cpp:30
-#: pcbnew/dialogs/dialog_position_relative_base.cpp:28
+#: pcbnew/dialogs/dialog_move_exact_base.cpp:32
+#: pcbnew/dialogs/dialog_position_relative_base.cpp:30
 msgid "x:"
 msgstr "x:"
 
-#: pcbnew/dialogs/dialog_move_exact_base.cpp:44
-#: pcbnew/dialogs/dialog_position_relative_base.cpp:42
+#: pcbnew/dialogs/dialog_move_exact_base.cpp:46
+#: pcbnew/dialogs/dialog_position_relative_base.cpp:44
 msgid "y:"
 msgstr "y:"
 
-#: pcbnew/dialogs/dialog_move_exact_base.cpp:58
-#: pcbnew/dialogs/dialog_position_relative_base.cpp:56
+#: pcbnew/dialogs/dialog_move_exact_base.cpp:60
+#: pcbnew/dialogs/dialog_position_relative_base.cpp:58
 msgid "Item rotation:"
 msgstr "Element Rotation:"
 
-#: pcbnew/dialogs/dialog_move_exact_base.cpp:75
+#: pcbnew/dialogs/dialog_move_exact_base.cpp:77
 msgid "Current Position"
 msgstr "Aktuelle Position"
 
-#: pcbnew/dialogs/dialog_move_exact_base.cpp:75
+#: pcbnew/dialogs/dialog_move_exact_base.cpp:77
 msgid "User Origin"
 msgstr "Ursprungspunkt (benutzerdefiniert)"
 
-#: pcbnew/dialogs/dialog_move_exact_base.cpp:75
+#: pcbnew/dialogs/dialog_move_exact_base.cpp:77
 msgid "Grid Origin"
 msgstr "Ursprungspunkt Raster"
 
-#: pcbnew/dialogs/dialog_move_exact_base.cpp:75
+#: pcbnew/dialogs/dialog_move_exact_base.cpp:77
 msgid "Drill/Place Origin"
 msgstr "Ursprung Bohrloch/Platzierung"
 
-#: pcbnew/dialogs/dialog_move_exact_base.cpp:75
+#: pcbnew/dialogs/dialog_move_exact_base.cpp:77
 msgid "Sheet Origin"
 msgstr "Ursprung Blatt"
 
-#: pcbnew/dialogs/dialog_move_exact_base.cpp:77
+#: pcbnew/dialogs/dialog_move_exact_base.cpp:79
 msgid "Move relative to:"
 msgstr "Bewege relativ zu:"
 
-#: pcbnew/dialogs/dialog_move_exact_base.cpp:86
+#: pcbnew/dialogs/dialog_move_exact_base.cpp:88
 msgid "Override default component anchor with:"
 msgstr "Überschreibe den Standardankerpunkt des Bauteils mit:"
 
-#: pcbnew/dialogs/dialog_move_exact_base.cpp:89
+#: pcbnew/dialogs/dialog_move_exact_base.cpp:91
 msgid "Top left pad"
 msgstr "Linkes oberes Pad"
 
-#: pcbnew/dialogs/dialog_move_exact_base.cpp:89
+#: pcbnew/dialogs/dialog_move_exact_base.cpp:91
 msgid "Footprint center"
 msgstr "Footprint Mittelpunkt"
 
@@ -20749,8 +20278,8 @@ msgid "Check footprints"
 msgstr "Footprints prüfen"
 
 #: pcbnew/dialogs/dialog_netlist.cpp:361
-msgid "Save contents of message window"
-msgstr "Vorliegende Meldungen speichern"
+msgid "Save Contents of Message Window"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_netlist.cpp:378
 #, c-format
@@ -20926,6 +20455,11 @@ msgstr ""
 msgid "Error : you must choose a layer"
 msgstr "Fehler : Sie müssen eine Lage wählen"
 
+#: pcbnew/dialogs/dialog_non_copper_zones_properties_base.cpp:30
+#: gerbview/dialogs/dialog_layers_select_to_pcb_base.h:83
+msgid "Layer selection:"
+msgstr "Lagenauswahl:"
+
 #: pcbnew/dialogs/dialog_non_copper_zones_properties_base.cpp:44
 msgid "Outlines Options"
 msgstr "Umriss Optionen:"
@@ -20950,13 +20484,9 @@ msgstr "Darstellung der Umrisse"
 msgid "Zone min thickness value:"
 msgstr "Flächenmindeststärke"
 
-#: pcbnew/dialogs/dialog_non_copper_zones_properties_base.h:67
-msgid "Non Copper Zones Properties"
-msgstr "Eigenschaften für Zonen ohne Kupfer"
-
 #: pcbnew/dialogs/dialog_pad_basicshapes_properties.cpp:101
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:837
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:939
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:839
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:941
 msgid "degree"
 msgstr "Grad"
 
@@ -21057,25 +20587,30 @@ msgstr ""
 msgid "Pad local clearance must be zero or greater than zero"
 msgstr "Lokaler Padabstand muss gleich oder größer als Null sein."
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1032
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1038
 msgid "Pad local solder mask clearance must be zero or greater than zero"
 msgstr "Lokale Pad Lötstoppmaske muss gleich oder größer als Null sein."
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1037
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1046
+#, c-format
+msgid "Pad local solder mask clearance must be greater than %s"
+msgstr ""
+
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1054
 msgid "Pad local solder paste clearance must be zero or less than zero"
 msgstr "Lokale Pad-Lötpaste muss gleich oder größer als Null sein."
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1043
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1060
 msgid "Error: pad has no layer"
 msgstr "Fehler: Sie müssen für das Pad eine Lage wählen"
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1050
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1067
 msgid "Error: the pad is not on a copper layer and has a hole"
 msgstr ""
 "Fehler: Das Pad befindet sich nicht auf einer Kupferlage und besitzt ein "
 "Bohrung"
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1055
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1072
 msgid ""
 "For NPTH pad, set pad size value to pad drill value, if you do not want this "
 "pad plotted in gerber files"
@@ -21083,19 +20618,19 @@ msgstr ""
 "Setze für ein NPTH-Pad die Padgröße auf den Padbohrdurchmesser,\n"
 "wenn dieses Pad nicht in Gerberdateien geplottet werden soll."
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1075
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1092
 msgid "Incorrect value for pad offset"
 msgstr "Inkorrekter Wert für Padoffset"
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1081
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1098
 msgid "Too large value for pad delta size"
 msgstr "Zu großer Wert für das Pad-Delta"
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1089
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1106
 msgid "Error: Through hole pad: drill diameter set to 0"
 msgstr "Fehler: Durchgangsbohrung Pad: Bohrdurchmesser gleich 0"
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1094
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1111
 msgid ""
 "Error: Connector pads are not on the solder paste layer\n"
 "Use SMD pads instead"
@@ -21103,163 +20638,163 @@ msgstr ""
 "Fehler: Anschlusspads befinden sich nicht auf der Lage der Lötstopppaste\n"
 "Verwende stattdessen SMD-Pads"
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1103
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1120
 msgid "Error: only one external copper layer allowed for SMD or Connector pads"
 msgstr "Fehler: Für SMD oder Anschlusspads ist nur eine Kupferlage zulässig"
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1115
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1132
 msgid "Incorrect corner size value"
 msgstr "Inkorrekte Größe für Eckwert"
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1119
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1136
 msgid "Incorrect (negative) corner size value"
 msgstr "Inkorrekte (negative) Größe für Eckwert"
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1121
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1138
 msgid "Corner size value must be smaller than 50%"
 msgstr "Größe Eckwert muss kleiner 50% sein."
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1129
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1146
 msgid "Incorrect pad shape: the shape must be equivalent to only one polygon"
 msgstr ""
 "Ungültige Padform: Die Form darf nur äquivalent zu einem der Polygone sein"
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1135
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1152
 msgid "Pad setup errors list"
 msgstr "Fehlerliste der Padeinstellungen"
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1372
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1389
 msgid "Unknown netname, netname not changed"
 msgstr "Unbekannter Netzname. Keine Änderung durchgeführt."
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1409
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1426
 msgid "Modify pad"
 msgstr "Pad modifizieren"
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1741
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1884
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1925
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1758
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1901
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1942
 msgid "No shape selected"
 msgstr "Keine Form gewählt"
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1832
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1849
 msgid "ring/circle"
 msgstr "Ring/Kreis"
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1832
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1849
 msgid "polygon"
 msgstr "Polygon"
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1835
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1852
 msgid "Select shape type:"
 msgstr "Wähle Formtyp:"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:38
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:40
 msgid "Pad number:"
 msgstr "Padnummer:"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:45
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:47
 msgid "Net name:"
 msgstr "Netzname:"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:52
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:54
 msgid "Pad type:"
 msgstr "Padtyp:"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:56
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:58
 msgid "Through-hole"
 msgstr "Durchgehende Bohrung"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:56
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:58
 msgid "Connector"
 msgstr "Anschluss"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:56
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:58
 msgid "NPTH, Mechanical"
 msgstr "NPTH, mechanisch"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:62
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:273
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:64
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:275
 #: pcbnew/dialogs/dialog_target_properties_base.cpp:50
 msgid "Shape:"
 msgstr "Form:"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:66
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:68
 msgid "Circular"
 msgstr "Kreis"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:66
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:68
 msgid "Rectangular"
 msgstr "Rechteck"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:66
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:68
 msgid "Trapezoidal"
 msgstr "Trapez"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:66
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:68
 msgid "Rounded Rectangle"
 msgstr "gerundetes Rechteck"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:66
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:68
 msgid "Custom Shape (Circular Anchor)"
 msgstr "Individuelle Form (runder Anker)"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:66
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:68
 msgid "Custom Shape (Rectangular Anchor)"
 msgstr "Individuelle Form (eckiger Anker)"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:103
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:287
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:105
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:289
 #: pcbnew/dialogs/dialog_set_grid_base.cpp:37
 msgid "Size X:"
 msgstr "Größe X:"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:114
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:298
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:116
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:300
 #: pcbnew/dialogs/dialog_set_grid_base.cpp:44
 msgid "Size Y:"
 msgstr "Größe Y:"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:129
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:131
 msgid "90"
 msgstr "90"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:129
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:131
 msgid "180"
 msgstr "180"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:149
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:151
 msgid "Shape offset X:"
 msgstr "Formoffset X:"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:160
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:162
 msgid "Shape offset Y:"
 msgstr "Formoffset Y:"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:171
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:173
 msgid "Pad to die length:"
 msgstr "Pad-zu-Die-Länge:"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:173
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:175
 msgid ""
 "Wire length from pad to die on chip ( used to calculate actual track length)"
 msgstr ""
 "Drahtlänge vom Pad zum Die des Chips (wird verwendet um die gegenwärtige "
 "Länge der Leiterbahn zu berechnen)"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:193
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:195
 msgid "Trapezoid delta:"
 msgstr "Trapezoid Delta:"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:204
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:206
 msgid "Trapezoid direction:"
 msgstr "Trapez Ausrichtung:"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:226
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:228
 msgid "Corner size:"
 msgstr "Eckwert:"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:228
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:230
 msgid ""
 "Corner radius in percent  of the pad width.\n"
 "The width is the smaller value between size X and size Y.\n"
@@ -21269,11 +20804,11 @@ msgstr ""
 "Die Weite ist der kleinere Wert zwischen der Größe X und Größe Y.\n"
 "Der Maximalwert beträgt 50%."
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:239
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:241
 msgid "Corner radius:"
 msgstr "Eckenradius"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:241
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:243
 msgid ""
 "Corner radius.\n"
 "Can be no more than half pad width.\n"
@@ -21285,7 +20820,7 @@ msgstr ""
 "Die Breite ist der kleinere Wert zwischen Größe X und Größe Y.\n"
 "Hinweis: Die IPC Norm setzt einen Maximalwert von 0,25mm."
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:247
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:249
 msgid ""
 "Corner radius.\n"
 "Can be no more than half pad width.\n"
@@ -21297,95 +20832,95 @@ msgstr ""
 "Die Breite ist der kleinere Wert zwischen Größe X und Größe Y.\n"
 "Hinweis: Die IPC Norm setzt einen Maximalwert von 0,25mm."
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:277
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:279
 msgid "Circular hole"
 msgstr "Kreisförmiges Loch"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:277
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:279
 msgid "Oval hole"
 msgstr "Ovalförmiges Loch"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:321
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:323
 msgid "Copper:"
 msgstr "Kupferlage:"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:325
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:327
 msgid "Front layer"
 msgstr "Ober-/Frontseite"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:325
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:327
 msgid "Back layer"
 msgstr "Rückseitige Kupferlage"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:325
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:327
 msgid "All copper layers"
 msgstr "Alle Kupferlagen"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:335
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:337
 msgid "Technical Layers"
 msgstr "Technische Lagen"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:337
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:339
 msgid "Front adhesive"
 msgstr "Vorderseitiger Kleber"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:340
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:342
 msgid "Back adhesive"
 msgstr "Rückseitiger Kleber"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:343
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:345
 msgid "Front solder paste"
 msgstr "Vorderseitige Lötpaste"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:346
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:348
 msgid "Back solder paste"
 msgstr "Rückseitige Lötpaste"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:352
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:354
 msgid "Back silk screen"
 msgstr "Rückseitiger Siebdruck"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:358
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:360
 msgid "Back solder mask"
 msgstr "Rückseitige Lötstoppmaske"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:361
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:363
 msgid "Drafting notes"
 msgstr "Entwurfsnotizen"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:364
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:366
 msgid "E.C.O.1"
 msgstr "E.C.O.1"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:367
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:369
 msgid "E.C.O.2"
 msgstr "E.C.O.2"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:377
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:379
 msgid "Parent footprint orientation"
 msgstr "Ausrichtung des Footprint-Elternelements"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:385
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:387
 msgid "Rotation:"
 msgstr "Drehung:"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:393
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:395
 msgid "Board side:"
 msgstr "Platinenseite:"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:397
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:399
 msgid "Front side"
 msgstr "Vorderansicht"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:423
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:425
 msgid "Clearances"
 msgstr "Abstandsmaße"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:431
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:433
 msgid "Net pad clearance:"
 msgstr "Netz-Pad Abstand:"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:433
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:435
 msgid ""
 "This is the local net clearance for  pad.\n"
 "If 0, the footprint local value or the Netclass value is used"
@@ -21394,7 +20929,7 @@ msgstr ""
 "Wenn auf 0 gesetzt wird der lokale Wert des Footprints oder der Netzklasse "
 "verwendet."
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:446
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:448
 msgid ""
 "This is the local clearance between this  pad and the solder mask\n"
 "If 0, the footprint local value or the global value is used"
@@ -21403,7 +20938,7 @@ msgstr ""
 "Wenn auf 0 gesetzt wird der lokale Wert des Footprints oder der globale Wert "
 "verwendet."
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:459
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:461
 msgid ""
 "This is the local clearance between this pad and the solder paste.\n"
 "If 0 the footprint value or the global value is used..\n"
@@ -21419,7 +20954,7 @@ msgstr ""
 "Ein negativer Wert bedeutet, dass die Maskengröße kleiner als die Padgröße "
 "ist."
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:472
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:474
 msgid ""
 "This is the local clearance ratio in per cent between this pad and the "
 "solder paste.\n"
@@ -21439,86 +20974,86 @@ msgstr ""
 "Ein negativer Wert bedeutet, dass die Maskengröße kleiner als die Padgröße "
 "ist."
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:489
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:491
 msgid "Copper Zones"
 msgstr "Kupferflächen"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:497
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:499
 msgid "Pad connection:"
 msgstr "Padverbindung:"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:501
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:503
 msgid "From parent footprint"
 msgstr "Vom Ursprungs-Footprint"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:510
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:512
 msgid "Thermal relief width:"
 msgstr "Breite der thermischen Abführung:"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:521
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:523
 msgid "Thermal relief gap:"
 msgstr "Abstand zur thermischen Abführung:"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:532
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:534
 msgid "Custom pad shape in zone:"
 msgstr "Benutzerdefinierte Padform in Zone:"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:536
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:538
 msgid "Use pad shape"
 msgstr "Benutze Padform"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:536
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:538
 msgid "Use pad convex hull"
 msgstr "Benutze konvexe Padformhülle"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:551
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:553
 msgid "Set fields to 0 to use parent or global values"
 msgstr ""
 "Felder mit einem Wert von 0 benutzen übergeordnete oder global definierte "
 "Werte."
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:564
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:566
 msgid "Local Clearance and Settings"
 msgstr "Lokale Abstände und Einstellungen"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:568
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:570
 msgid "Primitives list"
 msgstr "Primitives Liste"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:574
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1014
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:576
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1016
 msgid "Coordinates are relative to anchor pad, orientation 0"
 msgstr " Koordinaten sind relativ zum Ankerpad, Ausrichtung 0"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:589
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:591
 msgid "Delete Primitive"
 msgstr "Primitive entfernen"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:592
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:594
 msgid "Edit Primitive"
 msgstr "Primitive editieren"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:595
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:597
 msgid "Add Primitive"
 msgstr "Primitive hinzufügen"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:598
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:600
 msgid "Duplicate Primitive"
 msgstr "Primitive duplizieren"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:607
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:609
 msgid "Geometry Transform"
 msgstr "Geometrische Transformation"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:610
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:612
 msgid "Import Primitives"
 msgstr "Primitives importieren"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:623
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:625
 msgid "Custom Shape Primitives"
 msgstr "Individuelle Primitives Formen"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:645
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:647
 msgid ""
 "Warning:\n"
 "This pad is flipped on board.\n"
@@ -21528,7 +21063,7 @@ msgstr ""
 "Dieses Pad ist auf der Platine verkehrt herum.\n"
 "Rück- und Vorderseite werden vertauscht sein."
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:764
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:766
 msgid ""
 "Filled circle: set thickness to 0\n"
 "Ring:  set thickness to the width of the ring"
@@ -21536,76 +21071,64 @@ msgstr ""
 "Gefüllter Kreis: Setze Stärke auf 0\n"
 "Ring: Setze Stärke auf die Breite des Rings"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:777
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:779
 msgid "Start point"
 msgstr "Startpunkt"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:799
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:801
 msgid "End point"
 msgstr "Endpunkt"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:901
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:903
 msgid "Move vector"
 msgstr "Verschiebe Vektor"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:943
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:945
 msgid "Scaling factor"
 msgstr "Skalierungsfaktor"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:950
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:952
 msgid "1.0"
 msgstr "1.0"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:962
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:964
 msgid "Duplicate count"
 msgstr "Anzahl duplizieren"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1020
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1022
 msgid "Incorrect polygon"
 msgstr "Ungültiges Polygon"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1094
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1096
 msgid "Outline thickness"
 msgstr "Strichstärke Kontur"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1108
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1110
 msgid "(Thickness outline is usually set to 0)"
 msgstr "(Konturstärke ist üblicher Weise auf 0 gesetzt)"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.h:206
-msgid "Pad Properties"
-msgstr "Pad Eigenschaften"
-
-#: pcbnew/dialogs/dialog_pad_properties_base.h:278
-msgid "Pad Custom Shape Geometry Transform"
-msgstr "Individuelle Geometrische Padform Transformierung"
-
-#: pcbnew/dialogs/dialog_pad_properties_base.h:317
-msgid "Basic Shape Polygon"
-msgstr "Basisform Polygon"
-
-#: pcbnew/dialogs/dialog_pcb_text_properties.cpp:202
+#: pcbnew/dialogs/dialog_pcb_text_properties.cpp:203
 msgid "No layer selected, Please select the text layer"
 msgstr "Keine Lage ausgewählt. Bitte wählen Sie die Textlage."
 
-#: pcbnew/dialogs/dialog_pcb_text_properties.cpp:311
+#: pcbnew/dialogs/dialog_pcb_text_properties.cpp:312
 msgid "Change text properties"
 msgstr "Objekt Eigenschaften"
 
-#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:29
+#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:30
 msgid "Enter the text placed on selected layer."
 msgstr "Zu platzierenden Text für gewählte Lage eingeben."
 
-#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:71
+#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:72
 #: pcbnew/microwave.cpp:464
 msgid "Mirrored"
 msgstr "gespiegelt"
 
-#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:89
+#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:90
 msgid "Justification:"
 msgstr "Ausrichtung:"
 
-#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:115
+#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:116
 msgid "Orientation (deg):"
 msgstr "Ausrichtung (Grad):"
 
@@ -21639,16 +21162,10 @@ msgstr ""
 msgid "No layer selected, Nothing to plot"
 msgstr "Keine Lage gewählt, keine Daten zum Plotten."
 
-#: pcbnew/dialogs/dialog_plot.cpp:767
-#: pcbnew/exporters/gen_modules_placefile.cpp:257
-#, c-format
-msgid "Could not write plot files to folder \"%s\"."
-msgstr "Konnte die Plotdateien nicht in dem Verzeichnis \"%s\" anlegen."
-
 #: pcbnew/dialogs/dialog_plot.cpp:871
 #, c-format
-msgid "Plot file '%s' created."
-msgstr "Plotdatei '%s' erstellt."
+msgid "Plot file \"%s\" created."
+msgstr ""
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:26
 msgid "Plot format:"
@@ -21988,102 +21505,93 @@ msgstr "Alle Lagen auswählen"
 msgid "Deselect all Layers"
 msgstr "Alle Lagen abwählen"
 
-#: pcbnew/dialogs/dialog_pns_diff_pair_dimensions_base.cpp:36
+#: pcbnew/dialogs/dialog_pns_diff_pair_dimensions_base.cpp:38
 msgid "Trace gap:"
 msgstr "Abstand Zwischenraum:"
 
-#: pcbnew/dialogs/dialog_pns_diff_pair_dimensions_base.cpp:49
+#: pcbnew/dialogs/dialog_pns_diff_pair_dimensions_base.cpp:51
 msgid "Via gap:"
 msgstr "Abstand Durchkontaktierung:"
 
-#: pcbnew/dialogs/dialog_pns_diff_pair_dimensions_base.cpp:70
+#: pcbnew/dialogs/dialog_pns_diff_pair_dimensions_base.cpp:72
 msgid "Via gap same as trace gap"
 msgstr "Abstand DoKu gleich wie Abstand Zwischenraum"
 
-#: pcbnew/dialogs/dialog_pns_diff_pair_dimensions_base.h:64
-#: pcbnew/hotkeys.cpp:248
-msgid "Differential Pair Dimensions"
-msgstr "Abmessungen differenzielles Signalpaar"
-
-#: pcbnew/dialogs/dialog_pns_length_tuning_settings.cpp:56
+#: pcbnew/dialogs/dialog_pns_length_tuning_settings.cpp:57
 msgid "Single Track Length Tuning"
 msgstr "Anpassen einzelner Leiterbahnlängen"
 
-#: pcbnew/dialogs/dialog_pns_length_tuning_settings.cpp:62
+#: pcbnew/dialogs/dialog_pns_length_tuning_settings.cpp:63
 msgid "Differential Pair Length Tuning"
 msgstr "Anpassen der Länge von Differenziellem Paar"
 
-#: pcbnew/dialogs/dialog_pns_length_tuning_settings.cpp:68
+#: pcbnew/dialogs/dialog_pns_length_tuning_settings.cpp:69
 msgid "Differential Pair Skew Tuning"
 msgstr "Anpassen der Abstimmung eines differenziellem Signalpaares"
 
-#: pcbnew/dialogs/dialog_pns_length_tuning_settings.cpp:70
+#: pcbnew/dialogs/dialog_pns_length_tuning_settings.cpp:71
 msgid "Target skew: "
 msgstr "Ziel Versatz:"
 
-#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:20
+#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:22
 msgid "Length/skew"
 msgstr "Länge/Versatz"
 
-#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:28
+#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:30
 msgid "Tune from:"
 msgstr "Anpassen von:"
 
-#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:40
+#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:42
 msgid "Tune to:"
 msgstr "Anpassen nach:"
 
-#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:52
+#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:54
 msgid "Constraint:"
 msgstr "Beschränkung:"
 
-#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:56
+#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:58
 msgid "From Design Rules"
 msgstr "aus Design Regeln"
 
-#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:56
+#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:58
 msgid "Manual"
 msgstr "Handbuch"
 
-#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:67
+#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:69
 msgid "Target length:"
 msgstr "Ziellänge:"
 
-#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:85
+#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:87
 msgid "Meandering"
 msgstr "Mäandrierung"
 
-#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:96
+#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:98
 msgid "Min amplitude (Amin):"
 msgstr "Minimale Amplitude (Amin):"
 
-#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:107
+#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:109
 msgid "Max amplitude (Amax):"
 msgstr "Maximale Amplitude (Amax):"
 
-#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:118
+#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:120
 msgid "Spacing (s):"
 msgstr "Zwischenraum (s):"
 
-#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:129
+#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:131
 msgid "Miter radius (r):"
 msgstr "Auskehlungsradius (r):"
 
-#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:140
+#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:142
 msgid "Miter style:"
 msgstr "Auskehlungsdarstellung:"
 
-#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:146
+#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:148
 msgid "45 degree"
 msgstr "45 Grad"
 
-#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:146
+#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:148
 msgid "arc"
 msgstr "Kreisbogen"
-
-#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.h:79
-msgid "Trace length tuning"
-msgstr "Anpassen Leiterbahnlänge"
 
 #: pcbnew/dialogs/dialog_pns_settings.cpp:37
 msgid "DRC violation: highlight obstacles"
@@ -22241,23 +21749,13 @@ msgstr "Low"
 msgid "high"
 msgstr "High"
 
-#: pcbnew/dialogs/dialog_pns_settings_base.h:71
-#: pcbnew/router/router_tool.cpp:92
-msgid "Interactive Router Settings"
-msgstr "Einstellungen des interaktiven Routers"
-
-#: pcbnew/dialogs/dialog_position_relative_base.cpp:70
+#: pcbnew/dialogs/dialog_position_relative_base.cpp:72
 msgid "Anchor X:"
 msgstr "Anker X:"
 
-#: pcbnew/dialogs/dialog_position_relative_base.cpp:90
+#: pcbnew/dialogs/dialog_position_relative_base.cpp:92
 msgid "Select Anchor Item"
 msgstr "Ankerelement auswählen"
-
-#: pcbnew/dialogs/dialog_position_relative_base.h:75
-#: pcbnew/tools/position_relative_tool.cpp:152
-msgid "Position Relative"
-msgstr "Relative Position"
 
 #: pcbnew/dialogs/dialog_print_for_modedit.cpp:97
 msgid "An error occurred initializing the printer information."
@@ -22393,10 +21891,6 @@ msgstr "Wähle einen Ordner"
 msgid "Library folder (.pretty will be added to name, if missing)"
 msgstr "Bibliotheksordner (.pretty wird automatisch hinzugefügt falls nötig)"
 
-#: pcbnew/dialogs/dialog_select_pretty_lib_base.h:59
-msgid "Select Footprint Library Folder"
-msgstr "Auswahl Footprint-Bibliotheksordner"
-
 #: pcbnew/dialogs/dialog_set_grid.cpp:108
 #, c-format
 msgid "Incorrect grid size (size must be >= %.3f mm and <= %.3f mm)"
@@ -22430,35 +21924,27 @@ msgstr "Raster 1:"
 msgid "Grid 2:"
 msgstr "Raster 2:"
 
-#: pcbnew/dialogs/dialog_set_grid_base.h:71
-msgid "Grid Properties"
-msgstr "Raster Eigenschaften"
-
 #: pcbnew/dialogs/dialog_target_properties_base.cpp:54
 msgid "+"
 msgstr "+"
 
-#: pcbnew/dialogs/dialog_target_properties_base.h:61
-msgid "Target Properties"
-msgstr "Objekt Eigenschaften"
-
-#: pcbnew/dialogs/dialog_track_via_properties.cpp:487
-#: pcbnew/dialogs/dialog_track_via_size.cpp:60
+#: pcbnew/dialogs/dialog_track_via_properties.cpp:488
+#: pcbnew/dialogs/dialog_track_via_size.cpp:61
 msgid "Invalid track width"
 msgstr "Ungültige Leiterbahnbreite"
 
-#: pcbnew/dialogs/dialog_track_via_properties.cpp:496
-#: pcbnew/dialogs/dialog_track_via_size.cpp:67
+#: pcbnew/dialogs/dialog_track_via_properties.cpp:497
+#: pcbnew/dialogs/dialog_track_via_size.cpp:68
 msgid "Invalid via diameter"
 msgstr "Ungültiger DuKo Durchmesser"
 
-#: pcbnew/dialogs/dialog_track_via_properties.cpp:503
-#: pcbnew/dialogs/dialog_track_via_size.cpp:74
+#: pcbnew/dialogs/dialog_track_via_properties.cpp:504
+#: pcbnew/dialogs/dialog_track_via_size.cpp:75
 msgid "Invalid via drill size"
 msgstr "Ungültiger DoKu Bohrdurchmesser"
 
-#: pcbnew/dialogs/dialog_track_via_properties.cpp:510
-#: pcbnew/dialogs/dialog_track_via_size.cpp:81
+#: pcbnew/dialogs/dialog_track_via_properties.cpp:511
+#: pcbnew/dialogs/dialog_track_via_size.cpp:82
 msgid "Via drill size has to be smaller than via diameter"
 msgstr "DoKu Bohrdurchmesser muss kleiner dem DoKu Durchmesser sein"
 
@@ -22510,25 +21996,17 @@ msgstr "Endlage:"
 msgid "Use net class size"
 msgstr "Verwende Größe der Netzklasse"
 
-#: pcbnew/dialogs/dialog_track_via_properties_base.h:112
-msgid "Track & Via Properties"
-msgstr "Eigenschaften Leiterbahn und DoKu's"
-
-#: pcbnew/dialogs/dialog_track_via_size_base.cpp:25
+#: pcbnew/dialogs/dialog_track_via_size_base.cpp:27
 msgid "Track width:"
 msgstr "Leiterbahnbreite:"
 
-#: pcbnew/dialogs/dialog_track_via_size_base.cpp:36
+#: pcbnew/dialogs/dialog_track_via_size_base.cpp:38
 msgid "Via diameter:"
 msgstr "DuKo-Durchmesser:"
 
-#: pcbnew/dialogs/dialog_track_via_size_base.cpp:47
+#: pcbnew/dialogs/dialog_track_via_size_base.cpp:49
 msgid "Via drill:"
 msgstr "DuKo-Bohrdurchmesser:"
-
-#: pcbnew/dialogs/dialog_track_via_size_base.h:62
-msgid "Track width and via size"
-msgstr "Leiterbahnbreite und Durchkontaktierungsgröße"
 
 #: pcbnew/dialogs/dialog_update_pcb.cpp:49
 msgid "Changes to be applied:"
@@ -22559,24 +22037,24 @@ msgstr "Selektiere Bauteile durch:"
 msgid "Update PCB"
 msgstr "PCB aktualisieren"
 
-#: pcbnew/dialogs/wizard_3DShape_Libs_downloader.cpp:211
+#: pcbnew/dialogs/wizard_3DShape_Libs_downloader.cpp:212
 msgid "Update"
 msgstr "Aktualisieren"
 
-#: pcbnew/dialogs/wizard_3DShape_Libs_downloader.cpp:298
+#: pcbnew/dialogs/wizard_3DShape_Libs_downloader.cpp:299
 #: pcbnew/dialogs/wizard_add_fplib.cpp:559
 msgid "Choose a folder to save the downloaded libraries"
 msgstr "Auswahl des Ordners für heruntergeladene Bibliotheken"
 
-#: pcbnew/dialogs/wizard_3DShape_Libs_downloader.cpp:320
+#: pcbnew/dialogs/wizard_3DShape_Libs_downloader.cpp:321
 msgid "KISYS3DMOD path not defined , or not existing"
 msgstr "KISYS3DMOD Pfad ist nicht definiert oder existiert nicht"
 
-#: pcbnew/dialogs/wizard_3DShape_Libs_downloader.cpp:358
+#: pcbnew/dialogs/wizard_3DShape_Libs_downloader.cpp:359
 msgid "Downloading 3D libraries"
 msgstr "3D-Bibliotheken herunterladen"
 
-#: pcbnew/dialogs/wizard_3DShape_Libs_downloader.cpp:475
+#: pcbnew/dialogs/wizard_3DShape_Libs_downloader.cpp:476
 msgid "Aborted by user"
 msgstr "Abbruch durch Benutzer"
 
@@ -22640,10 +22118,6 @@ msgstr "Bibliotheken mit 3D-Formen zum herunterladen:"
 msgid "Libraries"
 msgstr "Bibliotheken"
 
-#: pcbnew/dialogs/wizard_3DShape_Libs_downloader_base.h:82
-msgid "Add 3D Shape Libraries Wizard"
-msgstr "Wizard für 3D-Formen hinzufügen"
-
 #: pcbnew/dialogs/wizard_add_fplib.cpp:78
 msgid "All supported library formats|"
 msgstr "Alle unterstützten Bibliotheksformate|"
@@ -22661,14 +22135,10 @@ msgstr "Bibliotheken herunterladen"
 #, c-format
 msgid ""
 "Error:\n"
-"'%s'\n"
+"\"%s\"\n"
 "while downloading library:\n"
-"'%s'"
+"\"%s\""
 msgstr ""
-"Fehler:\n"
-"'%s'\n"
-"ist aufgetreten beim Herunterladen der Bibliothek:\n"
-"'%s'."
 
 #: pcbnew/dialogs/wizard_add_fplib.cpp:815
 msgid "Please wait..."
@@ -22737,11 +22207,7 @@ msgstr "Zur globalen Bibliothekskonfiguration (sichtbar für alle Projekte)"
 msgid "To the current project only"
 msgstr "Nur zum gegenwärtigen Projekt"
 
-#: pcbnew/dialogs/wizard_add_fplib_base.h:88
-msgid "Add Footprint Libraries Wizard"
-msgstr "Footprint-Bibliothekswizard hinzufügen"
-
-#: pcbnew/dimension.cpp:149
+#: pcbnew/dimension.cpp:150
 msgid ""
 "This item has an illegal layer id.\n"
 "Now, forced on the drawings layer. Please, fix it"
@@ -22750,7 +22216,7 @@ msgstr ""
 "auf der Lage für Symbole und Zeichnungen platziert.\n"
 "Bitte korrigieren Sie dies ggfs."
 
-#: pcbnew/dimension.cpp:169
+#: pcbnew/dimension.cpp:170
 msgid ""
 "The layer currently selected is not enabled for this board\n"
 "You cannot use it"
@@ -22758,131 +22224,118 @@ msgstr ""
 "Die aktuell gewählte Lage ist nicht aktiviert für diese Platine,\n"
 "Sie können diese nicht benutzen."
 
-#: pcbnew/dimension.cpp:213
+#: pcbnew/dimension.cpp:214
 msgid "The text thickness is too large for the text size.  It will be clamped"
 msgstr "Die Textstärke ist für diesen Text zu groß. Text wird eingeklemmt."
 
-#: pcbnew/dimension.cpp:232
+#: pcbnew/dimension.cpp:233
 msgid "Modifed dimensions properties"
 msgstr "Geänderte Eigenschaften der Abmessungen"
 
-#: pcbnew/drc.cpp:209
+#: pcbnew/drc.cpp:374
 msgid "Aborting\n"
 msgstr "Abbruch\n"
 
-#: pcbnew/drc.cpp:222
+#: pcbnew/drc.cpp:387
 msgid "Pad clearances...\n"
 msgstr "Prüfe Padabstandsflächen ...\n"
 
-#: pcbnew/drc.cpp:232
+#: pcbnew/drc.cpp:397
 msgid "Track clearances...\n"
 msgstr "Prüfe Leiterbahnabstandsflächen ...\n"
 
-#: pcbnew/drc.cpp:242
+#: pcbnew/drc.cpp:407
 msgid "Fill zones...\n"
 msgstr "Prüfe Füllflächen ...\n"
 
-#: pcbnew/drc.cpp:252
+#: pcbnew/drc.cpp:417
 msgid "Test zones...\n"
 msgstr "Prüfe Flächen ...\n"
 
-#: pcbnew/drc.cpp:263
+#: pcbnew/drc.cpp:428
 msgid "Unconnected pads...\n"
 msgstr "Prüfe nicht angeschlossene Pads ...\n"
 
-#: pcbnew/drc.cpp:275
+#: pcbnew/drc.cpp:440
 msgid "Keepout areas ...\n"
 msgstr "Prüfe Sperrflächen ...\n"
 
-#: pcbnew/drc.cpp:285
+#: pcbnew/drc.cpp:450
 msgid "Test texts...\n"
 msgstr "Prüfe Texte ...\n"
 
-#: pcbnew/drc.cpp:296
+#: pcbnew/drc.cpp:461
 msgid "Courtyard areas...\n"
 msgstr "Umrissflächen ...\n"
 
-#: pcbnew/drc.cpp:350
+#: pcbnew/drc.cpp:515
 #, c-format
-msgid "NETCLASS: '%s' has Clearance:%s which is less than global:%s"
+msgid "NETCLASS: \"%s\" has Clearance:%s which is less than global:%s"
 msgstr ""
-"NETZKLASSE: '%s' hat Abstandsmaß: %s, welches kleiner ist als das Globale: %s"
 
-#: pcbnew/drc.cpp:364
+#: pcbnew/drc.cpp:529
 #, c-format
-msgid "NETCLASS: '%s' has TrackWidth:%s which is less than global:%s"
+msgid "NETCLASS: \"%s\" has TrackWidth:%s which is less than global:%s"
 msgstr ""
-"NETZKLASSE: '%s' hat Leiterbahnbreite: %s, welche kleiner ist als die "
-"Globale: %s"
 
-#: pcbnew/drc.cpp:377
+#: pcbnew/drc.cpp:542
 #, c-format
-msgid "NETCLASS: '%s' has Via Dia:%s which is less than global:%s"
+msgid "NETCLASS: \"%s\" has Via Dia:%s which is less than global:%s"
 msgstr ""
-"NETZKLASSE: '%s' hat DuKo Durchmesser: %s, welcher kleiner ist als der "
-"Globale: %s"
 
-#: pcbnew/drc.cpp:390
+#: pcbnew/drc.cpp:555
 #, c-format
-msgid "NETCLASS: '%s' has Via Drill:%s which is less than global:%s"
+msgid "NETCLASS: \"%s\" has Via Drill:%s which is less than global:%s"
 msgstr ""
-"NETZKLASSE: '%s' hat DuKo Bohrdurchmesser: %s, welcher kleiner ist als der "
-"Globale: %s"
 
-#: pcbnew/drc.cpp:403
+#: pcbnew/drc.cpp:568
 #, c-format
-msgid "NETCLASS: '%s' has uVia Dia:%s which is less than global:%s"
+msgid "NETCLASS: \"%s\" has uVia Dia:%s which is less than global:%s"
 msgstr ""
-"NETZKLASSE: '%s' hat Micro-DuKo Durchmesser: %s, welcher kleiner ist als der "
-"Globale: %s"
 
-#: pcbnew/drc.cpp:416
+#: pcbnew/drc.cpp:581
 #, c-format
-msgid "NETCLASS: '%s' has uVia Drill:%s which is less than global:%s"
+msgid "NETCLASS: \"%s\" has uVia Drill:%s which is less than global:%s"
 msgstr ""
-"NETZKLASSE: '%s' hat Micro-DuKo Bohrdurchmesser: %s, welcher kleiner ist als "
-"der Globale: %s"
 
-#: pcbnew/drc.cpp:506
+#: pcbnew/drc.cpp:671
 msgid "Track clearances"
 msgstr "Leiterbahnabstandsflächen"
 
-#: pcbnew/drc.cpp:991
+#: pcbnew/drc.cpp:1156
 #, c-format
-msgid "footprint '%s' has malformed courtyard"
-msgstr "Footprint '%s' hat ungültigen Umriss"
-
-#: pcbnew/drc.cpp:1008
-#, c-format
-msgid "footprint '%s' has no courtyard defined"
-msgstr "Footprint '%s' hat keinen Umriss definiert"
-
-#: pcbnew/drc.cpp:1046
-#, c-format
-msgid "footprints '%s' and '%s' overlap on front (top) layer"
+msgid "footprint \"%s\" has malformed courtyard"
 msgstr ""
-"Footprints '%s' und '%s' überschneiden sich auf der Vorderseite (Top Layer)"
 
-#: pcbnew/drc.cpp:1081
+#: pcbnew/drc.cpp:1173
 #, c-format
-msgid "footprints '%s' and '%s' overlap on back (bottom) layer"
+msgid "footprint \"%s\" has no courtyard defined"
 msgstr ""
-"Footprints '%s' und '%s' überschneiden sich auf der Rückseite (Bottom Layer)"
 
-#: pcbnew/eagle_plugin.cpp:791
+#: pcbnew/drc.cpp:1211
 #, c-format
-msgid "<package> name: '%s' duplicated in eagle <library>: '%s'"
-msgstr "<package> Name: '%s' doppelt in Eagle <library>: '%s'"
+msgid "footprints \"%s\" and \"%s\" overlap on front (top) layer"
+msgstr ""
 
-#: pcbnew/eagle_plugin.cpp:865
+#: pcbnew/drc.cpp:1246
 #, c-format
-msgid "No '%s' package in library '%s'"
-msgstr "Kein '%s' Package in Bibliothek '%s'"
+msgid "footprints \"%s\" and \"%s\" overlap on back (bottom) layer"
+msgstr ""
 
-#: pcbnew/eagle_plugin.cpp:2076
+#: pcbnew/eagle_plugin.cpp:789
 #, c-format
-msgid "File '%s' is not readable."
-msgstr "Datei '%s' ist nicht lesbar."
+msgid "<package> name: \"%s\" duplicated in eagle <library>: \"%s\""
+msgstr ""
+
+#: pcbnew/eagle_plugin.cpp:861
+#, c-format
+msgid "No \"%s\" package in library \"%s\""
+msgstr ""
+
+#: pcbnew/eagle_plugin.cpp:2073
+#, c-format
+msgid "File \"%s\" is not readable."
+msgstr ""
 
 #: pcbnew/edgemod.cpp:213
 msgid ""
@@ -22900,74 +22353,74 @@ msgstr "Neue Breite:"
 msgid "Edge Width"
 msgstr "Linienbreite Platinenumriss"
 
-#: pcbnew/edit.cpp:705 pcbnew/edit.cpp:727 pcbnew/edit.cpp:753
-#: pcbnew/edit.cpp:781 pcbnew/edit.cpp:809 pcbnew/edit.cpp:837
+#: pcbnew/edit.cpp:710 pcbnew/edit.cpp:732 pcbnew/edit.cpp:758
+#: pcbnew/edit.cpp:786 pcbnew/edit.cpp:814 pcbnew/edit.cpp:842
 #, c-format
 msgid "Footprint %s found, but it is locked"
 msgstr "Footprint %s gefunden, dieser ist jedoch gesperrt"
 
-#: pcbnew/edit.cpp:909 pcbnew/edit.cpp:928
+#: pcbnew/edit.cpp:914 pcbnew/edit.cpp:933
 #, c-format
 msgid "The parent (%s) of the pad is locked"
 msgstr "Das übergeordnete Element (%s) dieses Pads ist gesperrt"
 
-#: pcbnew/edit.cpp:1451 pcbnew/edit.cpp:1453
+#: pcbnew/edit.cpp:1456 pcbnew/edit.cpp:1458
 msgid "Add tracks"
 msgstr "Leiterbahnen hinzufügen"
 
-#: pcbnew/edit.cpp:1459 pcbnew/edit.cpp:1506
-#: pcbnew/tools/pcb_editor_control.cpp:406
+#: pcbnew/edit.cpp:1464 pcbnew/edit.cpp:1511
+#: pcbnew/tools/pcb_editor_control.cpp:394
 msgid "Add footprint"
 msgstr "Footprint hinzufügen"
 
-#: pcbnew/edit.cpp:1463 pcbnew/tools/drawing_tool.cpp:650
+#: pcbnew/edit.cpp:1468 pcbnew/tools/drawing_tool.cpp:650
 msgid "Add zones"
 msgstr "Flächen hinzufügen"
 
-#: pcbnew/edit.cpp:1466
+#: pcbnew/edit.cpp:1471
 msgid "Warning: zone display is OFF!!!"
 msgstr "Achtung: Flächen sind ausgeblendet!!!"
 
-#: pcbnew/edit.cpp:1474 pcbnew/tools/drawing_tool.cpp:660
+#: pcbnew/edit.cpp:1479 pcbnew/tools/drawing_tool.cpp:660
 msgid "Add keepout"
 msgstr "Sperrfläche hinzufügen"
 
-#: pcbnew/edit.cpp:1478 pcbnew/menubar_pcbframe.cpp:354 pcbnew/tool_pcb.cpp:476
-#: pcbnew/tools/pcb_editor_control.cpp:598
+#: pcbnew/edit.cpp:1483 pcbnew/menubar_pcbframe.cpp:354 pcbnew/tool_pcb.cpp:476
+#: pcbnew/tools/pcb_editor_control.cpp:553
 msgid "Add layer alignment target"
 msgstr "Orientierungspunkt hinzufügen"
 
-#: pcbnew/edit.cpp:1482 pcbnew/tools/pcb_editor_control.cpp:1017
+#: pcbnew/edit.cpp:1487 pcbnew/tools/pcb_editor_control.cpp:840
 msgid "Adjust zero"
 msgstr "Nullabgleich durchführen"
 
-#: pcbnew/edit.cpp:1486 pcbnew/tools/pcbnew_control.cpp:629
+#: pcbnew/edit.cpp:1491 pcbnew/tools/pcbnew_control.cpp:629
 msgid "Adjust grid origin"
 msgstr "Rasterursprung anpassen"
 
-#: pcbnew/edit.cpp:1490 pcbnew/tool_modedit.cpp:174
+#: pcbnew/edit.cpp:1495 pcbnew/tool_modedit.cpp:174
 #: pcbnew/tools/drawing_tool.cpp:228
 msgid "Add graphic line"
 msgstr "Grafische Linie hinzufügen"
 
-#: pcbnew/edit.cpp:1494 pcbnew/menubar_modedit.cpp:304
+#: pcbnew/edit.cpp:1499 pcbnew/menubar_modedit.cpp:304
 #: pcbnew/menubar_pcbframe.cpp:331 pcbnew/tool_modedit.cpp:180
 #: pcbnew/tool_pcb.cpp:463 pcbnew/tools/drawing_tool.cpp:291
 msgid "Add graphic arc"
 msgstr "Grafischen Kreisbogen hinzufügen"
 
-#: pcbnew/edit.cpp:1498 pcbnew/menubar_modedit.cpp:293
+#: pcbnew/edit.cpp:1503 pcbnew/menubar_modedit.cpp:293
 #: pcbnew/menubar_pcbframe.cpp:334 pcbnew/tool_modedit.cpp:177
 #: pcbnew/tool_pcb.cpp:460 pcbnew/tools/drawing_tool.cpp:262
 msgid "Add graphic circle"
 msgstr "Grafischen Kreis hinzufügen"
 
-#: pcbnew/edit.cpp:1510 pcbnew/menubar_pcbframe.cpp:350 pcbnew/tool_pcb.cpp:473
+#: pcbnew/edit.cpp:1515 pcbnew/menubar_pcbframe.cpp:350 pcbnew/tool_pcb.cpp:473
 #: pcbnew/tools/drawing_tool.cpp:492
 msgid "Add dimension"
 msgstr "Bemaßung hinzufügen"
 
-#: pcbnew/edit.cpp:1522
+#: pcbnew/edit.cpp:1527
 msgid "Select rats nest"
 msgstr "Netzlinien wählen"
 
@@ -23004,20 +22457,16 @@ msgstr "Pad zu Die"
 msgid "Segs Count"
 msgstr "Segmentanzahl"
 
-#: pcbnew/exporters/export_d356.cpp:359
-msgid "IPC-D-356 Test Files (.d356)|*.d356"
-msgstr "IPC-D-356 Testdateien (.d356)|*.d356"
-
-#: pcbnew/exporters/export_d356.cpp:364
+#: pcbnew/exporters/export_d356.cpp:365
 msgid "Export D-356 Test File"
 msgstr "Exportieren einer D-356 Testdatei"
 
 #: pcbnew/exporters/export_idf.cpp:605 pcbnew/exporters/export_idf.cpp:614
-#: pcbnew/exporters/export_idf.cpp:622 pcbnew/exporters/export_vrml.cpp:1587
+#: pcbnew/exporters/export_idf.cpp:622 pcbnew/exporters/export_vrml.cpp:1594
 msgid "IDF Export Failed:\n"
 msgstr "Der IDF-Export ist fehlgeschlagen:\n"
 
-#: pcbnew/exporters/export_vrml.cpp:807
+#: pcbnew/exporters/export_vrml.cpp:809
 msgid ""
 "Unable to calculate the board outlines; fall back to using the board "
 "boundary box."
@@ -23025,7 +22474,7 @@ msgstr ""
 "Konnte den Platinenumriss nicht bestimmen\n"
 "und verwende somit die äußeren Bereichsgrenzen."
 
-#: pcbnew/exporters/export_vrml.cpp:838
+#: pcbnew/exporters/export_vrml.cpp:840
 msgid "VRML Export Failed: Could not add holes to contours."
 msgstr ""
 "VRML Export fehlgeschlagen:\n"
@@ -23037,18 +22486,18 @@ msgstr "Kein Footprint für automatische Platzierung vorhanden."
 
 #: pcbnew/exporters/gen_modules_placefile.cpp:291
 #, c-format
-msgid "Unable to create '%s'."
-msgstr "Konnte '%s' nicht erstellen."
+msgid "Unable to create \"%s\"."
+msgstr ""
 
 #: pcbnew/exporters/gen_modules_placefile.cpp:298
 #, c-format
-msgid "Place file: '%s'."
-msgstr "Platzierungsdatei: '%s'"
+msgid "Place file: \"%s\"."
+msgstr ""
 
 #: pcbnew/exporters/gen_modules_placefile.cpp:300
 #, c-format
-msgid "Front side (top side) place file: '%s'."
-msgstr "Platzierungsdatei der Vorderseite (Oberseite): '%s'"
+msgid "Front side (top side) place file: \"%s\"."
+msgstr ""
 
 #: pcbnew/exporters/gen_modules_placefile.cpp:304
 #: pcbnew/exporters/gen_modules_placefile.cpp:345
@@ -23063,8 +22512,8 @@ msgstr "Erstellung Bauteil Platzierungsdatei abgeschlossen."
 
 #: pcbnew/exporters/gen_modules_placefile.cpp:342
 #, c-format
-msgid "Back side (bottom side) place file: '%s'."
-msgstr "Platzierungsdatei der Rückseite (Unterseite): '%s'"
+msgid "Back side (bottom side) place file: \"%s\"."
+msgstr ""
 
 #: pcbnew/exporters/gen_modules_placefile.cpp:353
 #, c-format
@@ -23075,19 +22524,12 @@ msgstr "Gesamte Anzahl Bauteile %d\n"
 #, c-format
 msgid ""
 "Footprint report file created:\n"
-"'%s'"
+"\"%s\""
 msgstr ""
-"Footprint Protokolldatei erstellt:\n"
-"'%s'"
 
 #: pcbnew/exporters/gen_modules_placefile.cpp:627
 msgid "Footprint Report"
 msgstr "Footprint Protokolldatei"
-
-#: pcbnew/exporters/gen_modules_placefile.cpp:632
-#, c-format
-msgid "Unable to create '%s'"
-msgstr "Konnte '%s' nicht erstellen"
 
 #: pcbnew/exporters/gendrill_Excellon_writer.cpp:119
 #: pcbnew/exporters/gendrill_file_writer_base.cpp:338
@@ -23098,21 +22540,21 @@ msgstr "Erstelle Datei %s\n"
 
 #: pcbnew/exporters/gerber_jobfile_writer.cpp:130
 #, c-format
-msgid "Unable to create job file '%s'"
-msgstr "Konnte Job-Datei '%s' nicht erstellen."
+msgid "Unable to create job file \"%s\""
+msgstr ""
 
 #: pcbnew/exporters/gerber_jobfile_writer.cpp:383
 #, c-format
-msgid "Create Gerber job file '%s'"
-msgstr "Erstelle Gerber-Job Datei '%s'"
+msgid "Create Gerber job file \"%s\""
+msgstr ""
 
 #: pcbnew/files.cpp:144
 msgid "Open Board File"
 msgstr "Platinendatei öffnen"
 
 #: pcbnew/files.cpp:144
-msgid "Import Non Kicad Board File"
-msgstr "Importiere Nicht KiCad Platinendatei"
+msgid "Import Non KiCad Board File"
+msgstr ""
 
 #: pcbnew/files.cpp:180
 msgid "Save Board File As"
@@ -23124,13 +22566,13 @@ msgstr "Bedruckte Leiterplatte"
 
 #: pcbnew/files.cpp:284
 #, c-format
-msgid "Recovery file '%s' not found."
-msgstr "Wiederherstellungsdatei '%s' wurde nicht gefunden."
+msgid "Recovery file \"%s\" not found."
+msgstr ""
 
 #: pcbnew/files.cpp:290
 #, c-format
-msgid "OK to load recovery or backup file '%s'"
-msgstr "Soll die Wiederherstellungsdatei '%s' geladen werden?"
+msgid "OK to load recovery or backup file \"%s\""
+msgstr ""
 
 #: pcbnew/files.cpp:351
 msgid "noname"
@@ -23138,8 +22580,8 @@ msgstr "namenlos"
 
 #: pcbnew/files.cpp:425
 #, c-format
-msgid "PCB file '%s' is already open."
-msgstr "Die PCB Datei '%s' ist bereits geöffnet."
+msgid "PCB file \"%s\" is already open."
+msgstr ""
 
 #: pcbnew/files.cpp:435
 msgid "The current board has been modified.  Do you wish to save the changes?"
@@ -23149,8 +22591,8 @@ msgstr ""
 
 #: pcbnew/files.cpp:461
 #, c-format
-msgid "Board '%s' does not exist.  Do you wish to create it?"
-msgstr "Die Platine '%s' existiert nicht. Möchten Sie diese erstellen?"
+msgid "Board \"%s\" does not exist.  Do you wish to create it?"
+msgstr ""
 
 #: pcbnew/files.cpp:526
 #, c-format
@@ -23171,46 +22613,42 @@ msgstr ""
 
 #: pcbnew/files.cpp:657
 #, c-format
-msgid "Warning: unable to create backup file '%s'"
-msgstr "Achtung: Konnte Wiederherstellungsdatei '%s' nicht erstellen"
+msgid "Warning: unable to create backup file \"%s\""
+msgstr ""
 
 #: pcbnew/files.cpp:684 pcbnew/files.cpp:777
 #, c-format
-msgid "No access rights to write to file '%s'"
-msgstr "Keine Zugriffsrechte um Datei '%s' schreiben zu können."
+msgid "No access rights to write to file \"%s\""
+msgstr ""
 
 #: pcbnew/files.cpp:723 pcbnew/files.cpp:802
 #, c-format
 msgid ""
-"Error saving board file '%s'.\n"
+"Error saving board file \"%s\".\n"
 "%s"
 msgstr ""
-"Fehler beim Speichern der Platine '%s'.\n"
-"%s"
 
 #: pcbnew/files.cpp:729
 #, c-format
-msgid "Failed to create '%s'"
-msgstr "Konnte Datei '%s' nicht erstellen"
+msgid "Failed to create \"%s\""
+msgstr ""
 
 #: pcbnew/files.cpp:755
 #, c-format
-msgid "Backup file: '%s'"
-msgstr "Wiederherstellungsdatei: '%s'"
+msgid "Backup file: \"%s\""
+msgstr ""
 
 #: pcbnew/files.cpp:757
 #, c-format
-msgid "Wrote board file: '%s'"
-msgstr "Platinendatei geschrieben: '%s'"
+msgid "Wrote board file: \"%s\""
+msgstr ""
 
 #: pcbnew/files.cpp:811
 #, c-format
 msgid ""
 "Board copied to:\n"
-"'%s'"
+"\"%s\""
 msgstr ""
-"Platine kopiert nach:\n"
-"'%s'"
 
 #: pcbnew/footprint_wizard.cpp:78 pcbnew/footprint_wizard_frame.cpp:111
 msgid "Footprint Wizard"
@@ -23266,32 +22704,24 @@ msgstr "Footprint Erstellung Hinweis"
 #, c-format
 msgid ""
 "malformed URL:\n"
-"'%s'"
+"\"%s\""
 msgstr ""
-"Ungültige URL:\n"
-"'%s'"
 
 #: pcbnew/github/github_getliblist.cpp:234
 #, c-format
 msgid ""
-"Error fetching JSON data from URL '%s'.\n"
-"Reason: '%s'"
+"Error fetching JSON data from URL \"%s\".\n"
+"Reason: \"%s\""
 msgstr ""
-"Konnte die JSON Daten nicht herunterladen von: '%s'.\n"
-"Grund: '%s'"
 
 #: pcbnew/github/github_plugin.cpp:300
 #, c-format
 msgid ""
 "Footprint\n"
-"'%s'\n"
+"\"%s\"\n"
 "is not in the writable portion of this Github library\n"
-"'%s'"
+"\"%s\""
 msgstr ""
-"Footprint\n"
-"'%s'\n"
-"befindet sich nicht im beschreibbaren Bereich dieser GitHub-Bibliothek\n"
-"'%s'"
 
 #: pcbnew/github/github_plugin.cpp:361
 msgid ""
@@ -23313,42 +22743,32 @@ msgstr ""
 #: pcbnew/github/github_plugin.cpp:416
 #, c-format
 msgid ""
-"option '%s' for Github library '%s' must point to a writable directory "
+"option \"%s\" for Github library \"%s\" must point to a writable directory "
 "ending with '.pretty'."
 msgstr ""
-"Die Option '%s' für die GitHub-Bibliothek '%s' muss auf ein beschreibbares "
-"Verzeichnis mit der Endung '.pretty' verweisen."
 
 #: pcbnew/github/github_plugin.cpp:549
 #, c-format
 msgid ""
 "Unable to parse URL:\n"
-"'%s'"
+"\"%s\""
 msgstr ""
-"Konnte die folgende URL nicht parsen:\n"
-"'%s'"
 
 #: pcbnew/github/github_plugin.cpp:573
 #, c-format
 msgid ""
 "%s\n"
-"Cannot get/download Zip archive: '%s'\n"
-"for library path: '%s'.\n"
-"Reason: '%s'"
+"Cannot get/download Zip archive: \"%s\"\n"
+"for library path: \"%s\".\n"
+"Reason: \"%s\""
 msgstr ""
-"%s\n"
-"Konnte das Zip-Archiv '%s' nicht herunterladen.\n"
-"Bibliothekspfad: '%s'\n"
-"Grund: '%s'"
 
 #: pcbnew/github/github_plugin.cpp:590
 #, c-format
 msgid ""
-"Cannot download library '%s'.\n"
+"Cannot download library \"%s\".\n"
 "The library does not exist on the server"
 msgstr ""
-"Bibliothek '%s' kann nicht herunter geladen werden.\n"
-"Diese Bibliothek existiert nicht auf dem Server."
 
 #: pcbnew/gpcb_plugin.cpp:113
 #, c-format
@@ -23356,19 +22776,18 @@ msgid "Cannot convert \"%s\" to an integer"
 msgstr "\"%s\" kann nicht in einen Zahlenwert konvertiert werden."
 
 #: pcbnew/gpcb_plugin.cpp:298 pcbnew/gpcb_plugin.cpp:984
-#: pcbnew/kicad_plugin.cpp:1968
+#: pcbnew/kicad_plugin.cpp:1985
 #, c-format
-msgid "footprint library path '%s' does not exist"
-msgstr "Der Footprintbibliothekspfad '%s' existiert nicht."
-
-#: pcbnew/gpcb_plugin.cpp:354
-#, c-format
-msgid "library <%s> has no footprint '%s' to delete"
+msgid "footprint library path \"%s\" does not exist"
 msgstr ""
-"Bibliothek <%s> besitzt keinen Footprint '%s', welcher gelöscht werden kann."
 
-#: pcbnew/gpcb_plugin.cpp:458 pcbnew/pcb_parser.cpp:436
-#: pcbnew/pcb_parser.cpp:541
+#: pcbnew/gpcb_plugin.cpp:354 pcbnew/kicad_plugin.cpp:345
+#, c-format
+msgid "library \"%s\" has no footprint \"%s\" to delete"
+msgstr ""
+
+#: pcbnew/gpcb_plugin.cpp:458 pcbnew/pcb_parser.cpp:458
+#: pcbnew/pcb_parser.cpp:563
 #, c-format
 msgid "unknown token \"%s\""
 msgstr "Unbekanntes Vorkommnis \"%s\""
@@ -23378,56 +22797,31 @@ msgstr "Unbekanntes Vorkommnis \"%s\""
 msgid "Element token contains %d parameters."
 msgstr "Elementvorkommnis enthält %d Parameter."
 
-#: pcbnew/gpcb_plugin.cpp:1049 pcbnew/kicad_plugin.cpp:2038
-#: pcbnew/kicad_plugin.cpp:2104 pcbnew/librairi.cpp:552
+#: pcbnew/gpcb_plugin.cpp:1049 pcbnew/kicad_plugin.cpp:2055
+#: pcbnew/kicad_plugin.cpp:2121 pcbnew/librairi.cpp:550
 #, c-format
-msgid "Library '%s' is read only"
-msgstr "Auf die Bibliothek '%s' kann nur lesend zugegriffen werden."
-
-#: pcbnew/gpcb_plugin.cpp:1068 pcbnew/kicad_plugin.cpp:2141
-#, c-format
-msgid "user does not have permission to delete directory '%s'"
-msgstr "Keine Berechtigung zum Löschen von Verzeichnis '%s'."
-
-#: pcbnew/gpcb_plugin.cpp:1076 pcbnew/kicad_plugin.cpp:2149
-#, c-format
-msgid "library directory '%s' has unexpected sub-directories"
+msgid "Library \"%s\" is read only"
 msgstr ""
-"Das Bibliotheksverzeichnis '%s' enthält unerwartete Unterverzeichnisse."
 
-#: pcbnew/gpcb_plugin.cpp:1095 pcbnew/kicad_plugin.cpp:2168
+#: pcbnew/gpcb_plugin.cpp:1068 pcbnew/kicad_plugin.cpp:2158
 #, c-format
-msgid "unexpected file '%s' was found in library path '%s'"
-msgstr "Es wurde eine unerwartete Datei '%s' im Bibliothekspfad '%s' gefunden."
-
-#: pcbnew/gpcb_plugin.cpp:1113 pcbnew/kicad_plugin.cpp:2186
-#, c-format
-msgid "footprint library '%s' cannot be deleted"
-msgstr "Die Footprintbibliothek '%s' konnte nicht gelöscht werden."
-
-#: pcbnew/help_common_strings.h:15 pcbnew/tool_modedit.cpp:110
-msgid "Undo last edition"
-msgstr "Letzte Änderung rückgängig machen"
-
-#: pcbnew/help_common_strings.h:17
-msgid "Find components and text in current loaded board"
-msgstr "Suche nach Bauteilen oder Text auf aktueller Platine"
-
-#: pcbnew/help_common_strings.h:21
-msgid "Zoom to fit board on screen"
-msgstr "Darstellung an den Bildschirm anpassen"
-
-#: pcbnew/help_common_strings.h:22
-msgid "Redraw screen"
-msgstr "Bildschirm neu zeichnen"
-
-#: pcbnew/help_common_strings.h:26
-msgid ""
-"Show/hide microwave toolbar\n"
-"(Experimental feature)"
+msgid "user does not have permission to delete directory \"%s\""
 msgstr ""
-"Werkzeugleiste für Mikrowellen-Applikationen ein-/ausblenden.\n"
-"(Experimentelles Feature!)"
+
+#: pcbnew/gpcb_plugin.cpp:1076 pcbnew/kicad_plugin.cpp:2166
+#, c-format
+msgid "library directory \"%s\" has unexpected sub-directories"
+msgstr ""
+
+#: pcbnew/gpcb_plugin.cpp:1095 pcbnew/kicad_plugin.cpp:2185
+#, c-format
+msgid "unexpected file \"%s\" was found in library path \"%s\""
+msgstr ""
+
+#: pcbnew/gpcb_plugin.cpp:1113 pcbnew/kicad_plugin.cpp:2203
+#, c-format
+msgid "footprint library \"%s\" cannot be deleted"
+msgstr ""
 
 #: pcbnew/hotkeys.cpp:72
 msgid "Switch to Copper (B.Cu) layer"
@@ -23538,6 +22932,13 @@ msgstr "Element duplizieren"
 msgid "Duplicate Item and Increment"
 msgstr "Element duplizieren und verdoppeln"
 
+#: pcbnew/hotkeys.cpp:123 pcbnew/modedit_onclick.cpp:371
+#: pcbnew/modedit_onclick.cpp:415 pcbnew/onrightclick.cpp:210
+#: pcbnew/onrightclick.cpp:848 pcbnew/tools/edit_tool.cpp:119
+#: pcbnew/dialogs/dialog_create_array_base.h:116
+msgid "Create Array"
+msgstr "Array erstellen"
+
 #: pcbnew/hotkeys.cpp:124
 msgid "Copy Item"
 msgstr "Element kopieren"
@@ -23598,7 +22999,7 @@ msgstr "Raster eine Stufe zurück umschalten"
 msgid "Track Display Mode"
 msgstr "Anzeige Leiterbahnfüllung (Umriss/voll)"
 
-#: pcbnew/hotkeys.cpp:232 pcbnew/tools/pcb_editor_control.cpp:119
+#: pcbnew/hotkeys.cpp:232 pcbnew/tools/pcb_editor_control.cpp:109
 msgid "Add Footprint"
 msgstr "Footprint hinzufügen"
 
@@ -23622,6 +23023,11 @@ msgstr "Auswahl Kupfer Verbindung"
 msgid "Custom Track/Via Size"
 msgstr "Benutzerdefinierte Leiterbahn/DuKo Größe"
 
+#: pcbnew/hotkeys.cpp:248
+#: pcbnew/dialogs/dialog_pns_diff_pair_dimensions_base.h:65
+msgid "Differential Pair Dimensions"
+msgstr "Abmessungen differenzielles Signalpaar"
+
 #: pcbnew/hotkeys.cpp:250
 msgid "Increase Via Size"
 msgstr "Größe Via erhöhen"
@@ -23634,11 +23040,11 @@ msgstr "Größe Via verkleinern"
 msgid "Board Editor"
 msgstr "Board Editor"
 
-#: pcbnew/import_dxf/dialog_dxf_import.cpp:232
+#: pcbnew/import_dxf/dialog_dxf_import.cpp:235
 msgid "Open File"
 msgstr "Datei öffnen"
 
-#: pcbnew/import_dxf/dialog_dxf_import.cpp:256
+#: pcbnew/import_dxf/dialog_dxf_import.cpp:259
 msgid "Error: No DXF filename!"
 msgstr "Fehler: Kein DXF Dateiname!"
 
@@ -23702,10 +23108,6 @@ msgstr "Voreinstellung für Linienbreite:"
 msgid "Graphic Layer:"
 msgstr "Grafische Lage:"
 
-#: pcbnew/import_dxf/dialog_dxf_import_base.h:78
-msgid "Import DXF File"
-msgstr "DXF-Datei importieren"
-
 #: pcbnew/initpcb.cpp:47
 msgid ""
 "Current Board will be lost and this operation cannot be undone. Continue ?"
@@ -23737,85 +23139,73 @@ msgstr "Inhalt der Zwischenablage ist nicht kompatibel mit KiCad"
 msgid "Cannot find component with reference \"%s\" in netlist."
 msgstr "Konnte in der Netzliste kein Bauteil mit der Referenz \"%s\" finden."
 
-#: pcbnew/kicad_netlist_reader.cpp:369 pcbnew/pcb_parser.cpp:1760
+#: pcbnew/kicad_netlist_reader.cpp:369 pcbnew/pcb_parser.cpp:1787
 #, c-format
 msgid ""
 "invalid footprint ID in\n"
-"file: <%s>\n"
+"file: \"%s\"\n"
 "line: %d\n"
 "offset: %d"
 msgstr ""
-"Unzulässige Footprint ID in\n"
-"Datei: '%s'\n"
-"Zeile: %d\n"
-"Offset: %d"
 
 #: pcbnew/kicad_plugin.cpp:219
 #, c-format
-msgid "Cannot create footprint library path '%s'"
-msgstr "Der Footprintbibliothekspfad '%s' konnte nicht erstellen werden."
+msgid "Cannot create footprint library path \"%s\""
+msgstr ""
 
 #: pcbnew/kicad_plugin.cpp:225
 #, c-format
-msgid "Footprint library path '%s' is read only"
-msgstr "Auf die Footprintbibliothek '%s' kann nur lesend zugegriffen werden."
+msgid "Footprint library path \"%s\" is read only"
+msgstr ""
 
 #: pcbnew/kicad_plugin.cpp:264
 #, c-format
-msgid "Cannot rename temporary file '%s' to footprint library file '%s'"
+msgid "Cannot rename temporary file \"%s\" to footprint library file \"%s\""
 msgstr ""
-"Konnte temporäre Datei '%s' nicht in Footprintbibliotheksdatei '%s' "
-"umbenennen."
 
 #: pcbnew/kicad_plugin.cpp:284
 #, c-format
-msgid "Footprint library path '%s' does not exist"
-msgstr "Footprintbibliothekspfad '%s' existiert nicht."
-
-#: pcbnew/kicad_plugin.cpp:345
-#, c-format
-msgid "library '%s' has no footprint '%s' to delete"
+msgid "Footprint library path \"%s\" does not exist"
 msgstr ""
-"Bibliothek '%s' besitzt keinen Footprint '%s', welcher gelöscht werden kann."
 
-#: pcbnew/kicad_plugin.cpp:1280 pcbnew/legacy_plugin.cpp:97
+#: pcbnew/kicad_plugin.cpp:1297 pcbnew/legacy_plugin.cpp:97
 #, c-format
 msgid "unknown pad type: %d"
 msgstr "unbekannter Pad-Typ: %d"
 
-#: pcbnew/kicad_plugin.cpp:1293 pcbnew/legacy_plugin.cpp:98
+#: pcbnew/kicad_plugin.cpp:1310 pcbnew/legacy_plugin.cpp:98
 #, c-format
 msgid "unknown pad attribute: %d"
 msgstr "unbekanntes Pad-Attribut: %d"
 
-#: pcbnew/kicad_plugin.cpp:1597
+#: pcbnew/kicad_plugin.cpp:1614
 #, c-format
 msgid "unknown via type %d"
 msgstr "Unbekannter Durchkontaktierungstyp %d"
 
-#: pcbnew/kicad_plugin.cpp:1735
+#: pcbnew/kicad_plugin.cpp:1752
 #, c-format
 msgid "unknown zone corner smoothing type %d"
 msgstr "Unbekannter Glättungsyp für Eckflächen %d"
 
-#: pcbnew/kicad_plugin.cpp:1925
+#: pcbnew/kicad_plugin.cpp:1942
 msgid "this file does not contain a PCB"
 msgstr "Diese Datei enthält keine PCB Daten."
 
-#: pcbnew/kicad_plugin.cpp:2055
+#: pcbnew/kicad_plugin.cpp:2072
 #, c-format
-msgid "Footprint file name '%s' is not valid."
-msgstr "'%s' ist kein gültiger Footprintdateiname."
+msgid "Footprint file name \"%s\" is not valid."
+msgstr ""
 
-#: pcbnew/kicad_plugin.cpp:2061
+#: pcbnew/kicad_plugin.cpp:2078
 #, c-format
-msgid "user does not have write permission to delete file '%s' "
-msgstr "Keine Berechtigung zum Löschen der Datei '%s'."
+msgid "user does not have write permission to delete file \"%s\" "
+msgstr ""
 
-#: pcbnew/kicad_plugin.cpp:2116
+#: pcbnew/kicad_plugin.cpp:2133
 #, c-format
-msgid "cannot overwrite library path '%s'"
-msgstr "Bibliothekspfad '%s' kann nicht überschrieben werden."
+msgid "cannot overwrite library path \"%s\""
+msgstr ""
 
 #: pcbnew/layer_widget.cpp:135
 msgid "Change Layer Color for "
@@ -23871,21 +23261,16 @@ msgstr ""
 
 #: pcbnew/legacy_netlist_reader.cpp:248
 #, c-format
-msgid "Cannot find component '%s' in footprint filter section of netlist."
+msgid "Cannot find component \"%s\" in footprint filter section of netlist."
 msgstr ""
-"Konnte das Bauteil '%s' in der Footprintfiltersektion der Netzliste nicht "
-"finden."
 
 #: pcbnew/legacy_plugin.cpp:95
 #, c-format
 msgid ""
-"File '%s' is format version: %d.\n"
+"File \"%s\" is format version: %d.\n"
 "I only support format version <= %d.\n"
 "Please upgrade Pcbnew to load this file."
 msgstr ""
-"Das Format der Datei '%s' besitzt die Version: %d.\n"
-"Unterstütze wird nur die Version <= %d.\n"
-"Bitte aktualisieren Sie Pcbnew, um diese Datei zu laden."
 
 #: pcbnew/legacy_plugin.cpp:96
 #, c-format
@@ -23894,50 +23279,67 @@ msgstr "unbekannter Grafiktyp: %d"
 
 #: pcbnew/legacy_plugin.cpp:731
 #, c-format
-msgid "Unknown sheet type '%s' on line:%d"
-msgstr "Unbekannter Schaltplantyp '%s' in Zeile: %d"
+msgid "Unknown sheet type \"%s\" on line:%d"
+msgstr ""
+
+#: pcbnew/legacy_plugin.cpp:1375
+#, c-format
+msgid "Missing '$EndMODULE' for MODULE \"%s\""
+msgstr ""
 
 #: pcbnew/legacy_plugin.cpp:1427
 #, c-format
-msgid "Unknown padshape '%c=0x%02x' on line: %d of footprint: '%s'"
-msgstr "Unbekannte Padform '%c=0x%02x' in Zeile: %d von Footprint: '%s'"
+msgid "Unknown padshape '%c=0x%02x' on line: %d of footprint: \"%s\""
+msgstr ""
+
+#: pcbnew/legacy_plugin.cpp:1633
+#, c-format
+msgid "Unknown EDGE_MODULE type:'%c=0x%02x' on line:%d of footprint:\"%s\""
+msgstr ""
 
 #: pcbnew/legacy_plugin.cpp:2461
 #, c-format
-msgid "duplicate NETCLASS name '%s'"
-msgstr "NETCLASS Namensduplikat '%s'"
+msgid "duplicate NETCLASS name \"%s\""
+msgstr ""
+
+#: pcbnew/legacy_plugin.cpp:2543 pcbnew/legacy_plugin.cpp:2554
+#, c-format
+msgid "Bad ZAux for CZONE_CONTAINER \"%s\""
+msgstr ""
+
+#: pcbnew/legacy_plugin.cpp:2571
+#, c-format
+msgid "Bad ZSmoothing for CZONE_CONTAINER \"%s\""
+msgstr ""
+
+#: pcbnew/legacy_plugin.cpp:2645
+#, c-format
+msgid "Bad ZClearance padoption for CZONE_CONTAINER \"%s\""
+msgstr ""
 
 #: pcbnew/legacy_plugin.cpp:2993 pcbnew/legacy_plugin.cpp:3030
 #, c-format
 msgid ""
-"invalid float number in file: '%s'\n"
+"invalid float number in file: \"%s\"\n"
 "line: %d, offset: %d"
 msgstr ""
-"Unzulässige Gleitkommazahl in Datei: '%s'\n"
-"Zeile: %d, Spalte: %d"
 
 #: pcbnew/legacy_plugin.cpp:3002 pcbnew/legacy_plugin.cpp:3038
 #, c-format
 msgid ""
-"missing float number in file: '%s'\n"
+"missing float number in file: \"%s\"\n"
 "line: %d, offset: %d"
 msgstr ""
-"Fehlende Gleitkommazahl in Datei: '%s'\n"
-"Zeile: %d, Spalte: %d"
 
 #: pcbnew/legacy_plugin.cpp:3264
 #, c-format
-msgid "File '%s' is empty or is not a legacy library"
+msgid "File \"%s\" is empty or is not a legacy library"
 msgstr ""
-"Die Datei '%s' ist entweder leer oder keine im alten Format vorliegende "
-"Bibliothek."
 
 #: pcbnew/librairi.cpp:60
 #, c-format
-msgid "Library '%s' exists, OK to replace ?"
+msgid "Library \"%s\" exists, OK to replace ?"
 msgstr ""
-"Die Bibliothek '%s' existiert bereits.\n"
-"Möchten Sie diese ersetzen?"
 
 #: pcbnew/librairi.cpp:61
 msgid "Create New Library Folder (the .pretty folder is the library)"
@@ -23946,17 +23348,12 @@ msgstr ""
 
 #: pcbnew/librairi.cpp:62
 #, c-format
-msgid "OK to delete footprint %s in library '%s'"
-msgstr "Möchten Sie den Footprint '%s' in der Bibliothek '%s' entfernen?"
+msgid "OK to delete footprint \"%s\" in library \"%s\""
+msgstr ""
 
 #: pcbnew/librairi.cpp:63
 msgid "Import Footprint"
 msgstr "Footprint importieren"
-
-#: pcbnew/librairi.cpp:64
-#, c-format
-msgid "File '%s' not found"
-msgstr "Datei '%s' nicht gefunden."
 
 #: pcbnew/librairi.cpp:65
 msgid "Not a footprint file"
@@ -23964,27 +23361,24 @@ msgstr "Keine Footprintdatei"
 
 #: pcbnew/librairi.cpp:66
 #, c-format
-msgid "Unable to find or load footprint %s from lib path '%s'"
-msgstr "Konnte Footprint '%s' im Bibliothekspfad '%s' nicht finden oder laden."
+msgid "Unable to find or load footprint \"%s\" from lib path \"%s\""
+msgstr ""
 
 #: pcbnew/librairi.cpp:67
 #, c-format
-msgid "Unable to find or load footprint from path '%s'"
-msgstr "Konnte Footprint im Pfad '%s' nicht finden oder laden."
+msgid "Unable to find or load footprint from path \"%s\""
+msgstr ""
 
 #: pcbnew/librairi.cpp:68
 #, c-format
 msgid ""
-"The footprint library '%s' could not be found in any of the search paths."
+"The footprint library \"%s\" could not be found in any of the search paths."
 msgstr ""
-"Die Footprintbibliothek '%s' konnte in keinem der Suchpfade gefunden werden."
 
 #: pcbnew/librairi.cpp:69
 #, c-format
-msgid "Library '%s' is read only, not writable"
+msgid "Library \"%s\" is read only, not writable"
 msgstr ""
-"Auf die Bibliothek '%s' kann nur lesend und nicht schreibend zugegriffen "
-"werden."
 
 #: pcbnew/librairi.cpp:71
 msgid "Export Footprint"
@@ -23996,13 +23390,13 @@ msgstr "Footprintname:"
 
 #: pcbnew/librairi.cpp:74
 #, c-format
-msgid "Footprint exported to file '%s'"
-msgstr "Footprint wurde in die Datei '%s' exportiert."
+msgid "Footprint exported to file \"%s\""
+msgstr ""
 
 #: pcbnew/librairi.cpp:75
 #, c-format
-msgid "Footprint %s deleted from library '%s'"
-msgstr "Footprint %s wurde aus der Bibliothek '%s' entfernt."
+msgid "Footprint \"%s\" deleted from library \"%s\""
+msgstr ""
 
 #: pcbnew/librairi.cpp:76
 msgid "New Footprint"
@@ -24010,16 +23404,12 @@ msgstr "Neuer Footprint"
 
 #: pcbnew/librairi.cpp:78
 #, c-format
-msgid "Footprint %s already exists in library '%s'"
-msgstr "Footprint %s existiert bereits in der Bibliothek '%s'."
+msgid "Footprint \"%s\" already exists in library \"%s\""
+msgstr ""
 
 #: pcbnew/librairi.cpp:79
 msgid "No footprint name defined."
 msgstr "Es wurde kein Footprintname definiert."
-
-#: pcbnew/librairi.cpp:80
-msgid "Select Library"
-msgstr "Wähle Bibliothek"
 
 #: pcbnew/librairi.cpp:83
 msgid ""
@@ -24048,38 +23438,28 @@ msgstr ""
 "aktualisieren Sie\n"
 "die Footprint Library Tabelle um den Footprint löschen zu können."
 
-#: pcbnew/librairi.cpp:94
-msgid "Legacy foot print export files (*.emp)|*.emp"
-msgstr "Alte Footprint-Exportdateien (*.emp)|*.emp"
-
-#: pcbnew/librairi.cpp:399
+#: pcbnew/librairi.cpp:397
 #, c-format
-msgid "Unable to create or write file '%s'"
-msgstr "Konnte Datei '%s' nicht erstellen"
+msgid "Unable to create or write file \"%s\""
+msgstr ""
 
-#: pcbnew/librairi.cpp:597
+#: pcbnew/librairi.cpp:595
 msgid "No footprints to archive!"
 msgstr "Keine Footprints zum Archivieren!"
 
-#: pcbnew/librairi.cpp:700
+#: pcbnew/librairi.cpp:759
 #, c-format
-msgid ""
-"Error:\n"
-"one of invalid chars '%s' found\n"
-"in '%s'"
+msgid "Component \"%s\" replaced in \"%s\""
 msgstr ""
-"Fehler:\n"
-"Unzulässiges Zeichen '%s' in '%s' gefunden."
 
-#: pcbnew/librairi.cpp:761
+#: pcbnew/librairi.cpp:760
 #, c-format
-msgid "Component [%s] replaced in '%s'"
-msgstr "Bauteil [%s] ersetzt in '%s'."
+msgid "Component \"%s\" added in  \"%s\""
+msgstr ""
 
-#: pcbnew/librairi.cpp:762
-#, c-format
-msgid "Component [%s] added in  '%s'"
-msgstr "Bauteil [%s] hinzugefügt zu '%s'."
+#: pcbnew/librairi.cpp:849 include/lib_table_grid.h:179
+msgid "Nickname"
+msgstr "Nickname"
 
 #: pcbnew/loadcmp.cpp:178
 msgid "Load Footprint"
@@ -24125,13 +23505,13 @@ msgstr "Footprints [%u Elemente]"
 
 #: pcbnew/loadcmp.cpp:571
 #, c-format
-msgid "Footprint '%s' saved"
-msgstr "Footprint '%s' gespeichert"
+msgid "Footprint \"%s\" saved"
+msgstr ""
 
 #: pcbnew/loadcmp.cpp:585
 #, c-format
-msgid "Footprint library '%s' saved as '%s'."
-msgstr "Die Footprintbibliothek '%s' wurde gespeichert als '%s'."
+msgid "Footprint library \"%s\" saved as \"%s\"."
+msgstr ""
 
 #: pcbnew/menubar_modedit.cpp:67
 msgid "Set Acti&ve Library"
@@ -24357,8 +23737,8 @@ msgid "Change footprint editor settings."
 msgstr "Ändern der Footprinteditor-Einstellungen."
 
 #: pcbnew/menubar_modedit.cpp:345 pcbnew/menubar_pcbframe.cpp:213
-msgid "&Display and Hide"
-msgstr "&Darstellung und Anzeige"
+msgid "&Display Settings"
+msgstr ""
 
 #: pcbnew/menubar_modedit.cpp:346
 msgid "Change footprint editor display settings"
@@ -24905,10 +24285,6 @@ msgstr "Eine entflechtete \"Specctra Session\" Datei (*.ses) importieren"
 msgid "&DXF File"
 msgstr "D&XF-Datei"
 
-#: pcbnew/menubar_pcbframe.cpp:762
-msgid "&Import"
-msgstr "&Importieren"
-
 #: pcbnew/menubar_pcbframe.cpp:763
 msgid "Import files"
 msgstr "Dateien importieren"
@@ -25032,16 +24408,16 @@ msgstr ""
 "Bauteildatei (*.cmp) für Eeschema Footprintfeld Back-Annotation exportieren"
 
 #: pcbnew/microwave.cpp:244
-msgid "Gap"
-msgstr "Zwischenraum"
+msgid "Gap Size:"
+msgstr ""
 
 #: pcbnew/microwave.cpp:250
-msgid "Stub"
-msgstr "Stichleitung"
+msgid "Stub Size:"
+msgstr ""
 
 #: pcbnew/microwave.cpp:257
-msgid "Arc Stub"
-msgstr "Teilkreisbogen"
+msgid "Arc Stub Radius Value:"
+msgstr ""
 
 #: pcbnew/microwave.cpp:268 pcbnew/microwave.cpp:286
 msgid "Create microwave module"
@@ -25087,19 +24463,19 @@ msgstr "Die Form hat eine Größe von Null!"
 msgid "Shape has no points!"
 msgstr "Die Form hat keine Punkte!"
 
-#: pcbnew/microwave.cpp:701
+#: pcbnew/microwave.cpp:704
 msgid "No pad for this footprint"
 msgstr "Kein Pad für diesen Footprint"
 
-#: pcbnew/microwave.cpp:709
+#: pcbnew/microwave.cpp:712
 msgid "Only one pad for this footprint"
 msgstr "Nur ein Pad für diese Footprint"
 
-#: pcbnew/microwave.cpp:720
+#: pcbnew/microwave.cpp:723
 msgid "Gap:"
 msgstr "Zwischenraum:"
 
-#: pcbnew/microwave.cpp:720
+#: pcbnew/microwave.cpp:723
 msgid "Create Microwave Gap"
 msgstr "Erstelle Microwave Abstand"
 
@@ -25344,54 +24720,43 @@ msgstr "Teilkreisbogen hinzufügen"
 msgid "Add Polynomial Shape"
 msgstr "Polynomische Form hinzufügen"
 
-#: pcbnew/netlist.cpp:204
-msgid "Components"
-msgstr "Bauteile"
-
 #: pcbnew/netlist.cpp:250
 #, c-format
-msgid "No footprint defined for component '%s'.\n"
-msgstr "Es wurde kein Footprint für die Komponente '%s' definiert.\n"
+msgid "No footprint defined for component \"%s\".\n"
+msgstr ""
 
 #: pcbnew/netlist.cpp:272
 #, c-format
 msgid ""
-"Footprint of component '%s' changed: board footprint '%s', netlist footprint "
-"'%s'\n"
+"Footprint of component \"%s\" changed: board footprint \"%s\", netlist "
+"footprint \"%s\"\n"
 msgstr ""
-"Geänderter Footprint des Bauteils '%s': Platinen Footprint '%s', Netzlisten "
-"Footprint '%s'\n"
 
 #: pcbnew/netlist.cpp:302
 #, c-format
-msgid "Component '%s' footprint ID '%s' is not valid.\n"
-msgstr "Bauteil '%s' mit ungültiger Footprint-ID '%s'.\n"
+msgid "Component \"%s\" footprint ID \"%s\" is not valid.\n"
+msgstr ""
 
 #: pcbnew/netlist.cpp:323
 #, c-format
 msgid ""
-"Component '%s' footprint '%s' was not found in any libraries in the "
+"Component \"%s\" footprint \"%s\" was not found in any libraries in the "
 "footprint library table.\n"
 msgstr ""
-"Bauteil '%s' mit Footprint '%s' konnte in keiner Bibliothek der "
-"Footprintbibliothekstabelle gefunden werden.\n"
 
 #: pcbnew/netlist_reader.cpp:181
 #, c-format
 msgid ""
 "invalid footprint ID in\n"
-"file: <%s>\n"
+"file: \"%s\"\n"
 "line: %d"
 msgstr ""
-"Unzulässige Footprint ID in\n"
-"Datei: <%s>\n"
-"Zeile: %d"
 
 #: pcbnew/onleftclick.cpp:259
 msgid "Graphic not allowed on Copper layers"
 msgstr "Auf Kupferlagen sind keine Grafikelemente erlaubt."
 
-#: pcbnew/onleftclick.cpp:283 pcbnew/router/router_tool.cpp:655
+#: pcbnew/onleftclick.cpp:283 pcbnew/router/router_tool.cpp:653
 msgid "Tracks on Copper layers only"
 msgstr "Leiterbahnen nur auf Kupferlagen"
 
@@ -25404,7 +24769,7 @@ msgid "Dimension not allowed on Copper or Edge Cut layers"
 msgstr ""
 "Auf Kupferlagen und der Lage der Außenkanten sind keine Bemaßungen erlaubt."
 
-#: pcbnew/onleftclick.cpp:444
+#: pcbnew/onleftclick.cpp:445
 msgid "This tool is not available in the legacy canvas"
 msgstr "Dieses Werkzeug in nicht möglich in der Legacy Canvas Darstellung."
 
@@ -25546,7 +24911,7 @@ msgstr "Leiterbahn brechen"
 msgid "Place Node"
 msgstr "Knoten platzieren"
 
-#: pcbnew/onrightclick.cpp:578 pcbnew/router/length_tuner_tool.cpp:51
+#: pcbnew/onrightclick.cpp:578 pcbnew/router/length_tuner_tool.cpp:52
 #: pcbnew/router/router_tool.cpp:140
 msgid "End Track"
 msgstr "Leiterbahn beenden"
@@ -25644,7 +25009,7 @@ msgstr "Fläche platzieren"
 msgid "Keepout Area"
 msgstr "Sperrfläche"
 
-#: pcbnew/onrightclick.cpp:729 pcbnew/tools/point_editor.cpp:51
+#: pcbnew/onrightclick.cpp:729 pcbnew/tools/point_editor.cpp:53
 msgid "Create Corner"
 msgstr "Ecke erstellen"
 
@@ -25664,8 +25029,7 @@ msgstr "Fläche für Ausschnitt hinzufügen"
 msgid "Duplicate Zone Onto Layer"
 msgstr "Fläche auf Layer duplizieren"
 
-#: pcbnew/onrightclick.cpp:749 pcbnew/tools/pcb_editor_control.cpp:680
-#: pcbnew/zones_by_polygon_fill_functions.cpp:123
+#: pcbnew/onrightclick.cpp:749 pcbnew/tools/zone_filler_tool.cpp:93
 msgid "Fill Zone"
 msgstr "Fläche füllen"
 
@@ -25768,88 +25132,71 @@ msgstr "Pad (Footprint %s %s) entfernen?"
 #, c-format
 msgid ""
 "invalid floating point number in\n"
-"file: <%s>\n"
+"file: \"%s\"\n"
 "line: %d\n"
 "offset: %d"
 msgstr ""
-"Unzulässige Gleitkommazahl in\n"
-"Datei: <%s>\n"
-"Zeile: %d\n"
-"Spalte: %d"
 
 #: pcbnew/pcb_parser.cpp:144
 #, c-format
 msgid ""
 "missing floating point number in\n"
-"file: <%s>\n"
+"file: \"%s\"\n"
 "line: %d\n"
 "offset: %d"
 msgstr ""
-"Fehlende Gleitkommazahl in\n"
-"Datei: <%s>\n"
-"Zeile: %d\n"
-"Spalte: %d"
 
 #: pcbnew/pcb_parser.cpp:197
 #, c-format
 msgid "cannot interpret date code %d"
 msgstr "Die Datumsangaben sind nicht korrekt %d"
 
-#: pcbnew/pcb_parser.cpp:647
+#: pcbnew/pcb_parser.cpp:669
 #, c-format
 msgid "page type \"%s\" is not valid "
 msgstr "Ungültiger Seitentyp \"%s\""
 
-#: pcbnew/pcb_parser.cpp:879
+#: pcbnew/pcb_parser.cpp:901
 #, c-format
-msgid "Layer '%s' in file '%s' at line %d, is not in fixed layer hash"
+msgid "Layer \"%s\" in file \"%s\" at line %d, is not in fixed layer hash"
 msgstr ""
-"Lage '%s' in Datei '%s' in Zeile %d wurde nicht in der Lagensektion fixiert."
 
-#: pcbnew/pcb_parser.cpp:912
+#: pcbnew/pcb_parser.cpp:934
 #, c-format
 msgid "%d is not a valid layer count"
 msgstr "%d ist keine gültige Lagenanzahl"
 
-#: pcbnew/pcb_parser.cpp:943
+#: pcbnew/pcb_parser.cpp:965
 #, c-format
 msgid ""
-"Layer '%s' in file\n"
-"'%s'\n"
+"Layer \"%s\" in file\n"
+"\"%s\"\n"
 "at line %d, position %d\n"
 "was not defined in the layers section"
 msgstr ""
-"Lage '%s' in Datei\n"
-"'%s'\n"
-"Zeile %d an Position %d\n"
-"wurde nicht in der Lagensektion definiert."
 
-#: pcbnew/pcb_parser.cpp:1329
+#: pcbnew/pcb_parser.cpp:1351
 #, c-format
-msgid "duplicate NETCLASS name '%s' in file <%s> at line %d, offset %d"
-msgstr "NETCLASS Namensduplikat '%s' in Datei <%s>, Zeile %d, Spalte %d."
+msgid "duplicate NETCLASS name \"%s\" in file \"%s\" at line %d, offset %d"
+msgstr ""
 
-#: pcbnew/pcb_parser.cpp:2011
+#: pcbnew/pcb_parser.cpp:2038
 #, c-format
 msgid "cannot handle footprint text type %s"
 msgstr "Kann den Footprint-Texttyp %s nicht verarbeiten."
 
-#: pcbnew/pcb_parser.cpp:2429 pcbnew/pcb_parser.cpp:2435
-#: pcbnew/pcb_parser.cpp:2664 pcbnew/pcb_parser.cpp:2746
-#: pcbnew/pcb_parser.cpp:2810
+#: pcbnew/pcb_parser.cpp:2463 pcbnew/pcb_parser.cpp:2469
+#: pcbnew/pcb_parser.cpp:2698 pcbnew/pcb_parser.cpp:2780
+#: pcbnew/pcb_parser.cpp:2844
 #, c-format
 msgid ""
 "invalid net ID in\n"
-"file: <%s>\n"
+"file: \"%s\"\n"
 "line: %d\n"
 "offset: %d"
 msgstr ""
-"Unzulässige Netz ID in\n"
-"Datei: '%s'\n"
-"Zeile: %d\n"
-"Offset: %d"
 
-#: pcbnew/pcb_parser.cpp:3136
+#: pcbnew/pcb_parser.cpp:3170
 #, c-format
 msgid ""
 "There is a zone that belongs to a not existing net\n"
@@ -25861,14 +25208,14 @@ msgstr ""
 
 #: pcbnew/pcbframe.cpp:664
 #, c-format
-msgid "The auto save file '%s' could not be removed!"
-msgstr "Die automatisch gespeicherte Datei '%s' konnte nicht gelöscht werden!"
+msgid "The auto save file \"%s\" could not be removed!"
+msgstr ""
 
-#: pcbnew/pcbframe.cpp:1046
+#: pcbnew/pcbframe.cpp:1039
 msgid " [new file]"
 msgstr " [neue Datei]"
 
-#: pcbnew/pcbframe.cpp:1186
+#: pcbnew/pcbframe.cpp:1179
 msgid ""
 "Cannot update the PCB, because Pcbnew is opened in stand-alone mode. In "
 "order to create or update PCBs from schematics, you need to launch the KiCad "
@@ -25936,71 +25283,71 @@ msgstr ""
 msgid "Multiple Layers"
 msgstr "Mehrere Lagen"
 
-#: pcbnew/router/length_tuner_tool.cpp:48 pcbnew/router/router_tool.cpp:137
+#: pcbnew/router/length_tuner_tool.cpp:49 pcbnew/router/router_tool.cpp:137
 msgid "New Track"
 msgstr "Neue Leiterbahn"
 
-#: pcbnew/router/length_tuner_tool.cpp:48 pcbnew/router/router_tool.cpp:137
+#: pcbnew/router/length_tuner_tool.cpp:49 pcbnew/router/router_tool.cpp:137
 msgid "Starts laying a new track."
 msgstr "Einen neuen Leiterzug/Leiterbahn verlegen"
 
-#: pcbnew/router/length_tuner_tool.cpp:51
+#: pcbnew/router/length_tuner_tool.cpp:52
 msgid "Stops laying the current meander."
 msgstr "Beendet die Mäanderung des aktuellen Leiterzuges."
 
-#: pcbnew/router/length_tuner_tool.cpp:54
+#: pcbnew/router/length_tuner_tool.cpp:55
 msgid "Length Tuning Settings"
 msgstr "Einstellungen Leiterbahnlängen Tuning"
 
-#: pcbnew/router/length_tuner_tool.cpp:54
+#: pcbnew/router/length_tuner_tool.cpp:55
 msgid "Sets the length tuning parameters for currently routed item."
 msgstr "Verändern der Längeneinstellungen für das aktuelle Element."
 
-#: pcbnew/router/length_tuner_tool.cpp:57
+#: pcbnew/router/length_tuner_tool.cpp:59
 msgid "Increase spacing"
 msgstr "Abstand vergrößern"
 
-#: pcbnew/router/length_tuner_tool.cpp:57
+#: pcbnew/router/length_tuner_tool.cpp:59
 msgid "Increase meander spacing by one step."
 msgstr "Erhöhen des Mäander Abstands um einen Stufe."
 
-#: pcbnew/router/length_tuner_tool.cpp:60
+#: pcbnew/router/length_tuner_tool.cpp:63
 msgid "Decrease spacing"
 msgstr "Abstand verkleinern"
 
-#: pcbnew/router/length_tuner_tool.cpp:60
+#: pcbnew/router/length_tuner_tool.cpp:63
 msgid "Decrease meander spacing by one step."
 msgstr "Verkleinern des Mäander Abstands um einen Stufe."
 
-#: pcbnew/router/length_tuner_tool.cpp:63
+#: pcbnew/router/length_tuner_tool.cpp:67
 msgid "Increase amplitude"
 msgstr "Schwingungsweite vergrößern"
 
-#: pcbnew/router/length_tuner_tool.cpp:63
+#: pcbnew/router/length_tuner_tool.cpp:67
 msgid "Increase meander amplitude by one step."
 msgstr "Erhöhen des Mäander Schwingungsabstands um einen Stufe."
 
-#: pcbnew/router/length_tuner_tool.cpp:66
+#: pcbnew/router/length_tuner_tool.cpp:71
 msgid "Decrease amplitude"
 msgstr "Schwingungsweite verkleinern"
 
-#: pcbnew/router/length_tuner_tool.cpp:66
+#: pcbnew/router/length_tuner_tool.cpp:71
 msgid "Decrease meander amplitude by one step."
 msgstr "Verkleinern des Mäander Schwingungsabstands um einen Stufe."
 
-#: pcbnew/router/length_tuner_tool.cpp:80
+#: pcbnew/router/length_tuner_tool.cpp:86
 msgid "Length Tuner"
 msgstr "Längen Abstimmung"
 
-#: pcbnew/router/length_tuner_tool.cpp:212
+#: pcbnew/router/length_tuner_tool.cpp:219
 msgid "Tune Trace Length"
 msgstr "Anpassen Leiterbahnlänge"
 
-#: pcbnew/router/length_tuner_tool.cpp:219
+#: pcbnew/router/length_tuner_tool.cpp:226
 msgid "Tune Diff Pair Length"
 msgstr "Anpassen Länge differenzielles Signalpaar"
 
-#: pcbnew/router/length_tuner_tool.cpp:226
+#: pcbnew/router/length_tuner_tool.cpp:233
 msgid "Tune Diff Pair Skew"
 msgstr "Anpassen des Versatzes eines differenziellem Signalpaares"
 
@@ -26113,6 +25460,11 @@ msgstr "Interaktives Routen (differenzielle Paare)"
 #: pcbnew/router/router_tool.cpp:88
 msgid "Run push & shove router (differential pairs)"
 msgstr "Starte Interaktives Routen eines differenziellem Signalpaares"
+
+#: pcbnew/router/router_tool.cpp:92
+#: pcbnew/dialogs/dialog_pns_settings_base.h:71
+msgid "Interactive Router Settings"
+msgstr "Einstellungen des interaktiven Routers"
 
 #: pcbnew/router/router_tool.cpp:93
 msgid "Open Interactive Router settings"
@@ -26264,24 +25616,24 @@ msgstr "Verwende Leiterbahn- und DuKo-Größen aus der Netzklasse"
 msgid "Interactive Router"
 msgstr "Interaktiver Router"
 
-#: pcbnew/router/router_tool.cpp:531
+#: pcbnew/router/router_tool.cpp:529
 msgid "Blind/buried vias have to be enabled in the design settings."
 msgstr ""
 "Blinde/vergrabene DoKu's müssen in den Design Einstellungen eingeschaltet "
 "werden."
 
-#: pcbnew/router/router_tool.cpp:537
+#: pcbnew/router/router_tool.cpp:535
 msgid "Microvias have to be enabled in the design settings."
 msgstr ""
 "Mikro-Durchkontaktierungen müssen in den Design Einstellungen eingeschaltet "
 "werden."
 
-#: pcbnew/router/router_tool.cpp:544
+#: pcbnew/router/router_tool.cpp:542
 msgid "Only through vias are allowed on 2 layer boards."
 msgstr ""
 "Auf 2-Lagen Platinen sind nur durchgehende Durchkontaktierungen erlaubt."
 
-#: pcbnew/router/router_tool.cpp:551
+#: pcbnew/router/router_tool.cpp:549
 msgid ""
 "Microvias can be placed only between the outer layers (F.Cu/B.Cu) and the "
 "ones directly adjacent to them."
@@ -26289,15 +25641,15 @@ msgstr ""
 "Micro-Durchkontaktierungen können nur jeweils zwischen den äußersten Lagen "
 "(F.Cu/B.Cu) und den direkt anliegenden Lagen platziert werden."
 
-#: pcbnew/router/router_tool.cpp:832
+#: pcbnew/router/router_tool.cpp:830
 msgid "Route Track"
 msgstr "Route Leiterbahnen"
 
-#: pcbnew/router/router_tool.cpp:839
+#: pcbnew/router/router_tool.cpp:837
 msgid "Router Differential Pair"
 msgstr "Route Differenzielles Paar"
 
-#: pcbnew/router/router_tool.cpp:946 pcbnew/router/router_tool.cpp:1017
+#: pcbnew/router/router_tool.cpp:934 pcbnew/router/router_tool.cpp:1005
 msgid "The item is locked. Do you want to continue?"
 msgstr ""
 "Die Auswahl enthält gesperrte Elemente.\n"
@@ -26307,23 +25659,23 @@ msgstr ""
 msgid "Warning: The Top Layer and Bottom Layer are same."
 msgstr "Achtung: Bestückungsseite und Lötseite sind die selben."
 
-#: pcbnew/specctra_export.cpp:149
+#: pcbnew/specctra_export.cpp:146
 msgid "BOARD exported OK."
 msgstr "Platine erfolgreich exportiert"
 
-#: pcbnew/specctra_export.cpp:154
+#: pcbnew/specctra_export.cpp:151
 msgid "Unable to export, please fix and try again"
 msgstr "Export nicht möglich. Bitte das Problem beheben und erneut versuchen."
 
-#: pcbnew/specctra_export.cpp:809
+#: pcbnew/specctra_export.cpp:806
 #, c-format
-msgid "Component with value of '%s' has empty reference id."
-msgstr "Das Bauteil mit dem Wert '%s' hat keine Referenz-ID."
+msgid "Component with value of \"%s\" has empty reference id."
+msgstr ""
 
-#: pcbnew/specctra_export.cpp:817
+#: pcbnew/specctra_export.cpp:814
 #, c-format
-msgid "Multiple components have identical reference IDs of '%s'."
-msgstr "Mehrere Bauteile verfügen über die selbe Referenz-ID '%s'."
+msgid "Multiple components have identical reference IDs of \"%s\"."
+msgstr ""
 
 #: pcbnew/specctra_import.cpp:78
 msgid "Merge Specctra Session file:"
@@ -26439,6 +25791,10 @@ msgstr "Footprint importieren"
 #: pcbnew/tool_modedit.cpp:105
 msgid "Export footprint"
 msgstr "Footprint exportieren"
+
+#: pcbnew/tool_modedit.cpp:110 pcbnew/help_common_strings.h:15
+msgid "Undo last edition"
+msgstr "Letzte Änderung rückgängig machen"
 
 #: pcbnew/tool_modedit.cpp:112
 msgid "Redo last undo command"
@@ -27003,14 +26359,10 @@ msgid "Copy selected content to clipboard"
 msgstr "Kopiert die Auswahl in die Zwischenablage"
 
 #: pcbnew/tools/edit_tool.cpp:174
-msgid "Cut"
-msgstr "Ausschneiden"
-
-#: pcbnew/tools/edit_tool.cpp:174
 msgid "Cut selected content to clipboard"
 msgstr "Ausschneiden der Auswahl in die Zwischenablage"
 
-#: pcbnew/tools/edit_tool.cpp:605
+#: pcbnew/tools/edit_tool.cpp:604
 msgid "Edit track width/via size"
 msgstr "Eigenschaften der Leiterbahnbreite und Größe der Durchkontaktierung"
 
@@ -27158,108 +26510,56 @@ msgstr ""
 msgid "Copy the current pad settings to other pads"
 msgstr "Kopiere aktuelle Pad-Einstellungen zu anderen Pads"
 
-#: pcbnew/tools/pcb_editor_control.cpp:89
-msgid "Fill"
-msgstr "Füllen"
-
-#: pcbnew/tools/pcb_editor_control.cpp:89
-msgid "Fill zone(s)"
-msgstr "Fülle Fläche(n)"
-
-#: pcbnew/tools/pcb_editor_control.cpp:93
-msgid "Fill All"
-msgstr "Alles ausfüllen"
-
-#: pcbnew/tools/pcb_editor_control.cpp:93
-msgid "Fill all zones"
-msgstr "Fülle alle Flächen"
-
-#: pcbnew/tools/pcb_editor_control.cpp:97
-msgid "Unfill"
-msgstr "Flächenfüllung entfernen"
-
-#: pcbnew/tools/pcb_editor_control.cpp:97
-msgid "Unfill zone(s)"
-msgstr "Flächenfüllung(en) entfernen"
-
-#: pcbnew/tools/pcb_editor_control.cpp:101
-msgid "Unfill All"
-msgstr "Alle Füllungen entfernen"
-
-#: pcbnew/tools/pcb_editor_control.cpp:101
-msgid "Unfill all zones"
-msgstr "Alle Flächenfüllungen entfernen"
-
-#: pcbnew/tools/pcb_editor_control.cpp:105
+#: pcbnew/tools/pcb_editor_control.cpp:95
 msgid "Merge Zones"
 msgstr "Flächen verbinden"
 
-#: pcbnew/tools/pcb_editor_control.cpp:105
-#: pcbnew/tools/pcb_editor_control.cpp:881
+#: pcbnew/tools/pcb_editor_control.cpp:95
+#: pcbnew/tools/pcb_editor_control.cpp:704
 msgid "Merge zones"
 msgstr "Flächen verbinden"
 
-#: pcbnew/tools/pcb_editor_control.cpp:109
+#: pcbnew/tools/pcb_editor_control.cpp:99
 msgid "Duplicate Zone onto Layer"
 msgstr "Fläche auf Layer duplizieren"
 
-#: pcbnew/tools/pcb_editor_control.cpp:109
+#: pcbnew/tools/pcb_editor_control.cpp:99
 msgid "Duplicate zone outline onto a different layer"
 msgstr "Duplizieren der Fläche auf einen anderen Layer"
 
-#: pcbnew/tools/pcb_editor_control.cpp:115
+#: pcbnew/tools/pcb_editor_control.cpp:105
 msgid "Add Layer Alignment Target"
 msgstr "Orientierungspunkt hinzufügen"
 
-#: pcbnew/tools/pcb_editor_control.cpp:115
+#: pcbnew/tools/pcb_editor_control.cpp:105
 msgid "Add a layer alignment target"
 msgstr "Orientierungspunkt hinzufügen"
 
-#: pcbnew/tools/pcb_editor_control.cpp:119
+#: pcbnew/tools/pcb_editor_control.cpp:109
 msgid "Add a footprint"
 msgstr "Footprint hinzufügen"
 
-#: pcbnew/tools/pcb_editor_control.cpp:135
+#: pcbnew/tools/pcb_editor_control.cpp:125
 msgid "Lock"
 msgstr "Gesperrt"
 
-#: pcbnew/tools/pcb_editor_control.cpp:139
+#: pcbnew/tools/pcb_editor_control.cpp:129
 msgid "Unlock"
 msgstr "Entsperren"
 
-#: pcbnew/tools/pcb_editor_control.cpp:221
+#: pcbnew/tools/pcb_editor_control.cpp:212
 msgid "Locking"
 msgstr "Sperren"
 
-#: pcbnew/tools/pcb_editor_control.cpp:481
+#: pcbnew/tools/pcb_editor_control.cpp:446
 msgid "Place a module"
 msgstr "Place a module"
 
-#: pcbnew/tools/pcb_editor_control.cpp:632
+#: pcbnew/tools/pcb_editor_control.cpp:587
 msgid "Place a layer alignment target"
 msgstr "Orientierungspunkt hinzufügen"
 
-#: pcbnew/tools/pcb_editor_control.cpp:693
-#: pcbnew/zones_by_polygon_fill_functions.cpp:49
-#, c-format
-msgid "Filling zone %d out of %d (net %s)..."
-msgstr "Fülle Fläche %d von %d (Netz %s) ..."
-
-#: pcbnew/tools/pcb_editor_control.cpp:701
-#: pcbnew/tools/pcb_editor_control.cpp:729
-#: pcbnew/zones_by_polygon_fill_functions.cpp:147
-msgid "Fill All Zones"
-msgstr "Fülle alle Flächen"
-
-#: pcbnew/tools/pcb_editor_control.cpp:758
-msgid "Unfill Zone"
-msgstr "Flächenfüllung(en) entfernen"
-
-#: pcbnew/tools/pcb_editor_control.cpp:783
-msgid "Unfill All Zones"
-msgstr "Alle Flächenfüllungen entfernen"
-
-#: pcbnew/tools/pcb_editor_control.cpp:929
+#: pcbnew/tools/pcb_editor_control.cpp:752
 msgid ""
 "The duplicated keepout zone cannot be on the same layers as the original "
 "zone."
@@ -27267,17 +26567,17 @@ msgstr ""
 "Die duplizierte Sperrfläche kann nicht auf der selben Lage liegen wie die "
 "originale Fläche."
 
-#: pcbnew/tools/pcb_editor_control.cpp:935 pcbnew/zones_by_polygon.cpp:141
+#: pcbnew/tools/pcb_editor_control.cpp:758 pcbnew/zones_by_polygon.cpp:143
 msgid "The duplicated zone cannot be on the same layer as the original zone."
 msgstr ""
 "Die duplizierte Fläche kann nicht auf der selben Lage liegen wie die "
 "originale Fläche."
 
-#: pcbnew/tools/pcb_editor_control.cpp:947
+#: pcbnew/tools/pcb_editor_control.cpp:770
 msgid "Duplicate zone"
 msgstr "Element duplizieren"
 
-#: pcbnew/tools/pcb_editor_control.cpp:1151
+#: pcbnew/tools/pcb_editor_control.cpp:988
 msgid "Pick Components for Local Ratsnest"
 msgstr "Auswahl Bauteile für Lokale Netzlinien"
 
@@ -27366,47 +26666,47 @@ msgstr "Oben ausrichten"
 msgid "Align to bottom"
 msgstr "Unten ausrichten"
 
-#: pcbnew/tools/placement_tool.cpp:219
+#: pcbnew/tools/placement_tool.cpp:234
 msgid "Align to left"
 msgstr "Links ausrichten"
 
-#: pcbnew/tools/placement_tool.cpp:256
+#: pcbnew/tools/placement_tool.cpp:286
 msgid "Align to right"
 msgstr "Rechts ausrichten"
 
-#: pcbnew/tools/placement_tool.cpp:311
+#: pcbnew/tools/placement_tool.cpp:341
 msgid "Distribute horizontally"
 msgstr "Horizontal verteilen"
 
-#: pcbnew/tools/placement_tool.cpp:354
+#: pcbnew/tools/placement_tool.cpp:384
 msgid "Distribute vertically"
 msgstr "Vertikal verteilen"
 
-#: pcbnew/tools/point_editor.cpp:51
+#: pcbnew/tools/point_editor.cpp:53
 msgid "Create a corner"
 msgstr "Rundung erstellen"
 
-#: pcbnew/tools/point_editor.cpp:55
+#: pcbnew/tools/point_editor.cpp:57
 msgid "Remove Corner"
 msgstr "Rundung entfernen"
 
-#: pcbnew/tools/point_editor.cpp:55
+#: pcbnew/tools/point_editor.cpp:57
 msgid "Remove corner"
 msgstr "Rundung entfernen"
 
-#: pcbnew/tools/point_editor.cpp:347
+#: pcbnew/tools/point_editor.cpp:349
 msgid "Drag a line ending"
 msgstr "Linienende ziehen"
 
-#: pcbnew/tools/point_editor.cpp:875
+#: pcbnew/tools/point_editor.cpp:903
 msgid "Add a zone corner"
 msgstr "Gefüllte Flächen hinzufügen"
 
-#: pcbnew/tools/point_editor.cpp:914
+#: pcbnew/tools/point_editor.cpp:942
 msgid "Split segment"
 msgstr "Segment aufsplitten"
 
-#: pcbnew/tools/point_editor.cpp:963
+#: pcbnew/tools/point_editor.cpp:1011
 msgid "Remove a zone/polygon corner"
 msgstr "Gefüllte Fläche/Polygon entfernen"
 
@@ -27419,6 +26719,11 @@ msgid "Positions the selected item(s) by an exact amount relative to another"
 msgstr ""
 "Die ausgewählte(n) Element(e) exakt zu anderen durch einen exakten Werte "
 "verschieben."
+
+#: pcbnew/tools/position_relative_tool.cpp:152
+#: pcbnew/dialogs/dialog_position_relative_base.h:76
+msgid "Position Relative"
+msgstr "Relative Position"
 
 #: pcbnew/tools/selection_tool.cpp:94
 msgid "Trivial Connection"
@@ -27473,13 +26778,13 @@ msgstr "Filtern der Art der Elemente in der Auswahl"
 msgid "Select..."
 msgstr "Wähle ..."
 
-#: pcbnew/tools/selection_tool.cpp:682
+#: pcbnew/tools/selection_tool.cpp:685
 msgid "Selection contains locked items. Do you want to continue?"
 msgstr ""
 "Die Auswahl enthält gesperrte Elemente.\n"
 "Möchten Sie trotzdem fortfahren?"
 
-#: pcbnew/tools/selection_tool.cpp:1253
+#: pcbnew/tools/selection_tool.cpp:1256
 msgid "Filter selection"
 msgstr "Filter Auswahl"
 
@@ -27507,60 +26812,2493 @@ msgstr ", Bohrung: Voreinstellung"
 msgid ", drill: "
 msgstr ", Bohrung:"
 
-#: pcbnew/tools/zone_create_helper.cpp:154
+#: pcbnew/tools/zone_create_helper.cpp:156
 msgid "Add a zone cutout"
 msgstr "Eine gefüllte Fläche hinzufügen"
 
-#: pcbnew/tools/zone_create_helper.cpp:166
+#: pcbnew/tools/zone_create_helper.cpp:171
 msgid "Add a zone"
 msgstr "Eine Fläche hinzufügen"
 
-#: pcbnew/tools/zone_create_helper.cpp:179
+#: pcbnew/tools/zone_create_helper.cpp:184
 msgid "Add a graphical polygon"
 msgstr "Ein grafisches Polygon hinzufügen"
 
-#: pcbnew/zones_by_polygon.cpp:135
+#: pcbnew/tools/zone_filler_tool.cpp:47
+msgid "Fill"
+msgstr "Füllen"
+
+#: pcbnew/tools/zone_filler_tool.cpp:47
+msgid "Fill zone(s)"
+msgstr "Fülle Fläche(n)"
+
+#: pcbnew/tools/zone_filler_tool.cpp:51
+msgid "Fill All"
+msgstr "Alles ausfüllen"
+
+#: pcbnew/tools/zone_filler_tool.cpp:51
+msgid "Fill all zones"
+msgstr "Fülle alle Flächen"
+
+#: pcbnew/tools/zone_filler_tool.cpp:55
+msgid "Unfill"
+msgstr "Flächenfüllung entfernen"
+
+#: pcbnew/tools/zone_filler_tool.cpp:55
+msgid "Unfill zone(s)"
+msgstr "Flächenfüllung(en) entfernen"
+
+#: pcbnew/tools/zone_filler_tool.cpp:59
+msgid "Unfill All"
+msgstr "Alle Füllungen entfernen"
+
+#: pcbnew/tools/zone_filler_tool.cpp:59
+msgid "Unfill all zones"
+msgstr "Alle Flächenfüllungen entfernen"
+
+#: pcbnew/tools/zone_filler_tool.cpp:116
+#: pcbnew/zones_by_polygon_fill_functions.cpp:103
+msgid "Fill All Zones"
+msgstr "Fülle alle Flächen"
+
+#: pcbnew/tools/zone_filler_tool.cpp:143
+msgid "Unfill Zone"
+msgstr "Flächenfüllung(en) entfernen"
+
+#: pcbnew/tools/zone_filler_tool.cpp:161
+msgid "Unfill All Zones"
+msgstr "Alle Flächenfüllungen entfernen"
+
+#: pcbnew/zone_filler.cpp:115
+msgid "Calculating zone fills..."
+msgstr ""
+
+#: pcbnew/zone_filler.cpp:157
+msgid "Removing insulated copper islands..."
+msgstr ""
+
+#: pcbnew/zone_filler.cpp:179
+msgid "Caching polygon triangulations..."
+msgstr ""
+
+#: pcbnew/zone_filler.cpp:210
+msgid "Committing changes..."
+msgstr ""
+
+#: pcbnew/zone_filler.cpp:217
+msgid "Fill Zone(s)"
+msgstr ""
+
+#: pcbnew/zones_by_polygon.cpp:137
 msgid "The duplicated zone cannot be on the same layers as the original zone."
 msgstr ""
 "Die duplizierte Fläche kann nicht auf den selben Lagen liegen wie die "
 "originale Fläche."
 
-#: pcbnew/zones_by_polygon.cpp:171
+#: pcbnew/zones_by_polygon.cpp:175
 msgid "Warning: The new zone fails DRC"
 msgstr "Warnung: Die neue Fläche verletzt den DRC."
 
-#: pcbnew/zones_by_polygon.cpp:372 pcbnew/zones_by_polygon.cpp:430
-#: pcbnew/zones_by_polygon.cpp:816
+#: pcbnew/zones_by_polygon.cpp:377 pcbnew/zones_by_polygon.cpp:436
+#: pcbnew/zones_by_polygon.cpp:823
 msgid "Area: DRC outline error"
 msgstr "Bereich: DRC Umriss Fehler"
 
-#: pcbnew/zones_by_polygon.cpp:545
+#: pcbnew/zones_by_polygon.cpp:551
 msgid "Error: a keepout area is allowed only on copper layers"
 msgstr "Fehler: Eine Sperrfläche ist nur auf Kupferlagen zulässig"
 
-#: pcbnew/zones_by_polygon.cpp:690
+#: pcbnew/zones_by_polygon.cpp:696
 msgid "DRC error: this start point is inside or too close an other area"
 msgstr ""
 "DRC Fehler: Der Anfangspunkt ist innerhalb einer anderen Fläche oder dieser "
 "zu nahe."
 
-#: pcbnew/zones_by_polygon.cpp:755
+#: pcbnew/zones_by_polygon.cpp:761
 msgid "DRC error: closing this area creates a DRC error with an other area"
 msgstr ""
 "DRC Fehler: Der Abschluss dieser Fläche erzeugt einen DRC Fehler gegenüber "
 "einer anderen Fläche."
 
-#: pcbnew/zones_by_polygon.cpp:912 pcbnew/zones_by_polygon.cpp:962
+#: pcbnew/zones_by_polygon.cpp:919 pcbnew/zones_by_polygon.cpp:970
 msgid "Modify zone properties"
 msgstr "Flächeneigenschaften editieren"
 
-#: pcbnew/zones_by_polygon_fill_functions.cpp:153
-msgid "Starting zone fill..."
-msgstr "Beginne Flächen zu füllen ..."
+#: 3d-viewer/3d_cache/dialogs/dlg_3d_pathconfig_base.h:64
+msgid "3D Search Path Configuration"
+msgstr "3D-Suchpfad-Konfiguration"
 
-#: pcbnew/zones_by_polygon_fill_functions.cpp:184
-msgid "Updating ratsnest..."
-msgstr "Aktualisiere Netzlinien ..."
+#: 3d-viewer/3d_viewer/dialogs/dialog_3D_view_option_base.h:79
+msgid "3D Display Options"
+msgstr "3D-Anzeigeoptionen"
+
+#: bitmap2component/bitmap2cmp_gui_base.h:92
+msgid "Bitmap to Component Converter"
+msgstr "Bitmap zu Bauteil Konverter"
+
+#: common/dialog_about/dialog_about_base.h:56
+msgid "About"
+msgstr "Über"
+
+#: common/dialogs/dialog_env_var_config_base.h:66
+msgid "Path Configuration"
+msgstr "Pfadkonfiguration"
+
+#: common/dialogs/dialog_env_var_config_base.h:97
+msgid "Edit Environment Value Variable"
+msgstr "Bearbeiten Umgebungsvariable"
+
+#: common/dialogs/dialog_hotkeys_editor_base.h:55
+msgid "Hotkeys Editor"
+msgstr "Editor für Tastaturbefehle"
+
+#: common/dialogs/dialog_image_editor_base.h:64
+msgid "Image Editor"
+msgstr "Bildeditor"
+
+#: common/dialogs/dialog_page_settings_base.h:121
+msgid "Page Settings"
+msgstr "Seite einrichten"
+
+#: eeschema/dialogs/dialog_annotate_base.h:89
+msgid "Annotate Schematic"
+msgstr "Annotation des Schaltplans"
+
+#: eeschema/dialogs/dialog_bom_base.h:97
+msgid "Bill of Material"
+msgstr "Stückliste (BOM)"
+
+#: eeschema/dialogs/dialog_bom_editor_base.h:74
+msgid "BOM editor"
+msgstr "BOM Editor"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.h:114
+#: eeschema/dialogs/dialog_lib_new_component_base.h:62
+msgid "Component Properties"
+msgstr "Bauteileigenschaften"
+
+#: eeschema/dialogs/dialog_edit_components_libid_base.h:66
+msgid "Edit Components Links to Symbols in Libraries"
+msgstr ""
+
+#: eeschema/dialogs/dialog_edit_label_base.h:70
+msgid "Text Editor"
+msgstr "Text Editor"
+
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.h:95
+msgid "Field Properties"
+msgstr "Feldeigenschaften"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.h:129
+msgid "Schematic Editor Options"
+msgstr "Einstellungen Schaltplaneditor"
+
+#: eeschema/dialogs/dialog_erc_base.h:90
+msgid "Electrical Rules Checker"
+msgstr "Elektrischer Regel Check"
+
+#: eeschema/dialogs/dialog_global_sym_lib_table_config_base.h:58
+msgid "Configure Global Symbol Library Table"
+msgstr "Konfiguriere globale Symbol Bibliothekstabelle"
+
+#: eeschema/dialogs/dialog_lib_edit_draw_item_base.h:62
+msgid "Drawing Properties"
+msgstr "Darstellungs Eigenschaften"
+
+#: eeschema/dialogs/dialog_lib_edit_pin_base.h:107
+msgid "Pin Properties"
+msgstr "Pin Eigenschaften"
+
+#: eeschema/dialogs/dialog_lib_edit_pin_table_base.h:50
+msgid "Pin Table"
+msgstr "Pinname"
+
+#: eeschema/dialogs/dialog_lib_edit_text_base.h:69
+msgid "Library Text Properties"
+msgstr "Bauteilbibliothek - Texteigenschaften"
+
+#: eeschema/dialogs/dialog_libedit_options_base.h:78
+msgid "Library Editor Options"
+msgstr "Bibliothekseditor Optionen"
+
+#: eeschema/dialogs/dialog_netlist_base.h:78
+#: pcbnew/dialogs/dialog_netlist_fbp.h:84
+msgid "Netlist"
+msgstr "Netzliste"
+
+#: eeschema/dialogs/dialog_netlist_base.h:119
+msgid "Plugins:"
+msgstr "Plugins:"
+
+#: eeschema/dialogs/dialog_plot_schematic_base.h:85
+msgid "Plot Schematic Options"
+msgstr "Optionen Schaltplan Plotten"
+
+#: eeschema/dialogs/dialog_sch_edit_sheet_pin_base.h:56
+msgid "Sheet Pin Properties"
+msgstr "Schaltplanpin Eigenschaften"
+
+#: eeschema/dialogs/dialog_sch_sheet_props_base.h:60
+msgid "Schematic Sheet Properties"
+msgstr "Schaltplan Eigenschaften"
+
+#: eeschema/dialogs/dialog_spice_model_base.h:177
+msgid "Spice Model Editor"
+msgstr "Spice-Modell Editor"
+
+#: eeschema/dialogs/dialog_sym_lib_table_base.h:75
+msgid "Schematic Library Tables"
+msgstr "Tabelle Bauteilbibliotheken"
+
+#: eeschema/dialogs/dialog_update_fields_base.h:58
+msgid "Update symbol fields"
+msgstr "Symbolfelder aktualisieren"
+
+#: eeschema/help_common_strings.h:40
+msgid "Undo last command"
+msgstr "Letzte Änderung rückgängig machen"
+
+#: eeschema/help_common_strings.h:41
+msgid "Redo last command"
+msgstr "Wiederherstellen des letzten Rückgängigmachens"
+
+#: eeschema/help_common_strings.h:45
+msgid "Fit schematic sheet on screen"
+msgstr "Schaltplan an Bildschirmgöße anpassen"
+
+#: eeschema/help_common_strings.h:46
+msgid "Redraw schematic view"
+msgstr "Schaltplandarstellung neu zeichnen"
+
+#: eeschema/help_common_strings.h:51
+msgid "Find components and text"
+msgstr "Bauteil und Text suchen"
+
+#: eeschema/help_common_strings.h:52
+msgid "Find and replace text in schematic items"
+msgstr "Suchen und Ersetzen von Text in Schaltplanelementen"
+
+#: eeschema/help_common_strings.h:53
+msgid "Place component"
+msgstr "Bauteil hinzufügen"
+
+#: eeschema/help_common_strings.h:54
+msgid "Place power port"
+msgstr "Spannungsquelle hinzufügen"
+
+#: eeschema/help_common_strings.h:55
+msgid "Place wire"
+msgstr "Elektr. Verbindung hinzufügen"
+
+#: eeschema/help_common_strings.h:56
+msgid "Place bus"
+msgstr "Einen Bus verlegen"
+
+#: eeschema/help_common_strings.h:57
+msgid "Place wire to bus entry"
+msgstr "Elektr. Verbindung an Buseingang führen"
+
+#: eeschema/help_common_strings.h:58
+msgid "Place bus to bus entry"
+msgstr "Buseingang zu Buseingang führen"
+
+#: eeschema/help_common_strings.h:59
+msgid "Place not-connected flag"
+msgstr "'Keine-Verbindung' Symbol hinzufügen"
+
+#: eeschema/help_common_strings.h:61
+msgid "Place net name - local label"
+msgstr "Netznamen - lokales Label hinzufügen"
+
+#: eeschema/help_common_strings.h:64
+msgid ""
+"Place global label.\n"
+"Warning: inside global hierarchy , all global labels with same name are "
+"connected"
+msgstr ""
+"Ein globales Label hinzufügen.\n"
+"Warnung: Alle globalen Label mit dem selben Namen sind in der gesamten "
+"Hierarchie miteinander verbunden."
+
+#: eeschema/help_common_strings.h:66
+msgid ""
+"Place a hierarchical label. Label will be seen as a hierarchical pin in the "
+"sheet symbol"
+msgstr ""
+"Ein hierarchisches Label hinzufügen. Dieses Label wird als ein Pin am "
+"Schaltungssymbol betrachtet."
+
+#: eeschema/help_common_strings.h:68
+msgid "Place junction"
+msgstr "Knotenpunkt hinzufügen"
+
+#: eeschema/help_common_strings.h:69
+msgid "Create hierarchical sheet"
+msgstr "Einen hierarchischen Schaltplan erstellen"
+
+#: eeschema/help_common_strings.h:71
+msgid ""
+"Place hierarchical pin imported from the corresponding hierarchical label"
+msgstr ""
+"Hierarchischen Pin hinzufügen, importiert aus entsprechendem hierarchischen "
+"Label."
+
+#: eeschema/help_common_strings.h:72
+msgid "Place hierarchical pin in sheet"
+msgstr "Hierarchischen Pin dem Schaltplan hinzufügen"
+
+#: eeschema/help_common_strings.h:73
+msgid "Place graphic lines or polygons"
+msgstr "Grafische Linien oder Polygone hinzufügen"
+
+#: eeschema/help_common_strings.h:74
+msgid "Place text"
+msgstr "Text hinzufügen"
+
+#: eeschema/help_common_strings.h:76
+msgid "Annotate schematic components"
+msgstr "Annotation im Schaltplan durchführen"
+
+#: eeschema/help_common_strings.h:77
+msgid "Library Editor - Create/edit components"
+msgstr "Bibliothekseditor - Bauteile erstellen oder bearbeiten"
+
+#: eeschema/help_common_strings.h:78
+msgid "Library Browser - Browse components"
+msgstr "Bibliotheksbrowser - Bauteilbestand durchsuchen"
+
+#: eeschema/help_common_strings.h:79
+msgid "Generate bill of materials"
+msgstr "Stückliste (BOM) erstellen"
+
+#: eeschema/help_common_strings.h:81
+msgid ""
+"Back-import component footprint association fields from the .cmp back import "
+"file created by Pcbnew"
+msgstr ""
+"Rückimport von Bauteil Footprintfeldern durch eine in Pcbnew erstellte "
+"CvPvb .cmp Datei."
+
+#: eeschema/help_common_strings.h:84
+msgid "Add pins to component"
+msgstr "Pins dem Bauteil hinzufügen"
+
+#: eeschema/help_common_strings.h:85
+msgid "Add text to component body"
+msgstr "Text dem Bauteil hinzufügen"
+
+#: eeschema/help_common_strings.h:86
+msgid "Add graphic rectangle to component body"
+msgstr "Rechteck hinzufügen"
+
+#: eeschema/help_common_strings.h:87
+msgid "Add circles to component body"
+msgstr "Kreis hinzufügen"
+
+#: eeschema/help_common_strings.h:88
+msgid "Add arcs to component body"
+msgstr "Bögen hinzufügen"
+
+#: eeschema/help_common_strings.h:89
+msgid "Add lines and polygons to component body"
+msgstr "Linien und Polygone hinzufügen"
+
+#: eeschema/sch_bitmap.h:129
+msgid "Image"
+msgstr "Bil&d"
+
+#: eeschema/sch_marker.h:97
+msgid "ERC Marker"
+msgstr "ERC Marker"
+
+#: eeschema/sch_no_connect.h:84
+msgid "No Connect"
+msgstr "Keine-Verbindung"
+
+#: eeschema/sim/sim_plot_frame_base.h:108
+msgid "Spice Simulator"
+msgstr "Spice Simulator"
+
+#: gerbview/dialogs/dialog_show_page_borders_base.h:50
+msgid "Page Borders"
+msgstr "Seitenbegrenzung"
+
+#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.h:63
+msgid "Gerbview Options"
+msgstr "GerbView Optionen"
+
+#: include/class_drc_item.h:164
+#, c-format
+msgid "ErrType(%d): <b>%s</b><ul><li> %s </li></ul>"
+msgstr "Fehler Type(%d): <b>%s</b><ul><li> %s </li></ul>"
+
+#: include/class_drc_item.h:177
+#, c-format
+msgid "ErrType(%d): <b>%s</b><ul><li> %s: %s </li><li> %s: %s </li></ul>"
+msgstr "Fehler Type(%d): <b>%s</b><ul><li> %s: %s </li><li> %s: %s </li></ul>"
+
+#: include/class_drc_item.h:185
+#, c-format
+msgid "ErrType(%d): <b>%s</b><ul><li> %s: %s </li></ul>"
+msgstr "Fehler Type(%d): <b>%s</b><ul><li> %s: %s </li></ul>"
+
+#: include/kiway_player.h:316
+msgid "This file is already open."
+msgstr "Die Datei ist bereits geöffnet."
+
+#: include/lib_table_grid.h:180
+msgid "Library Path"
+msgstr "Bibliothekspfad"
+
+#: include/lib_table_grid.h:183
+msgid "Plugin Type"
+msgstr "Plugintyp"
+
+#: include/lib_table_grid.h:186
+msgid "Active"
+msgstr ""
+
+#: kicad/dialogs/dialog_template_selector_base.h:68
+msgid "Project Template Selector"
+msgstr "Projektvorlagenauswahl"
+
+#: pagelayout_editor/dialogs/dialog_new_dataitem_base.h:71
+msgid "New Item"
+msgstr "Neues Element"
+
+#: pcb_calculator/dialogs/dialog_regulator_data_base.h:63
+msgid "Regulator Parameters"
+msgstr "Parameter Spannungsregler"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.h:311
+msgid "PCB Calculator"
+msgstr "PCB Kalkulator"
+
+#: pcbnew/dialogs/dialog_SVG_print_base.h:76
+msgid "Export SVG file"
+msgstr "Als SVG exportieren"
+
+#: pcbnew/dialogs/dialog_cleaning_options_base.h:50
+msgid "Cleaning Options"
+msgstr "Optionen für das Aufräumen"
+
+#: pcbnew/dialogs/dialog_copper_zones_base.h:131
+msgid "Copper Zone Properties"
+msgstr "Eigenschaften von Kupferflächen"
+
+#: pcbnew/dialogs/dialog_design_rules_base.h:121
+msgid "Design Rules Editor"
+msgstr "Design Regel Editor"
+
+#: pcbnew/dialogs/dialog_dimension_editor_base.h:70
+msgid "Dimension Properties"
+msgstr "Eigenschaften der Abmessungen"
+
+#: pcbnew/dialogs/dialog_drc_base.h:116
+msgid "DRC Control"
+msgstr "DRC Steuerung"
+
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.h:134
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.h:117
+msgid "Footprint Properties"
+msgstr "Footprint Eigenschaften"
+
+#: pcbnew/dialogs/dialog_edit_module_text_base.h:79
+msgid "Footprint Text Properties"
+msgstr "Footprint Texteigenschaften"
+
+#: pcbnew/dialogs/dialog_enum_pads_base.h:53
+msgid "Pad enumeration settings"
+msgstr "Einstellungen Pad-Aufzählung"
+
+#: pcbnew/dialogs/dialog_exchange_modules_base.h:72
+msgid "Change Footprint"
+msgstr "Ändere Footprint"
+
+#: pcbnew/dialogs/dialog_export_idf_base.h:63
+msgid "Export IDFv3"
+msgstr "Export IDFv3"
+
+#: pcbnew/dialogs/dialog_export_step_base.h:72
+msgid "Export STEP"
+msgstr "STEP-Export"
+
+#: pcbnew/dialogs/dialog_export_vrml_base.h:72
+msgid "VRML Export Options"
+msgstr "VRML-Exportoptionen"
+
+#: pcbnew/dialogs/dialog_footprint_wizard_list_base.h:68
+msgid "Footprint Generators"
+msgstr "Footprint-Generatoren"
+
+#: pcbnew/dialogs/dialog_footprint_wizard_list_base.h:87
+msgid "Traceback of errors in not loadable python scripts"
+msgstr "Traceback der Fehler in Python-Skripten die sich nicht laden lassen"
+
+#: pcbnew/dialogs/dialog_fp_lib_table_base.h:81
+msgid "PCB Library Tables"
+msgstr "PCB Bibliothekstabelle"
+
+#: pcbnew/dialogs/dialog_gen_module_position_file_base.h:61
+msgid "Generate Component Position Files"
+msgstr "Bauteilplatzierungsdatei erstellen"
+
+#: pcbnew/dialogs/dialog_gendrill_base.h:83
+msgid "Drill Files Generation"
+msgstr "Bohrdatei Generator"
+
+#: pcbnew/dialogs/dialog_get_footprint_by_name_base.h:57
+msgid "Search for footprint"
+msgstr "Suche Footprint"
+
+#: pcbnew/dialogs/dialog_global_deletion_base.h:75
+msgid "Delete Items"
+msgstr "Elemente entfernen"
+
+#: pcbnew/dialogs/dialog_global_edit_tracks_and_vias_base.h:73
+msgid "Global Edition of Tracks and Vias"
+msgstr "Globale Einstellung für Leiterbahnen und Durchkontaktierungen"
+
+#: pcbnew/dialogs/dialog_global_modules_fields_edition_base.h:67
+msgid "Set Text Size"
+msgstr "Einstellungen der Textgröße"
+
+#: pcbnew/dialogs/dialog_global_pads_edition_base.h:58
+msgid "Global Pads Edition"
+msgstr "Globale Pad-Einstellungen"
+
+#: pcbnew/dialogs/dialog_graphic_item_properties_base.h:78
+msgid "Graphic Item Properties"
+msgstr "Eigenschaften grafischer Elemente"
+
+#: pcbnew/dialogs/dialog_graphic_items_options_base.h:73
+msgid "Text and Drawings"
+msgstr "Texte und Zeichnungen"
+
+#: pcbnew/dialogs/dialog_keepout_area_properties_base.h:67
+msgid "Keepout Area Properties"
+msgstr "Eigenschaften von Sperrflächen"
+
+#: pcbnew/dialogs/dialog_layer_selection_base.h:81
+msgid "Select Copper Layer Pair:"
+msgstr "Auswahl eines Kupferlagenpaares:"
+
+#: pcbnew/dialogs/dialog_layers_setup_base.h:417
+msgid "Layer Setup"
+msgstr "Lagen Einstellungen"
+
+#: pcbnew/dialogs/dialog_mask_clearance_base.h:74
+msgid "Pads Mask Clearance"
+msgstr "Pads Abstandsmaske"
+
+#: pcbnew/dialogs/dialog_modedit_options_base.h:81
+msgid "Footprint Editor Options"
+msgstr "Footprinteditor Optionen"
+
+#: pcbnew/dialogs/dialog_non_copper_zones_properties_base.h:67
+msgid "Non Copper Zones Properties"
+msgstr "Eigenschaften für Zonen ohne Kupfer"
+
+#: pcbnew/dialogs/dialog_pad_properties_base.h:207
+msgid "Pad Properties"
+msgstr "Pad Eigenschaften"
+
+#: pcbnew/dialogs/dialog_pad_properties_base.h:279
+msgid "Pad Custom Shape Geometry Transform"
+msgstr "Individuelle Geometrische Padform Transformierung"
+
+#: pcbnew/dialogs/dialog_pad_properties_base.h:318
+msgid "Basic Shape Polygon"
+msgstr "Basisform Polygon"
+
+#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.h:80
+msgid "Trace length tuning"
+msgstr "Anpassen Leiterbahnlänge"
+
+#: pcbnew/dialogs/dialog_select_pretty_lib_base.h:59
+msgid "Select Footprint Library Folder"
+msgstr "Auswahl Footprint-Bibliotheksordner"
+
+#: pcbnew/dialogs/dialog_set_grid_base.h:71
+msgid "Grid Properties"
+msgstr "Raster Eigenschaften"
+
+#: pcbnew/dialogs/dialog_target_properties_base.h:61
+msgid "Target Properties"
+msgstr "Objekt Eigenschaften"
+
+#: pcbnew/dialogs/dialog_track_via_properties_base.h:112
+msgid "Track & Via Properties"
+msgstr "Eigenschaften Leiterbahn und DoKu's"
+
+#: pcbnew/dialogs/dialog_track_via_size_base.h:63
+msgid "Track width and via size"
+msgstr "Leiterbahnbreite und Durchkontaktierungsgröße"
+
+#: pcbnew/dialogs/wizard_3DShape_Libs_downloader_base.h:82
+msgid "Add 3D Shape Libraries Wizard"
+msgstr "Wizard für 3D-Formen hinzufügen"
+
+#: pcbnew/dialogs/wizard_add_fplib_base.h:88
+msgid "Add Footprint Libraries Wizard"
+msgstr "Footprint-Bibliothekswizard hinzufügen"
+
+#: pcbnew/help_common_strings.h:17
+msgid "Find components and text in current loaded board"
+msgstr "Suche nach Bauteilen oder Text auf aktueller Platine"
+
+#: pcbnew/help_common_strings.h:21
+msgid "Zoom to fit board on screen"
+msgstr "Darstellung an den Bildschirm anpassen"
+
+#: pcbnew/help_common_strings.h:22
+msgid "Redraw screen"
+msgstr "Bildschirm neu zeichnen"
+
+#: pcbnew/help_common_strings.h:26
+msgid ""
+"Show/hide microwave toolbar\n"
+"(Experimental feature)"
+msgstr ""
+"Werkzeugleiste für Mikrowellen-Applikationen ein-/ausblenden.\n"
+"(Experimentelles Feature!)"
+
+#: pcbnew/import_dxf/dialog_dxf_import_base.h:78
+msgid "Import DXF File"
+msgstr "DXF-Datei importieren"
+
+#~ msgid "Create a logo file"
+#~ msgstr "Logodatei erstellen"
+
+#~ msgid "File '%s' could not be created."
+#~ msgstr "Konnte die Datei '%s' nicht erstellen."
+
+#~ msgid "Create a Postscript file"
+#~ msgstr "Postscript-Datei erstellen"
+
+#~ msgid "Create a component library file for Eeschema"
+#~ msgstr "Bauteilbibliotheksdatei für Eeschema erstellen"
+
+#~ msgid "Create a footprint file for Pcbnew"
+#~ msgstr "Footprintdatei für Pcbnew erstellen"
+
+#~ msgid ""
+#~ "Html or pdf help file \n"
+#~ "'%s'\n"
+#~ " or\n"
+#~ "'%s' could not be found."
+#~ msgstr ""
+#~ "Die HTML- oder PDF-Hilfedatei '\n"
+#~ "'%s'\n"
+#~ "oder\n"
+#~ "'%s' wurde nicht gefunden."
+
+#~ msgid "Help file '%s' could not be found."
+#~ msgstr "Die Hilfedatei '%s' wurde nicht gefunden."
+
+#~ msgid "You do not have write permissions to folder <%s>."
+#~ msgstr "Keine Schreibrechte für Verzeichnis <%s>."
+
+#~ msgid "You do not have write permissions to save file <%s> to folder <%s>."
+#~ msgstr ""
+#~ "Keine Schreibrechte zum Speichern der Datei <%s> im Verzeichnis <%s>."
+
+#~ msgid "You do not have write permissions to save file <%s>."
+#~ msgstr "Keine Schreibrechte zum Speichern der Datei <%s>."
+
+#~ msgid ""
+#~ "Well this is potentially embarrassing!\n"
+#~ "It appears that the last time you were editing the file\n"
+#~ "'%s'\n"
+#~ "it was not saved properly.  Do you wish to restore the last saved edits "
+#~ "you made?"
+#~ msgstr ""
+#~ "Es scheint, dass die Datei '%s' nach dem Editieren nicht ordnungsgemäß "
+#~ "gespeichert wurde.\n"
+#~ "Möchten Sie die letzten Änderungen wiederherstellen?"
+
+#~ msgid "Could not create backup file <%s>"
+#~ msgstr "Konnte die Sicherungskopie <%s> nicht erstellen."
+
+#~ msgid "Cannot make path '%s' absolute with respect to '%s'."
+#~ msgstr ""
+#~ "Kann den absoluten Pfad '%s' nicht erstellen unter Berücksichtigung von "
+#~ "'%s'."
+
+#~ msgid "Output directory '%s' created.\n"
+#~ msgstr "Das Ausgabeverzeichnis '%s' wurde erstellt.\n"
+
+#~ msgid "Cannot create output directory '%s'.\n"
+#~ msgstr "Konnte das Ausgabeverzeichnis '%s' nicht erstellen.\n"
+
+#~ msgid ""
+#~ "The KiCad EDA Suite is a set of open source applications for the creation "
+#~ "of electronic schematics and to design printed circuit boards."
+#~ msgstr ""
+#~ "Die KiCad EDA Suite besteht aus quelloffenen Anwendungen für das "
+#~ "Erstellen von elektronischen Schaltungen und den Entwurf gedruckter "
+#~ "Leiterplatten."
+
+#~ msgid "The official KiCad website"
+#~ msgstr "Die offizielle KiCad Webseite"
+
+#~ msgid "Developer's website on Launchpad"
+#~ msgstr "Projektseite auf Launchpad"
+
+#~ msgid "Official repository for component and footprint libraries"
+#~ msgstr "Offizielles Repository mit Bauteil- und Footprintbibliotheken"
+
+#~ msgid "Footprint wizards info on our official repository"
+#~ msgstr "Footprint Wizard Info in unserem offizielles Repository"
+
+#~ msgid "Non official repositories"
+#~ msgstr "Nicht offizielle Repositorys"
+
+#~ msgid "Additional component libraries repository (smisioto)"
+#~ msgstr "Repository mit zusätzlichen Bauteilbibliotheken (smisioto)"
+
+#~ msgid "Report or examine bugs"
+#~ msgstr "Melde oder Prüfe Fehler"
+
+#~ msgid "KiCad user's group"
+#~ msgstr "KiCad-Benutzergruppen"
+
+#~ msgid "KiCad forum"
+#~ msgstr "KiCad-Forum"
+
+#~ msgid "Environment variable '%s' cannot be renamed"
+#~ msgstr "Die Umgebungsvariable '%s' kann nicht umbenannt werden."
+
+#~ msgid "Page layout description file <%s> not found. Abort"
+#~ msgstr ""
+#~ "Datei <%s> mit Seitenlayoutbeschreibung konnte nicht gefunden werden. "
+#~ "Abbruch!"
+
+#~ msgid "Select Page Layout Descr File"
+#~ msgstr "Dateiauswahl für Seitenlayoutbeschreibung"
+
+#~ msgid ""
+#~ "The page layout descr filename has changed.\n"
+#~ "Do you want to use the relative path:\n"
+#~ "'%s'\n"
+#~ "instead of\n"
+#~ "'%s'"
+#~ msgstr ""
+#~ "Der Dateiname für die Seitenlayoutbeschreibung wurde geändert.\n"
+#~ "Möchte Sie den folgenden relativen Pfad verwenden:\n"
+#~ "'%s'\n"
+#~ "statt\n"
+#~ "'%s'"
+
+#~ msgid "<b>Error: </b></font><font size=2>"
+#~ msgstr "<b>Fehler: </b></font><font size=2>"
+
+#~ msgid "<b>Warning: </b></font><font size=2>"
+#~ msgstr "<b>Warnung: </b></font><font size=2>"
+
+#~ msgid "<b>Info: </b>"
+#~ msgstr "<b>Hinweis: </b>"
+
+#~ msgid "Save report to file"
+#~ msgstr "Speichere in Protokolldatei"
+
+#~ msgid "Cannot write report to file '%s'."
+#~ msgstr "Kann Protokolldatei '%s' nicht erstellen."
+
+#~ msgid "Expecting '%s'"
+#~ msgstr "Erwartete Zeichen '%s'"
+
+#~ msgid "Unexpected '%s'"
+#~ msgstr "Unerwartete Zeichen '%s'"
+
+#~ msgid "need a NUMBER for '%s'"
+#~ msgstr "benötige eine Zahl für '%s'"
+
+#~ msgid "Doc File '%s' not found"
+#~ msgstr "Die Dokumentationsdatei '%s' wurde nicht gefunden."
+
+#~ msgid "Unknown MIME type for doc file <%s>"
+#~ msgstr "Unbekannter MIME-Typ für Doc-Datei <%s>"
+
+#~ msgid ""
+#~ "%s in input/source\n"
+#~ "'%s'\n"
+#~ "line %d, offset %d"
+#~ msgstr ""
+#~ "%s in Eingang/Quelle\n"
+#~ "'%s'\n"
+#~ "Zeile %d, Offset %d"
+
+#~ msgid ""
+#~ "KiCad was unable to open this file, as it was created with a more recent "
+#~ "version than the one you are running. To open it, you'll need to upgrade "
+#~ "KiCad to a more recent version.\n"
+#~ "\n"
+#~ "Date of KiCad version required (or newer): %s\n"
+#~ "\n"
+#~ "Full error text:\n"
+#~ "%s"
+#~ msgstr ""
+#~ "KiCad konnte diese Datei nicht öffnen, da sie mit einer neueren Version "
+#~ "als der aktuell benutzten erstellt wurde. Um die Datei öffnen zu können "
+#~ "müssen Sie KiCad auf eine neuere Version aktualisieren.\n"
+#~ "\n"
+#~ "Die benötigte KiCad Version (oder neuer): %s\n"
+#~ "\n"
+#~ "Der komplette Fehlertext:\n"
+#~ "%s"
+
+#~ msgid ""
+#~ "Duplicate library nickname '%s' found in footprint library table file "
+#~ "line %d"
+#~ msgstr ""
+#~ "Doppelter Bibliotheks-Nickname '%s' in der Tabelle der "
+#~ "Footprintbibliotheken in Zeile '%d gefunden."
+
+#~ msgid "fp-lib-table files contain no library with nickname '%s'"
+#~ msgstr ""
+#~ "Die Footprint-Bibliothekstabelle enthält keine Bibliothek mit dem "
+#~ "Nicknamen '%s'"
+
+#~ msgid "Cannot create global library table path '%s'."
+#~ msgstr ""
+#~ "Der Pfad '%s' für die globale Bibliothekstabelle konnte nicht erstellen "
+#~ "werden."
+
+#~ msgid "Command <%s> could not found"
+#~ msgstr "Programm <%s> nicht gefunden."
+
+#~ msgid ""
+#~ "Problem while running the PDF viewer\n"
+#~ "Command is '%s'"
+#~ msgstr ""
+#~ "Es ist ein Problem beim Starten des PDF-Betrachters aufgetreten.\n"
+#~ "Ausgeführter Befehl: '%s'"
+
+#~ msgid "Unable to find a PDF viewer for '%s'"
+#~ msgstr "Konnte keinen PDF-Betrachter für '%s' finden."
+
+#~ msgid "Failed to load kiface library '%s'."
+#~ msgstr "Konnte die kiface-Bibliothek '%s' nicht laden."
+
+#~ msgid ""
+#~ "Could not read instance name and version symbol form kiface library '%s'."
+#~ msgstr ""
+#~ "Konnte den Instanzierungsnamen und die Symbolversionsform nicht von der "
+#~ "kiface Bibliothek '%s' lesen"
+
+#~ msgid ""
+#~ "Fatal Installation Bug. File:\n"
+#~ "'%s'\n"
+#~ "could not be loaded\n"
+#~ msgstr ""
+#~ "Schwerer Installationsfehler. Die Datei:\n"
+#~ "'%s'\n"
+#~ "konnte nicht geladen werden.\n"
+
+#~ msgid "Unable to find '%s' template config file."
+#~ msgstr "Konnte die Vorgaben Konfigurationsdatei '%s' nicht finden."
+
+#~ msgid "Cannot create prj file '%s' (Directory not writable)"
+#~ msgstr ""
+#~ "Projektdatei '%s' konnte nicht erstellt werden (Ordner ist nicht "
+#~ "beschreibbar)"
+
+#~ msgid "Unable to open filename '%s' for reading"
+#~ msgstr "Konnte Datei '%s' nicht zum Lesen öffnen"
+
+#~ msgid "cannot open or save file '%s'"
+#~ msgstr "Konnte Datei '%s' nicht öffnen oder speichern."
+
+#~ msgid "error writing to file '%s'"
+#~ msgstr "Ein Fehler ist beim Schreiben von Datei '%s' aufgetreten."
+
+#~ msgid ""
+#~ "<%s> is already assigned to \"%s\" in section \"%s\". Are you sure you "
+#~ "want to change its assignment?"
+#~ msgstr ""
+#~ "<%s ist bereits zu \"%s\" in Sektion \"%s\" zugewiesen. Sind Sie sicher "
+#~ "diese Zuweisung ändern zu wollen?"
+
+#~ msgid "KiCad drawing symbol file (*.sym)|*.sym"
+#~ msgstr "KiCad Zeichensymboldateien (*.sym)|*.sym"
+
+#~ msgid "KiCad component library file (*.lib)|*.lib"
+#~ msgstr "KiCad Bauteilbibliotheksdatei (*.lib)|*.lib"
+
+#~ msgid "KiCad project files (*.pro)|*.pro"
+#~ msgstr "KiCad Projektdateien (*.pro)|*.pro"
+
+#~ msgid "KiCad schematic files (*.sch)|*.sch"
+#~ msgstr "KiCad Schaltplandateien (*.sch)|*.sch"
+
+#~ msgid "Eagle XML schematic file (*.sch)|*.sch"
+#~ msgstr "Eagle XML Schaltplandatei (*.sch)|*.sch"
+
+#~ msgid "Eagle XML files (*.sch *.brd)|*.sch;*.brd"
+#~ msgstr "Eagle XML Dateien (*.sch *.brd)|*.sch;*.brd"
+
+#~ msgid "KiCad netlist files (*.net)|*.net"
+#~ msgstr "KiCad Netzlistedateien (*.net)|*.net"
+
+#~ msgid "Gerber files (*.pho)|*.pho"
+#~ msgstr "Gerber Dateien (*.pho)|*.pho"
+
+#~ msgid "KiCad printed circuit board files (*.brd)|*.brd"
+#~ msgstr "KiCad Dateien gedruckter Schaltungen (*.brd)|*.brd"
+
+#~ msgid "Eagle ver. 6.x XML PCB files (*.brd)|*.brd"
+#~ msgstr "Eagle Ver. 6.x XML PCB Dateien (*.brd)|*.brd"
+
+#~ msgid "P-Cad 200x ASCII PCB files (*.pcb)|*.pcb"
+#~ msgstr "P-Cad 200x ASCII PCB Dateien (*.pcb)|*.pcb"
+
+#~ msgid "KiCad s-expr printed circuit board files (*.kicad_pcb)|*.kicad_pcb"
+#~ msgstr ""
+#~ "KiCad s-expr Dateien gedruckter Schaltungen (*.kicad_pcb)|*.kicad_pcb"
+
+#~ msgid "KiCad footprint s-expre file (*.kicad_mod)|*.kicad_mod"
+#~ msgstr "KiCad Footprint S-Expre Dateien (*.kicad_mod)|*.kicad_mod"
+
+#~ msgid "KiCad footprint s-expre library path (*.pretty)|*.pretty"
+#~ msgstr "KiCad Footprint S-Expre Bibliothekspfad (*.pretty)|*.pretty"
+
+#~ msgid "Legacy footprint library file (*.mod)|*.mod"
+#~ msgstr "Altes Footprint-Bibliotheksformat (*.mod)|*.mod"
+
+#~ msgid "Eagle ver. 6.x XML library files (*.lbr)|*.lbr"
+#~ msgstr "Eagle Ver. 6.x XML Bibliotheksdateien (*.lbr)|*.lbr"
+
+#~ msgid "Geda PCB footprint library file (*.fp)|*.fp"
+#~ msgstr "Geda PCB Footprint-Bibliotheksdateien (*.fp)|*.fp"
+
+#~ msgid "Component-footprint link file (*.cmp)|*cmp"
+#~ msgstr "Bauteil-Footprint-Zuordnungsdateien (*.cmp)|*.cmp"
+
+#~ msgid "Page layout design file (*.kicad_wks)|*kicad_wks"
+#~ msgstr "Seitenlayoubeschreibungsdateien (*.kicad_wks)|*kicad_wks"
+
+#~ msgid "KiCad cmp/footprint link files (*.cmp)|*.cmp"
+#~ msgstr "KiCad Bauteil/Footprint-Zuordnungsdatei (*.cmp)|*.cmp"
+
+#~ msgid "Drill files (*.drl)|*.drl;*.DRL"
+#~ msgstr "Bohrdateien (*.drl)|*.drl;*.DRL"
+
+#~ msgid "SVG files (*.svg)|*.svg;*.SVG"
+#~ msgstr "SVG Dateien (*.svg)|*.svg;*.SVG"
+
+#~ msgid "HTML files (*.html)|*.htm;*.html"
+#~ msgstr "HTML Dateien (*.html)|*.htm;*.html"
+
+#~ msgid "CSV Files (*.csv)|*.csv"
+#~ msgstr "Komma separierte Datei (*.csv)|*.csv"
+
+#~ msgid "Portable document format files (*.pdf)|*.pdf"
+#~ msgstr "Portables Dokumenten Format Dateien (*.pdf)|*.pdf"
+
+#~ msgid "PostScript files (.ps)|*.ps"
+#~ msgstr "PostScript Dateien (.ps)|*.ps"
+
+#~ msgid "Report files (*.rpt)|*.rpt"
+#~ msgstr "Protokolldateien (*.rpt)|*.rpt"
+
+#~ msgid "Footprint place files (*.pos)|*.pos"
+#~ msgstr "Footprint Platzierungsdateien (*.pos)|*.pos"
+
+#~ msgid "Vrml and x3d files (*.wrl *.x3d)|*.wrl;*.x3d"
+#~ msgstr "Vrml und x3d Dateien (*.wrl *.x3d)|*.wrl;*.x3d"
+
+#~ msgid "IDFv3 component files (*.idf)|*.idf"
+#~ msgstr "IDFv3 Bauteildateien (*.idf)|*.idf"
+
+#~ msgid "Text files (*.txt)|*.txt"
+#~ msgstr "Textdateien (*.txt)|*.txt"
+
+#~ msgid ""
+#~ "Equivalence file '%s' could not be found in the default search paths."
+#~ msgstr ""
+#~ "Äquivalenz Datei '%s' konnte nicht in den voreingestellten Suchpfaden "
+#~ "gefunden werden."
+
+#~ msgid "Error opening equivalence file '%s'."
+#~ msgstr "Ein Fehler ist beim Öffnen der Äquivalenzdatei '%s' aufgetreten."
+
+#~ msgid "Project file '%s' is not writable"
+#~ msgstr "Projektdatei '%s' ist nicht beschreibbar."
+
+#~ msgid "Footprint '%s' not found"
+#~ msgstr "Footprint '%s' nicht gefunden"
+
+#~ msgid "Component/footprint equ files (*.equ)|*.equ"
+#~ msgstr "Bauteil-/Footprintaliasdateien (*.equ)|*.equ"
+
+#~ msgid ""
+#~ "Error occurred saving the global footprint library table:\n"
+#~ "'%s'\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Bei dem Versuch die globale Bibliothekstabelle für Footprints zu "
+#~ "speichern ist ein Fehler aufgetreten:\n"
+#~ "'%s'\n"
+#~ "%s"
+
+#~ msgid ""
+#~ "Error occurred saving the project footprint library table:\n"
+#~ "'%s'\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Bei dem Versuch die Projektbibliothek für Footprints zu speichern ist ein "
+#~ "Fehler aufgetreten:\n"
+#~ "'%s'\n"
+#~ "%s"
+
+#~ msgid "Project file: '%s'"
+#~ msgstr "Projektdatei: '%s'"
+
+#~ msgid "Equ files:"
+#~ msgstr "Footprint Alias-Bibliotheksdatein:"
+
+#~ msgid "File '%s' already exists in list"
+#~ msgstr "Datei '%s' existiert bereits in der Liste"
+
+#~ msgid "Unload the selected library"
+#~ msgstr "Die gewählte Bibliothek entladen"
+
+#~ msgid "Component '%s' footprint '%s' was <b>not found</b> in any library.\n"
+#~ msgstr ""
+#~ "Das Bauteil '%s' mit dem Footprint '%s' konnte in <b>keiner</b> der "
+#~ "Bibliotheken gefunden werden.\n"
+
+#~ msgid ""
+#~ "Component '%s' footprint '%s' was found in <b>multiple</b> libraries.\n"
+#~ msgstr ""
+#~ "Das Bauteil '%s' mit dem Footprint '%s' wurde in <b>mehreren</b> "
+#~ "Bibliotheken gefunden werden.\n"
+
+#~ msgid "Load Component Footprint Link File"
+#~ msgstr "Laden einer Bauteil-Footprint-Zuordnungsdatei"
+
+#~ msgid "Failed to open component-footprint link file '%s'"
+#~ msgstr "Konnte Bauteil-Footprint Zuordnungsdatei '%s' nicht öffnen."
+
+#~ msgid ""
+#~ "The sheet changes cannot be made because the destination sheet already "
+#~ "has the sheet <%s> or one of it's subsheets as a parent somewhere in the "
+#~ "schematic hierarchy."
+#~ msgstr ""
+#~ "Die Änderungen des Zeichnungsblatts können nicht durchgeführt werden, da "
+#~ "das Ziel bereits das Blatt <%s> hat oder irgendwo eines der Unterblätter "
+#~ "in der Obergruppe ist in der Schaltplanhierarchie."
+
+#~ msgid ""
+#~ "Library '%s' has duplicate entry name '%s'.\n"
+#~ "This may cause some unexpected behavior when loading components into a "
+#~ "schematic."
+#~ msgstr ""
+#~ "Die Bauteilbibliothek '%s' hat einen doppelten Eintrag '%s'.\n"
+#~ "Dies kann zu unerwartetem Verhalten führen, wenn Bauteile für den "
+#~ "Schaltplan geladen werden."
+
+#~ msgid "Unable to load project's '%s' file"
+#~ msgstr "Konnte Projektdatei '%s' nicht laden"
+
+#~ msgid ""
+#~ "Part library '%s' failed to load. Error:\n"
+#~ " %s"
+#~ msgstr ""
+#~ "Bauteilbibliothek '%s' wurde nicht geladen. Fehler:\n"
+#~ "%s"
+
+#~ msgid ""
+#~ "Part library '%s' failed to load.\n"
+#~ "Error: %s"
+#~ msgstr ""
+#~ "Bauteilbibliothek '%s' wurde nicht geladen.\n"
+#~ "Fehler: %s"
+
+#~ msgid "Failed to open file '%s'"
+#~ msgstr "Konnte Datei '%s' nicht öffnen"
+
+#~ msgid "Alias <%s> cannot be removed while it is being edited!"
+#~ msgstr "Alias <%s> kann nicht während der Bearbeitung entfernt werden!"
+
+#~ msgid "Alias or component name <%s> already in use."
+#~ msgstr "Alias oder Bauteilname <%s> wird bereits verwendet."
+
+#~ msgid "Symbol name '%s' already exists in library '%s'."
+#~ msgstr "Symbolname '%s' existiert bereits in der Bibliothek '%s'."
+
+#~ msgid "Foot print filter <%s> is already defined."
+#~ msgstr "Footprintfilter <%s> ist bereits definiert."
+
+#~ msgid "'%s' is not a valid library symbol indentifier."
+#~ msgstr ""
+#~ "'%s' ist keine gültige Bezeichnung für eine Symbolbibliothekskennung."
+
+#~ msgid "Symbol '%s' not found in library '%s'"
+#~ msgstr "Symbol '%s' konnte nicht in der Bibliothek '%s' gefunden werden."
+
+#~ msgid "Symbol '%s' found in library '%s'"
+#~ msgstr "Symbol '%s' in der Bibliothek '%s' gefunden"
+
+#~ msgid "Symbol library identifier '%s' is not valid!"
+#~ msgstr "Die Symbolbibliothekskennung '%s' ist keine gültige Bezeichnung!"
+
+#~ msgid "Symbol '%s' not found in library '%s'!"
+#~ msgstr ""
+#~ "Das Symbol '%s' konnte nicht in der Bibliothek '%s' gefunden werden."
+
+#~ msgid ""
+#~ "The field name <%s> does not have a value and is not defined in the field "
+#~ "template list.  Empty field values are invalid an will be removed from "
+#~ "the component.  Do you wish to remove this and all remaining undefined "
+#~ "fields?"
+#~ msgstr ""
+#~ "Der Feldname <%s> besitzt keinen Wert und ist nicht in der Feldvorlage "
+#~ "definiert. Leere Felder sind nicht zulässig und werden vom Bauteil "
+#~ "entfernt.\n"
+#~ "Möchten Sie diese Felder und alle verbliebenen undefinierten Felder "
+#~ "entfernen?"
+
+#~ msgid "Electronic rule check file (.erc)|*.erc"
+#~ msgstr "Elektronische Regel Check (ERC) Datei (.erc)|*.erc"
+
+#~ msgid "File '%s' not found."
+#~ msgstr "Datei '%s' nicht gefunden."
+
+#~ msgid ""
+#~ "File '%s' is not a valid symbol library table file.\n"
+#~ "\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Datei '%s' ist keine gültige Symbolbibliotheksdatei.\n"
+#~ "\n"
+#~ "%s"
+
+#~ msgid ""
+#~ "Cannot copy global symbol library table file:\n"
+#~ "\n"
+#~ " '%s'\n"
+#~ "\n"
+#~ ":to:\n"
+#~ "\n"
+#~ "%s."
+#~ msgstr ""
+#~ "Die globale Symbolbibliothekstabelle konnte nicht kopiert werden:\n"
+#~ "\n"
+#~ " '%s'\n"
+#~ "\n"
+#~ ":to:\n"
+#~ "\n"
+#~ "%s."
+
+#~ msgid "Align left"
+#~ msgstr "Links ausrichten"
+
+#~ msgid "Align center"
+#~ msgstr "Mittig ausrichten"
+
+#~ msgid "Align right"
+#~ msgstr "Rechts ausrichten"
+
+#~ msgid "Align bottom"
+#~ msgstr "Unten ausrichten"
+
+#~ msgid "Align top"
+#~ msgstr "Oben ausrichten"
+
+#~ msgid "SPICE netlist file (.cir)|*.cir"
+#~ msgstr "SPICE Netzliste Datei (.cir)|*.cir"
+
+#~ msgid "CadStar netlist file (.frp)|*.frp"
+#~ msgstr "CadStar Netzliste Datei (.frp)|*.frp"
+
+#~ msgid ""
+#~ "Do you want to use a path relative to\n"
+#~ "'%s'"
+#~ msgstr ""
+#~ "Möchten Sie einen relativen Pfad zu '%s'\n"
+#~ "benutzen?"
+
+#~ msgid "Could not write plot files to folder '%s'."
+#~ msgstr "Konnte die Plotdateien nicht in dem Verzeichnis '%s' anlegen."
+
+#~ msgid ""
+#~ "It looks like this project was made using older schematic symbol "
+#~ "libraries.\n"
+#~ "Some parts may need to be relinked to a different symbol name, and some "
+#~ "symbols\n"
+#~ "may need to be \"rescued\" (cloned and renamed) into a new library.\n"
+#~ "\n"
+#~ "The following changes are recommended to update the project."
+#~ msgstr ""
+#~ "Es scheint das dieses Projekt unter Benutzung von älteren "
+#~ "Bauteilsymbolbibliotheken erstellt worden ist.\n"
+#~ "Manche Teile müssen neu zu einem anderen Symbolnamen verbunden werden, "
+#~ "und manche Symbole\n"
+#~ "müssen in eine neue Bibliothek \"gesichert\" werden (z.B. geklont oder "
+#~ "umbenannt).\n"
+#~ "\n"
+#~ "Die folgenden Änderungen werden empfohlen um Ihr Projekt zu aktualisieren."
+
+#~ msgid "Action"
+#~ msgstr "Aktion"
+
+#~ msgid "Rescue Symbolss"
+#~ msgstr "Bauteile wiederherstellen"
+
+#~ msgid "Cached Part:"
+#~ msgstr "Gespeicherter Bauteil:"
+
+#~ msgid "Library Part:"
+#~ msgstr "Bibliotheksbauteil:"
+
+#~ msgid "Illegal character '%s' found in Nickname: '%s' in row %d"
+#~ msgstr "Unzulässiges Zeichen '%s' im Nicknamen '%s' und Zeile %d gefunden."
+
+#~ msgid "Duplicate Nickname: '%s' in rows %d and %d"
+#~ msgstr "Doppelter Nickname: '%s' in Zeile %d und %d"
+
+#~ msgid "Adding library '%s', file '%s' to project symbol library table."
+#~ msgstr ""
+#~ "Hinzufügen der Bibliothek '%s' (Datei '%s') zur Bauteilsymboltabelle."
+
+#~ msgid "Library '%s' not found."
+#~ msgstr "Bibliothek '%s' nicht gefunden."
+
+#~ msgid "No symbol '%s' found in symbol library table."
+#~ msgstr "Symbol '%s' konnte in keiner Bibliothek gefunden werden."
+
+#~ msgid "Symbol '%s' mapped to symbol library '%s'."
+#~ msgstr "Das Symbol '%s' ist in die Symbolbibliothek '%s' gemappt."
+
+#~ msgid ""
+#~ "This schematic currently uses the symbol library look\n"
+#~ "up method for loading schematic symbols.  KiCad will\n"
+#~ "attempt to map the existing symbols to use the new\n"
+#~ "symbol library table.  If you choose to skip\n"
+#~ "this step, you will be responsible for manually assigning\n"
+#~ "symbols."
+#~ msgstr ""
+#~ "Dieser Schaltplan benutzt derzeit die Symbolbibliothek\n"
+#~ "als Referenzierungsmethode um Symbole laden zu können.\n"
+#~ "KiCad wird versuchen die existierenden Symbole abzubilden damit\n"
+#~ "die neue Symbolbibliothekstabelle benutzt werden kann. Wenn Sie\n"
+#~ "diesen Schritt abbrechen sind Sie selbst für die manuelle korrekte\n"
+#~ "Zuordnung der Symbole verantwortlich."
+
+#~ msgid "Couldn't load image from <%s>"
+#~ msgstr "Konnte Bild von <%s> nicht einlesen."
+
+#~ msgid "Global label '%s' (sheet '%s') looks like:"
+#~ msgstr "Globaler Bezeichner '%s' (Schaltplan '%s') sieht aus wie:"
+
+#~ msgid "Local label '%s' (sheet '%s') looks like:"
+#~ msgstr "Lokaler Bezeichner '%s' (Schaltplan '%s') sieht aus wie:"
+
+#~ msgid "Global label '%s' (sheet '%s')"
+#~ msgstr "Globaler Bezeichner '%s' (Schaltplan '%s')"
+
+#~ msgid "Local label '%s' (sheet '%s')"
+#~ msgstr "Lokaler Bezeichner '%s' (Schaltplan '%s')"
+
+#~ msgid "Could not save backup of file '%s'"
+#~ msgstr "Konnte Sicherungskopie der Datei '%s' nicht speichern."
+
+#~ msgid ""
+#~ "Error saving schematic file '%s'.\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Fehler beim Speichern des Schaltplanes '%s'.\n"
+#~ "%s"
+
+#~ msgid "Failed to save '%s'"
+#~ msgstr "Konnte Datei '%s' nicht speichern"
+
+#~ msgid "Schematic file '%s' is already open."
+#~ msgstr "Schaltplan Datei '%s' ist bereits geöffnet."
+
+#~ msgid "Schematic '%s' does not exist.  Do you wish to create it?"
+#~ msgstr "Der Schaltplan'%s' existiert nicht. Möchten Sie diesen erstellen?"
+
+#~ msgid ""
+#~ "Error loading schematic file '%s'.\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Fehler beim Laden des Schaltplanes '%s'.\n"
+#~ "%s"
+
+#~ msgid "Failed to load '%s'"
+#~ msgstr "Konnte Datei '%s' nicht laden"
+
+#~ msgid ""
+#~ "This operation cannot be undone. Besides, take into account that "
+#~ "hierarchical sheets will not be appended.\n"
+#~ "\n"
+#~ "Do you want to save the current document before proceeding?"
+#~ msgstr ""
+#~ "Diese Aktion kann nicht wieder rückgängig gemacht werden. Bedenken Sie, "
+#~ "dass hierarchische Schaltpläne nicht hinzugefügt werden.\n"
+#~ "\n"
+#~ "Möchten Sie das gegenwärtige Dokument speichern, bevor Sie fortfahren?"
+
+#~ msgid "Directory '%s' is not writable"
+#~ msgstr "Das Verzeichnis '%s' ist nicht beschreibbar."
+
+#~ msgid "No alternate body style found for symbol '%s' in library '%s'."
+#~ msgstr ""
+#~ "Keine alternative Bauteilform für Symbol %s in der Bauteilbibliothek '%s' "
+#~ "gefunden."
+
+#~ msgid "Load Component"
+#~ msgstr "Bauteil laden"
+
+#~ msgid "Arc only had %d parameters of the required 8"
+#~ msgstr "Der Kreisbogen hatte nur %d Parameter von den benötigten 8."
+
+#~ msgid "Bezier only had %d parameters of the required 4"
+#~ msgstr "Die Bezierkurve hatte nur %d Parameter von den benötigten 4"
+
+#~ msgid "Bezier count parameter %d is invalid"
+#~ msgstr "Der Zählparameter %d der Bezierkurve ist ungültig"
+
+#~ msgid "Bezier point %d X position not defined"
+#~ msgstr "Die X-Position von Punkt %d der Bezierkurve ist nicht definiert"
+
+#~ msgid "Bezier point %d Y position not defined"
+#~ msgstr "Die Y-Position von Punkt %d der Bezierkurve ist nicht definiert"
+
+#~ msgid "Circle only had %d parameters of the required 6"
+#~ msgstr "Der Kreis hatte nur %d Parameter von den benötigten 6."
+
+#~ msgid "Cannot import symbol library '%s'."
+#~ msgstr "Symbolbibliothek '%s' kann nicht importiert werden."
+
+#~ msgid "Symbol library file '%s' is empty."
+#~ msgstr "Symbolbibliothek '%s' ist leer."
+
+#~ msgid "New Symbol Library"
+#~ msgstr "Neue Symbolbibliothek"
+
+#~ msgid "Error occurred attempting to load symbol library file '%s'"
+#~ msgstr ""
+#~ "Bei dem Versuch die Symbolbibliothek '%s' zu laden ist ein Fehler "
+#~ "aufgetreten."
+
+#~ msgid "Symbol '%s' already exists. Overwrite it?"
+#~ msgstr "Das Symbol %s existiert bereits, überschreiben?"
+
+#~ msgid "Write permissions are requured to save library '%s'."
+#~ msgstr "Keine Schreibberechtigung zum Speichern der Bibliothek <%s>."
+
+#~ msgid "Error creating symbol library '%s'"
+#~ msgstr "Ein Fehler ist aufgetreten beim Erstellen der Bibliothek '%s'."
+
+#~ msgid ""
+#~ "This library will not be available until it is added to the symbol "
+#~ "library table."
+#~ msgstr ""
+#~ "Diese Bibliothek steht erst zur Verfügung wenn diese zur Symbolbibliothek "
+#~ "hinzugefügt wurden ist."
+
+#~ msgid "Symbol '%s' saved in library '%s'"
+#~ msgstr "Symbol '%s' in Bibliothek '%s' gespeichert."
+
+#~ msgid "Polyline only had %d parameters of the required 4"
+#~ msgstr "Der Linienzug hatte nur %d Parameter von den benötigten 4."
+
+#~ msgid "Polyline count parameter %d is invalid"
+#~ msgstr "Der Zählerwert %d des Linienzugs ist ungültig."
+
+#~ msgid "Polyline point %d X position not defined"
+#~ msgstr "Die X-Position von Punkt %d des Linienzugs ist nicht definiert."
+
+#~ msgid "Polyline point %d Y position not defined"
+#~ msgstr "Die Y-Position von Punkt %d des Linienzugs ist nicht definiert."
+
+#~ msgid "Rectangle only had %d parameters of the required 7"
+#~ msgstr "Das Rechteck hatte nur %d Parameter von den benötigten 7."
+
+#~ msgid "Text only had %d parameters of the required 8"
+#~ msgstr "Der Text hatte nur %d Parameter von den benötigten 8."
+
+#~ msgid "Failed to save symbol library file '%s'"
+#~ msgstr "Konnte die Bauteilbibliothek '%s' nicht speichern."
+
+#~ msgid "Error occurred loading symbol '%s' from library '%s'."
+#~ msgstr ""
+#~ "Bei dem Versuch das Symbol '%s' aus der Bibliothek '%s' zu laden ist ein "
+#~ "Fehler aufgetreten."
+
+#~ msgid "Include current symbol changes?"
+#~ msgstr "Möchten Sie die Symboländerungen übernehmen?"
+
+#~ msgid "Symbol Library Name"
+#~ msgstr "Name Symbolbibliothek"
+
+#~ msgid "Modify symbol library file '%s' ?"
+#~ msgstr "Möchten Sie die existierende Symbolbibliothek '%s' überschreiben?"
+
+#~ msgid "Failed to rename old symbol library to file "
+#~ msgstr "Konnte die alte Symbolbibliothek nicht umbenennen."
+
+#~ msgid "Failed to save old library document to file "
+#~ msgstr "Konnte die alte Symbol Dokumentationsbibliothek nicht speichern."
+
+#~ msgid "Failed to copy symbol library file "
+#~ msgstr "Konnte die Symbolbibliothek nicht kopieren "
+
+#~ msgid "Failed to copy symbol library document file "
+#~ msgstr "Konnte die Symbol Dokumentationsbibliothek nicht speichern "
+
+#~ msgid "Failed to save changes to symbol library file '%s'"
+#~ msgstr "Konnte die Änderungen an der Symbolbibliothek '%s' nicht speichern."
+
+#~ msgid "Symbol library file '%s' saved"
+#~ msgstr "Symbolbibliothek '%s' gespeichert."
+
+#~ msgid "Symbol library documentation file '%s' saved"
+#~ msgstr "Symbol Dokumentationsdatei '%s' gespeichert."
+
+#~ msgid "Please select a symbol library."
+#~ msgstr "Wähle bitte eine Symbolbibliothek."
+
+#~ msgid "Delete Symbol (%u items loaded)"
+#~ msgstr "Symbol löschen (%u Elemente geladen)"
+
+#~ msgid "Delete symbol '%s' from library '%s'?"
+#~ msgstr "Möchten Sie das Symbol '%s' aus Bibliothek '%s' entfernen?"
+
+#~ msgid ""
+#~ "The symbol being deleted has been modified. All changes will be lost. "
+#~ "Discard changes?"
+#~ msgstr ""
+#~ "Das zu löschende Symbol wurde modifiziert. Alle Änderungen werden somit "
+#~ "verloren gehen.\n"
+#~ "Möchten Sie die Änderungen verwerfen?"
+
+#~ msgid "Error occurred deleting symbol '%s' from library '%s'"
+#~ msgstr ""
+#~ "Ein Fehler ist aufgetreten beim Löschen des Symbols '%s' in der "
+#~ "Bibliothek '%s'."
+
+#~ msgid ""
+#~ "All changes to the current symbol will be lost!\n"
+#~ "\n"
+#~ "Clear the current symbol from the screen?"
+#~ msgstr ""
+#~ "Alle Änderungen werden am gegenwärtigen Symbol verloren gehen!\n"
+#~ "\n"
+#~ "Soll das Bauteil wirklich entfernt werden?"
+
+#~ msgid "Symbol '%s' already exists in library '%s'"
+#~ msgstr "Symbol '%s' existiert bereits in der Bibliothek '%s'."
+
+#~ msgid "Can't save file <%s>"
+#~ msgstr "Konnte Datei <%s> nicht speichern."
+
+#~ msgid "Save the changes in the library before closing?"
+#~ msgstr ""
+#~ "Möchten Sie die Änderungen an der Bibliothek vor dem Beenden speichern?"
+
+#~ msgid "No part to save."
+#~ msgstr "Kein Bauteil zum Speichern vorhanden"
+
+#~ msgid "No valid library specified."
+#~ msgstr "Keine gültige Bibliothek angegeben."
+
+#~ msgid "Unexpected error occured saving symbol '%s' to symbol library '%s'."
+#~ msgstr ""
+#~ "Bei dem Versuch das Bauteil '%s' in die Symbolbibliothek '%s' zu "
+#~ "speichern ist ein Fehler aufgetreten."
+
+#~ msgid ""
+#~ "The name '%s' conflicts with an existing entry in the component library "
+#~ "'%s'.\n"
+#~ "\n"
+#~ "Do you wish to replace the current component in the library with this one?"
+#~ msgstr ""
+#~ "Der Name '%s' steht in Konflikt mit einem existierenden Eintrag in der "
+#~ "Bauteilbibliothek '%s'.\n"
+#~ "\n"
+#~ "Möchten Sie das gegenwärtige Bauteil in der Bibliothek durch diesen "
+#~ "ersetzen?"
+
+#~ msgid ""
+#~ "The current component already has an alias named '%s'.\n"
+#~ "\n"
+#~ "Do you wish to remove this alias from the component?"
+#~ msgstr ""
+#~ "Das gegenwärtige Bauteil besitzt bereits einen Alias '%s'.\n"
+#~ "\n"
+#~ "Möchten Sie diesen Alias entfernen?"
+
+#~ msgid ""
+#~ "The new symbol contains alias names that conflict with entries in the "
+#~ "library '%s'.\n"
+#~ "\n"
+#~ "Do you wish to remove all of the conflicting aliases from this symbol?"
+#~ msgstr ""
+#~ "Das neue Symbol besitzt einen Aliasnamen, der mit Einträgen in der "
+#~ "Bibliothek %s in Konflikt steht.\n"
+#~ "\n"
+#~ "Möchten Sie alle in Konflikt stehenden Aliasnamen dieses Bauteils "
+#~ "entfernen?"
+
+#~ msgid "Failed to open '%s'"
+#~ msgstr "Es trat ein Fehler beim Öffnen von '%s' auf."
+
+#~ msgid "Loading '%s'"
+#~ msgstr "Lade '%s'"
+
+#~ msgid "'%s' is NOT an Eeschema file!"
+#~ msgstr "'%s' ist keine Eeschema Datei!"
+
+#~ msgid ""
+#~ "'%s' was created by a more recent version of Eeschema and may not load "
+#~ "correctly. Please consider updating!"
+#~ msgstr ""
+#~ "'%s' wurde von einer älteren Version von Eeschema erstellt und wird "
+#~ "möglicherweise nicht korrekt eingelesen. Bitte erwägen Sie ein "
+#~ "Aktualisierung durchzuführen!"
+
+#~ msgid ""
+#~ " was created by an older version of Eeschema. It will be stored in the "
+#~ "new file format when you save this file again."
+#~ msgstr ""
+#~ " wurde von einer älteren Version von Eeschema erstellt. Wenn Sie die "
+#~ "Datei erneut speichern wird diese im neuen Dateiformat angelegt."
+
+#~ msgid "Eeschema file text load error at line %d"
+#~ msgstr "Fehler beim Einlesen der Eeschema-Datei in Zeile %d"
+
+#~ msgid "Eeschema file undefined object at line %d, aborted"
+#~ msgstr "Undefiniertes Objekt in Zeile %d der Eeschema-Datei. Abbruch!"
+
+#~ msgid "Eeschema file object not loaded at line %d, aborted"
+#~ msgstr ""
+#~ "Das Objekt aus Zeile %d der Eeschema-Datei wurde nicht eingelesen. "
+#~ "Abbruch!"
+
+#~ msgid "Done Loading <%s>"
+#~ msgstr "<%s> geladen"
+
+#~ msgid ""
+#~ "Eeschema file dimension definition error line %d,\n"
+#~ "Abort reading file.\n"
+#~ msgstr ""
+#~ "Fehler in Eeschema-Datei bei der Definition von Abmessungen in Zeile %d,\n"
+#~ "Einlesen der Datei wurde abgebrochen.\n"
+
+#~ msgid "Select &Current Library"
+#~ msgstr "&Aktive Bibliothek auswählen"
+
+#~ msgid "Select working library"
+#~ msgstr "Arbeitsbibliothek auswählen"
+
+#~ msgid "&Save Current Library"
+#~ msgstr "Aktuelle Bauteilbibliothek &speichern"
+
+#~ msgid "Save Current Library &As..."
+#~ msgstr "A&ktuelle Bauteilbibliothek speichern unter ..."
+
+#~ msgid "Save current active library as..."
+#~ msgstr "Momentan aktive Bauteilbibliothek speichern unter ..."
+
+#~ msgid "Create &New Library and Save Current Component"
+#~ msgstr "&Neue Bibliothek erstellen und aktuelles Bauteil speichern"
+
+#~ msgid "Save current component to new library"
+#~ msgstr "Gegenwärtiges Bauteil in einer neuen Bibliothek speichern"
+
+#~ msgid "Create a PNG file from the component displayed on screen"
+#~ msgstr "Eine PNG-Datei vom gegenwärtigen Bauteil erstellen"
+
+#~ msgid "Create a SVG file from the current loaded component"
+#~ msgstr "Eine SVG-Datei vom gegenwärtigen Bauteil erstellen"
+
+#~ msgid "Set Component Editor default values and options"
+#~ msgstr "Standardwerte und Optionen für den Bauteileditor einstellen"
+
+#~ msgid "Failed to create file '%s'"
+#~ msgstr "Konnte Datei '%s' nicht erstellen."
+
+#~ msgid "Plot: '%s' OK.\n"
+#~ msgstr "Plot: <%s> erstellt\n"
+
+#~ msgid "Unable to create file '%s'.\n"
+#~ msgstr "Konnte Datei '%s' nicht erstellen.\n"
+
+#~ msgid "Cannot create file '%s'.\n"
+#~ msgstr "Konnte Datei '%s' nicht erstellen.\n"
+
+#~ msgid "Failed to create symbol library file '%s'"
+#~ msgstr "Konnte die Bauteilbibliothek '%s' nicht erstellen."
+
+#~ msgid "Could not load symbol '%s' from library '%s'."
+#~ msgstr "Konnte das Symbol %s aus der Bibliothek '%s' nicht laden."
+
+#~ msgid "Unable to read file '%s'"
+#~ msgstr "Konnte die Datei <%s> nicht öffnen."
+
+#~ msgid "Plugin '%s' does not implement the '%s' function."
+#~ msgstr "Das Plugin '%s' implementiert nicht die Funktion '%s'."
+
+#~ msgid "Plugin type '%s' is not found."
+#~ msgstr "Plugintyp '%s' wurde nicht gefunden."
+
+#~ msgid "'%s' does not appear to be an Eeschema file"
+#~ msgstr "'%s' ist anscheinend keine Eeschema-Datei!"
+
+#~ msgid "user does not have permission to read library document file '%s'"
+#~ msgstr "Keine Berechtigung zum Lesen der Bibliotheksdatei '%s'."
+
+#~ msgid "symbol library '%s' already exists, cannot create a new library"
+#~ msgstr ""
+#~ "Symbolbibliothek '%s' existiert bereits, neue Bibliothek kann nicht "
+#~ "erstellt werden."
+
+#~ msgid "library '%s' cannot be deleted"
+#~ msgstr "Die Bibliothek '%s' kann nicht gelöscht werden."
+
+#~ msgid ""
+#~ "Save the changes in\n"
+#~ "'%s'\n"
+#~ "before closing?"
+#~ msgstr ""
+#~ "Änderungen in\n"
+#~ "'%s'\n"
+#~ "vor dem Beenden speichern?"
+
+#~ msgid "Schematic file '%s' already exists, use Open instead"
+#~ msgstr ""
+#~ "Die Schaltplan Datei '%s' existiert bereits, statt dessen \"Öffnen\" "
+#~ "benutzen"
+
+#~ msgid "Error occurred loading symbol library '%s'."
+#~ msgstr ""
+#~ "Ein Fehler ist aufgetreten beim Laden eines Symbols aus der Bibliothek "
+#~ "'%s'."
+
+#~ msgid "A file named '%s' already exists in the current schematic hierarchy."
+#~ msgstr ""
+#~ "Eine Datei namens '%s' existiert bereits in der gegenwärtigen "
+#~ "Schaltplanhierarchie."
+
+#~ msgid "A file named '%s' already exists."
+#~ msgstr "Eine Datei namens '%s' existiert bereits."
+
+#~ msgid "A file named <%s> already exists in the current schematic hierarchy."
+#~ msgstr ""
+#~ "Eine Datei namens <%s> existiert bereits in der gegenwärtigen "
+#~ "Schaltplanhierarchie."
+
+#~ msgid "A file named <%s> already exists."
+#~ msgstr "Eine Datei namens <%s> existiert bereits."
+
+#~ msgid "Workbook file (*.wbk)|*.wbk"
+#~ msgstr "Workbook Datei (*.wbk)|*.wbk"
+
+#~ msgid "Save simulation workbook"
+#~ msgstr "Arbeitsmappe speichern"
+
+#~ msgid "Save plot as image"
+#~ msgstr "Speichert den Plot als Bilddatei."
+
+#~ msgid "PNG file (*.png)|*.png"
+#~ msgstr "PNG Datei (*.png)|*.png"
+
+#~ msgid "Save plot data"
+#~ msgstr "Plotdaten speichern"
+
+#~ msgid "'%s' is not a valid Spice value"
+#~ msgstr "'%s' ist kein gültiger Spice-Wert."
+
+#~ msgid "Import Symbol Drawings"
+#~ msgstr "Zeichnungs-Symbole importieren"
+
+#~ msgid "No parts found in part file '%s'."
+#~ msgstr "Keine Bauteile in Symbolbibliothek '%s' gefunden."
+
+#~ msgid "Error '%s' occurred loading part file '%s'."
+#~ msgstr ""
+#~ "Fehler '%s' ist aufgetreten beim Einlesen der Symbolbibliotheksdatei '%s'."
+
+#~ msgid "More than one part in part file '%s'."
+#~ msgstr "Symboldatei '%s' enthält mehr als ein Element."
+
+#~ msgid "Export Symbol Drawings"
+#~ msgstr "Zeichnungs Symbole exportieren"
+
+#~ msgid "Saving symbol in '%s'"
+#~ msgstr "Speichere Symbol in '%s'"
+
+#~ msgid "An error occurred attempting to save symbol file '%s'"
+#~ msgstr ""
+#~ "Bei dem Versuch die Symboldatei '%s' zu speichern ist ein Fehler "
+#~ "aufgetreten."
+
+#~ msgid ""
+#~ "Duplicate library nickname '%s' found in symbol library table file line %d"
+#~ msgstr ""
+#~ "Doppelter Bibliotheken-Nickname '%s' in der Tabelle der "
+#~ "Bauteilbibliotheken in Zeile '%d gefunden."
+
+#~ msgid "sym-lib-table files contain no library with nickname '%s'"
+#~ msgstr ""
+#~ "Die Symbol-Bibliotheks-Tabelle enthält keine Bibliothek mit dem Nicknamen "
+#~ "'%s'"
+
+#~ msgid "Save into current library"
+#~ msgstr "In momentan aktive Bauteilbibliothek speichern"
+
+#~ msgid "Delete component in current library"
+#~ msgstr "Bauteil in aktueller Bibliothek entfernen"
+
+#~ msgid "Create new component"
+#~ msgstr "Ein neues Bauteil erstellen"
+
+#~ msgid "Load component from current library"
+#~ msgstr "Bauteil zum Editieren aus der gegenwärtigen Bibliothek laden"
+
+#~ msgid "Create new component from current component"
+#~ msgstr "Aus dem gegenwärtigen Bauteil ein Neues erstellen"
+
+#~ msgid "Update current component in current library"
+#~ msgstr "Gegenwärtiges Bauteil in aktueller Bibliothek aktualisieren"
+
+#~ msgid "Import component"
+#~ msgstr "Bauteil importieren"
+
+#~ msgid "Export component"
+#~ msgstr "Bauteil exportieren"
+
+#~ msgid "Edit component properties"
+#~ msgstr "Eigenschaften des Bauteils editieren"
+
+#~ msgid "Cut selected item"
+#~ msgstr "Gewähltes Element ausschneiden"
+
+#~ msgid "Copy selected item"
+#~ msgstr "Gewähltes Element kopieren"
+
+#~ msgid "Source file '%s' is not available"
+#~ msgstr "Quelldatei '%s' ist nicht vorhanden"
+
+#~ msgid "Board file name:"
+#~ msgstr "Dateiename der Platine:"
+
+#~ msgid "Cannot create file '%s'"
+#~ msgstr "Konnte Datei '%s' nicht erstellen."
+
+#~ msgid "Zip file '%s' cannot be opened"
+#~ msgstr "Zip-Datei '%s' konnte nicht geöffnet werden"
+
+#~ msgid "Info: skip file <i>'%s'</i> (unknown type)\n"
+#~ msgstr "Info: Überspringe <i>%s</i> (unbekannter Typ)\n"
+
+#~ msgid "<b>Unable to create temporary file '%s'</b>\n"
+#~ msgstr "<b>Konnte temporäre Datei '%s' nicht erstellen.</b>\n"
+
+#~ msgid "Zip file (*.zip)|*.zip;.zip"
+#~ msgstr "Zip-Archivdatei  (*.zip)|*.zip;.zip"
+
+#~ msgid "Image name: '%s'  Layer name: '%s'"
+#~ msgstr "Bildname: '%s',  Lagenname: '%s'"
+
+#~ msgid "Gerber job file (*.gbrjob)|*.gbrjob;.gbrjob"
+#~ msgstr "Gerber-Job Dateien (*.gbrjob)|*.gbrjob;.gbrjob"
+
+#~ msgid "Highlight items of component '%s'"
+#~ msgstr "Elemente vom Bauteil '%s' hervorheben"
+
+#~ msgid "Highlight items of net '%s'"
+#~ msgstr "Elemente vom Netz '%s' hervorheben"
+
+#~ msgid "Highlight aperture type '%s'"
+#~ msgstr "Öffnungstype '%s' hervorheben"
+
+#~ msgid "File <%s> not found"
+#~ msgstr "Datei <%s> nicht gefunden."
+
+#~ msgid " (%s):"
+#~ msgstr " (%s):"
+
+#~ msgid "Do you really want to delete '%s'"
+#~ msgstr "Möchten Sie wirklich '%s' löschen?"
+
+#~ msgid "Zip file (*.zip)|*.zip"
+#~ msgstr "Zip-Archivdatei (*.zip)|*.zip"
+
+#~ msgid ""
+#~ "\n"
+#~ "Open '%s'\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Öffne '%s'\n"
+
+#~ msgid "Unzipping project in '%s'\n"
+#~ msgstr "Entpacke Projekt nach '%s'\n"
+
+#~ msgid "Extract file '%s'"
+#~ msgstr "Extrahiere Datei '%s'"
+
+#~ msgid "Unable to create zip archive file '%s'"
+#~ msgstr "Konnte Zip-Archiv ''%s' nicht erstellen"
+
+#~ msgid "Archive file <%s>"
+#~ msgstr "Archivdatei <%s>"
+
+#~ msgid ""
+#~ "\n"
+#~ "Zip archive <%s> created (%d bytes)"
+#~ msgstr ""
+#~ "\n"
+#~ "Zip-Archiv <%s> wurde erstellt (%d Bytes)."
+
+#~ msgid "Kicad Project Destination"
+#~ msgstr "Zielpfad KiCad Projekt"
+
+#~ msgid "Text file ("
+#~ msgstr "Textdatei ("
+
+#~ msgid "Edit PCB Footprint"
+#~ msgstr "Bearbeite Leiterplatten Footprint"
+
+#~ msgid ""
+#~ "Directory '%s' could not be created.\n"
+#~ "\n"
+#~ "Please make sure you have write permissions and try again."
+#~ msgstr ""
+#~ "Verzeichnis '%s' konnte nicht erstellt werden.\n"
+#~ "\n"
+#~ "Stellen Sie sicher das Sie Schreibrechte besitzen und wiederholen Sie den "
+#~ "Vorgang."
+
+#~ msgid "Cannot write to folder '%s'."
+#~ msgstr "Konnte nicht in den Ordner '%s' schreiben."
+
+#~ msgid "Cannot create folder '%s'."
+#~ msgstr "Konnte Ordner '%s' nicht erstellen."
+
+#~ msgid "Cannot copy file '%s'."
+#~ msgstr "Konnte Datei '%s' nicht kopieren."
+
+#~ msgid "Change filename: '%s'"
+#~ msgstr "Dateinamen ändern: '%s'"
+
+#~ msgid "File <%s> loaded"
+#~ msgstr "Datei <%s> geladen"
+
+#~ msgid "File <%s> inserted"
+#~ msgstr "Datei <%s> eingefügt"
+
+#~ msgid "Unable to write <%s>"
+#~ msgstr "Konnte '%s' nicht erstellen."
+
+#~ msgid "File <%s> written"
+#~ msgstr "Datei <%s> geschrieben"
+
+#~ msgid "Unable to create <%s>"
+#~ msgstr "Konnte <%s> nicht erstellen"
+
+#~ msgid "Error when loading file <%s>"
+#~ msgstr "Fehler beim Laden von <%s>."
+
+#~ msgid "Error when loading file '%s'"
+#~ msgstr "Fehler beim Laden von Datei '%s'"
+
+#~ msgid ""
+#~ "Save the changes in\n"
+#~ "<%s>\n"
+#~ "before closing?"
+#~ msgstr ""
+#~ "Änderungen in\n"
+#~ "<%s>\n"
+#~ "speichern vor dem Schließen?"
+
+#~ msgid ""
+#~ "Unable to write file<%s>\n"
+#~ "Do you want to exit and abandon your change?"
+#~ msgstr ""
+#~ "Datei <%s> kann nicht geschrieben werden.\n"
+#~ "Möchten Sie beenden und die Veränderungen verwerfen?"
+
+#~ msgid "PCB Calculator data  file (*.%s)|*.%s"
+#~ msgstr "PCB Kalkulationsdatendatei (*.%s)|*.%s"
+
+#~ msgid "Select a PCB Calculator data file"
+#~ msgstr "Wählen Sie eine PCB Kalkulationsdatendatei"
+
+#~ msgid "Unable to read data file <%s>"
+#~ msgstr "Konnte die Datei <%s> nicht öffnen."
+
+#~ msgid "Remove single pad net \"%s\" on \"%s\" pad '%s'\n"
+#~ msgstr "Entferne einzelnes Padnetz \"%s\" auf \"%s\" Pad '%s'\n"
+
+#~ msgid "Comma separated value files (*.csv)|*.csv"
+#~ msgstr "Komma separierte Datei (*.csv)|*.csv"
+
+#~ msgid "Unable to create file <%s>"
+#~ msgstr "Konnte Datei <%s> nicht erstellen"
+
+#~ msgid "Component '%s' pad '%s' not found in footprint '%s'\n"
+#~ msgstr ""
+#~ "Bauteil '%s' mit Pad '%s' konnte nicht im Footprint '%s' gefunden "
+#~ "werden.\n"
+
+#~ msgid "Copper zone (net name '%s'): net has no pads connected."
+#~ msgstr "Kupferzone (Netz Name '%s'): Netz hat kein verbundenen Pads."
+
+#~ msgid "Selecting all from sheet '%s'"
+#~ msgstr "Wähle alles vom Blatt '%s'"
+
+#~ msgid "Plot: '%s' OK."
+#~ msgstr "Plot: '%s' erstellt"
+
+#~ msgid "Unable to create file '%s'."
+#~ msgstr "Konnte Datei '%s' nicht erstellen."
+
+#~ msgid "Unable to create report file '%s' "
+#~ msgstr "Konnte Protokolldatei '%s' nicht erstellen"
+
+#~ msgid "Unable to create report file '%s'"
+#~ msgstr "Konnte Protokolldatei '%s' nicht erstellen"
+
+#~ msgid ""
+#~ "Error:\n"
+#~ "one of invalid chars <%s> found\n"
+#~ "in <%s>"
+#~ msgstr ""
+#~ "Fehler:\n"
+#~ "Unzulässiges Zeichen <%s> gefunden\n"
+#~ "in <%s>"
+
+#~ msgid "Rotation (-90.0 to 90.0)"
+#~ msgstr "Drehung (-90.0 bis 90.0)"
+
+#~ msgid "Change footprint of '%s'"
+#~ msgstr "Footprint von '%s' ändern"
+
+#~ msgid "Change footprints '%s'"
+#~ msgstr "Footprints '%s' ändern"
+
+#~ msgid "File '%s' created\n"
+#~ msgstr "Die Datei '%s' wurde erstellt.\n"
+
+#~ msgid "** Could not create file '%s' ***\n"
+#~ msgstr "** Konnte die Datei '%s' nicht erstellen. **\n"
+
+#~ msgid "Change footprint '%s' (from '%s') to '%s'"
+#~ msgstr "Ändere Footprint '%s' (von '%s') nach '%s'"
+
+#~ msgid "Could not create file '%s'"
+#~ msgstr "Konnte die Datei '%s' nicht erstellen."
+
+#~ msgid "Unable to create file '%s'"
+#~ msgstr "Konnte Datei '%s' nicht erstellen"
+
+#~ msgid "<%s> found"
+#~ msgstr "<%s> gefunden"
+
+#~ msgid "<%s> not found"
+#~ msgstr "<%s> nicht gefunden"
+
+#~ msgid "Options for Library '%s'"
+#~ msgstr "Optionen für Bibliothek '%s'"
+
+#~ msgid "Specctra DSN file:"
+#~ msgstr "Specctra DSN Datei:"
+
+#~ msgid "GenCAD 1.4 board files (.cad)|*.cad"
+#~ msgstr "GenCAD 1.4 Platinen Dateien (.cad)|*.cad"
+
+#~ msgid "Save contents of message window"
+#~ msgstr "Vorliegende Meldungen speichern"
+
+#~ msgid "Plot file '%s' created."
+#~ msgstr "Plotdatei '%s' erstellt."
+
+#~ msgid ""
+#~ "Error:\n"
+#~ "'%s'\n"
+#~ "while downloading library:\n"
+#~ "'%s'"
+#~ msgstr ""
+#~ "Fehler:\n"
+#~ "'%s'\n"
+#~ "ist aufgetreten beim Herunterladen der Bibliothek:\n"
+#~ "'%s'."
+
+#~ msgid "NETCLASS: '%s' has Clearance:%s which is less than global:%s"
+#~ msgstr ""
+#~ "NETZKLASSE: '%s' hat Abstandsmaß: %s, welches kleiner ist als das "
+#~ "Globale: %s"
+
+#~ msgid "NETCLASS: '%s' has TrackWidth:%s which is less than global:%s"
+#~ msgstr ""
+#~ "NETZKLASSE: '%s' hat Leiterbahnbreite: %s, welche kleiner ist als die "
+#~ "Globale: %s"
+
+#~ msgid "NETCLASS: '%s' has Via Dia:%s which is less than global:%s"
+#~ msgstr ""
+#~ "NETZKLASSE: '%s' hat DuKo Durchmesser: %s, welcher kleiner ist als der "
+#~ "Globale: %s"
+
+#~ msgid "NETCLASS: '%s' has Via Drill:%s which is less than global:%s"
+#~ msgstr ""
+#~ "NETZKLASSE: '%s' hat DuKo Bohrdurchmesser: %s, welcher kleiner ist als "
+#~ "der Globale: %s"
+
+#~ msgid "NETCLASS: '%s' has uVia Dia:%s which is less than global:%s"
+#~ msgstr ""
+#~ "NETZKLASSE: '%s' hat Micro-DuKo Durchmesser: %s, welcher kleiner ist als "
+#~ "der Globale: %s"
+
+#~ msgid "NETCLASS: '%s' has uVia Drill:%s which is less than global:%s"
+#~ msgstr ""
+#~ "NETZKLASSE: '%s' hat Micro-DuKo Bohrdurchmesser: %s, welcher kleiner ist "
+#~ "als der Globale: %s"
+
+#~ msgid "footprint '%s' has malformed courtyard"
+#~ msgstr "Footprint '%s' hat ungültigen Umriss"
+
+#~ msgid "footprint '%s' has no courtyard defined"
+#~ msgstr "Footprint '%s' hat keinen Umriss definiert"
+
+#~ msgid "footprints '%s' and '%s' overlap on front (top) layer"
+#~ msgstr ""
+#~ "Footprints '%s' und '%s' überschneiden sich auf der Vorderseite (Top "
+#~ "Layer)"
+
+#~ msgid "footprints '%s' and '%s' overlap on back (bottom) layer"
+#~ msgstr ""
+#~ "Footprints '%s' und '%s' überschneiden sich auf der Rückseite (Bottom "
+#~ "Layer)"
+
+#~ msgid "<package> name: '%s' duplicated in eagle <library>: '%s'"
+#~ msgstr "<package> Name: '%s' doppelt in Eagle <library>: '%s'"
+
+#~ msgid "No '%s' package in library '%s'"
+#~ msgstr "Kein '%s' Package in Bibliothek '%s'"
+
+#~ msgid "File '%s' is not readable."
+#~ msgstr "Datei '%s' ist nicht lesbar."
+
+#~ msgid "IPC-D-356 Test Files (.d356)|*.d356"
+#~ msgstr "IPC-D-356 Testdateien (.d356)|*.d356"
+
+#~ msgid "Unable to create '%s'."
+#~ msgstr "Konnte '%s' nicht erstellen."
+
+#~ msgid "Place file: '%s'."
+#~ msgstr "Platzierungsdatei: '%s'"
+
+#~ msgid "Front side (top side) place file: '%s'."
+#~ msgstr "Platzierungsdatei der Vorderseite (Oberseite): '%s'"
+
+#~ msgid "Back side (bottom side) place file: '%s'."
+#~ msgstr "Platzierungsdatei der Rückseite (Unterseite): '%s'"
+
+#~ msgid ""
+#~ "Footprint report file created:\n"
+#~ "'%s'"
+#~ msgstr ""
+#~ "Footprint Protokolldatei erstellt:\n"
+#~ "'%s'"
+
+#~ msgid "Unable to create '%s'"
+#~ msgstr "Konnte '%s' nicht erstellen"
+
+#~ msgid "Unable to create job file '%s'"
+#~ msgstr "Konnte Job-Datei '%s' nicht erstellen."
+
+#~ msgid "Create Gerber job file '%s'"
+#~ msgstr "Erstelle Gerber-Job Datei '%s'"
+
+#~ msgid "Import Non Kicad Board File"
+#~ msgstr "Importiere Nicht KiCad Platinendatei"
+
+#~ msgid "Recovery file '%s' not found."
+#~ msgstr "Wiederherstellungsdatei '%s' wurde nicht gefunden."
+
+#~ msgid "OK to load recovery or backup file '%s'"
+#~ msgstr "Soll die Wiederherstellungsdatei '%s' geladen werden?"
+
+#~ msgid "PCB file '%s' is already open."
+#~ msgstr "Die PCB Datei '%s' ist bereits geöffnet."
+
+#~ msgid "Board '%s' does not exist.  Do you wish to create it?"
+#~ msgstr "Die Platine '%s' existiert nicht. Möchten Sie diese erstellen?"
+
+#~ msgid "Warning: unable to create backup file '%s'"
+#~ msgstr "Achtung: Konnte Wiederherstellungsdatei '%s' nicht erstellen"
+
+#~ msgid "No access rights to write to file '%s'"
+#~ msgstr "Keine Zugriffsrechte um Datei '%s' schreiben zu können."
+
+#~ msgid ""
+#~ "Error saving board file '%s'.\n"
+#~ "%s"
+#~ msgstr ""
+#~ "Fehler beim Speichern der Platine '%s'.\n"
+#~ "%s"
+
+#~ msgid "Failed to create '%s'"
+#~ msgstr "Konnte Datei '%s' nicht erstellen"
+
+#~ msgid "Backup file: '%s'"
+#~ msgstr "Wiederherstellungsdatei: '%s'"
+
+#~ msgid "Wrote board file: '%s'"
+#~ msgstr "Platinendatei geschrieben: '%s'"
+
+#~ msgid ""
+#~ "Board copied to:\n"
+#~ "'%s'"
+#~ msgstr ""
+#~ "Platine kopiert nach:\n"
+#~ "'%s'"
+
+#~ msgid ""
+#~ "malformed URL:\n"
+#~ "'%s'"
+#~ msgstr ""
+#~ "Ungültige URL:\n"
+#~ "'%s'"
+
+#~ msgid ""
+#~ "Error fetching JSON data from URL '%s'.\n"
+#~ "Reason: '%s'"
+#~ msgstr ""
+#~ "Konnte die JSON Daten nicht herunterladen von: '%s'.\n"
+#~ "Grund: '%s'"
+
+#~ msgid ""
+#~ "Footprint\n"
+#~ "'%s'\n"
+#~ "is not in the writable portion of this Github library\n"
+#~ "'%s'"
+#~ msgstr ""
+#~ "Footprint\n"
+#~ "'%s'\n"
+#~ "befindet sich nicht im beschreibbaren Bereich dieser GitHub-Bibliothek\n"
+#~ "'%s'"
+
+#~ msgid ""
+#~ "option '%s' for Github library '%s' must point to a writable directory "
+#~ "ending with '.pretty'."
+#~ msgstr ""
+#~ "Die Option '%s' für die GitHub-Bibliothek '%s' muss auf ein "
+#~ "beschreibbares Verzeichnis mit der Endung '.pretty' verweisen."
+
+#~ msgid ""
+#~ "Unable to parse URL:\n"
+#~ "'%s'"
+#~ msgstr ""
+#~ "Konnte die folgende URL nicht parsen:\n"
+#~ "'%s'"
+
+#~ msgid ""
+#~ "%s\n"
+#~ "Cannot get/download Zip archive: '%s'\n"
+#~ "for library path: '%s'.\n"
+#~ "Reason: '%s'"
+#~ msgstr ""
+#~ "%s\n"
+#~ "Konnte das Zip-Archiv '%s' nicht herunterladen.\n"
+#~ "Bibliothekspfad: '%s'\n"
+#~ "Grund: '%s'"
+
+#~ msgid ""
+#~ "Cannot download library '%s'.\n"
+#~ "The library does not exist on the server"
+#~ msgstr ""
+#~ "Bibliothek '%s' kann nicht herunter geladen werden.\n"
+#~ "Diese Bibliothek existiert nicht auf dem Server."
+
+#~ msgid "footprint library path '%s' does not exist"
+#~ msgstr "Der Footprintbibliothekspfad '%s' existiert nicht."
+
+#~ msgid "library <%s> has no footprint '%s' to delete"
+#~ msgstr ""
+#~ "Bibliothek <%s> besitzt keinen Footprint '%s', welcher gelöscht werden "
+#~ "kann."
+
+#~ msgid "Library '%s' is read only"
+#~ msgstr "Auf die Bibliothek '%s' kann nur lesend zugegriffen werden."
+
+#~ msgid "user does not have permission to delete directory '%s'"
+#~ msgstr "Keine Berechtigung zum Löschen von Verzeichnis '%s'."
+
+#~ msgid "library directory '%s' has unexpected sub-directories"
+#~ msgstr ""
+#~ "Das Bibliotheksverzeichnis '%s' enthält unerwartete Unterverzeichnisse."
+
+#~ msgid "unexpected file '%s' was found in library path '%s'"
+#~ msgstr ""
+#~ "Es wurde eine unerwartete Datei '%s' im Bibliothekspfad '%s' gefunden."
+
+#~ msgid "footprint library '%s' cannot be deleted"
+#~ msgstr "Die Footprintbibliothek '%s' konnte nicht gelöscht werden."
+
+#~ msgid ""
+#~ "invalid footprint ID in\n"
+#~ "file: <%s>\n"
+#~ "line: %d\n"
+#~ "offset: %d"
+#~ msgstr ""
+#~ "Unzulässige Footprint ID in\n"
+#~ "Datei: '%s'\n"
+#~ "Zeile: %d\n"
+#~ "Offset: %d"
+
+#~ msgid "Cannot create footprint library path '%s'"
+#~ msgstr "Der Footprintbibliothekspfad '%s' konnte nicht erstellen werden."
+
+#~ msgid "Footprint library path '%s' is read only"
+#~ msgstr ""
+#~ "Auf die Footprintbibliothek '%s' kann nur lesend zugegriffen werden."
+
+#~ msgid "Cannot rename temporary file '%s' to footprint library file '%s'"
+#~ msgstr ""
+#~ "Konnte temporäre Datei '%s' nicht in Footprintbibliotheksdatei '%s' "
+#~ "umbenennen."
+
+#~ msgid "Footprint library path '%s' does not exist"
+#~ msgstr "Footprintbibliothekspfad '%s' existiert nicht."
+
+#~ msgid "library '%s' has no footprint '%s' to delete"
+#~ msgstr ""
+#~ "Bibliothek '%s' besitzt keinen Footprint '%s', welcher gelöscht werden "
+#~ "kann."
+
+#~ msgid "Footprint file name '%s' is not valid."
+#~ msgstr "'%s' ist kein gültiger Footprintdateiname."
+
+#~ msgid "user does not have write permission to delete file '%s' "
+#~ msgstr "Keine Berechtigung zum Löschen der Datei '%s'."
+
+#~ msgid "cannot overwrite library path '%s'"
+#~ msgstr "Bibliothekspfad '%s' kann nicht überschrieben werden."
+
+#~ msgid "Cannot find component '%s' in footprint filter section of netlist."
+#~ msgstr ""
+#~ "Konnte das Bauteil '%s' in der Footprintfiltersektion der Netzliste nicht "
+#~ "finden."
+
+#~ msgid ""
+#~ "File '%s' is format version: %d.\n"
+#~ "I only support format version <= %d.\n"
+#~ "Please upgrade Pcbnew to load this file."
+#~ msgstr ""
+#~ "Das Format der Datei '%s' besitzt die Version: %d.\n"
+#~ "Unterstütze wird nur die Version <= %d.\n"
+#~ "Bitte aktualisieren Sie Pcbnew, um diese Datei zu laden."
+
+#~ msgid "Unknown sheet type '%s' on line:%d"
+#~ msgstr "Unbekannter Schaltplantyp '%s' in Zeile: %d"
+
+#~ msgid "Unknown padshape '%c=0x%02x' on line: %d of footprint: '%s'"
+#~ msgstr "Unbekannte Padform '%c=0x%02x' in Zeile: %d von Footprint: '%s'"
+
+#~ msgid "duplicate NETCLASS name '%s'"
+#~ msgstr "NETCLASS Namensduplikat '%s'"
+
+#~ msgid ""
+#~ "invalid float number in file: '%s'\n"
+#~ "line: %d, offset: %d"
+#~ msgstr ""
+#~ "Unzulässige Gleitkommazahl in Datei: '%s'\n"
+#~ "Zeile: %d, Spalte: %d"
+
+#~ msgid ""
+#~ "missing float number in file: '%s'\n"
+#~ "line: %d, offset: %d"
+#~ msgstr ""
+#~ "Fehlende Gleitkommazahl in Datei: '%s'\n"
+#~ "Zeile: %d, Spalte: %d"
+
+#~ msgid "File '%s' is empty or is not a legacy library"
+#~ msgstr ""
+#~ "Die Datei '%s' ist entweder leer oder keine im alten Format vorliegende "
+#~ "Bibliothek."
+
+#~ msgid "Library '%s' exists, OK to replace ?"
+#~ msgstr ""
+#~ "Die Bibliothek '%s' existiert bereits.\n"
+#~ "Möchten Sie diese ersetzen?"
+
+#~ msgid "OK to delete footprint %s in library '%s'"
+#~ msgstr "Möchten Sie den Footprint '%s' in der Bibliothek '%s' entfernen?"
+
+#~ msgid "File '%s' not found"
+#~ msgstr "Datei '%s' nicht gefunden."
+
+#~ msgid "Unable to find or load footprint %s from lib path '%s'"
+#~ msgstr ""
+#~ "Konnte Footprint '%s' im Bibliothekspfad '%s' nicht finden oder laden."
+
+#~ msgid "Unable to find or load footprint from path '%s'"
+#~ msgstr "Konnte Footprint im Pfad '%s' nicht finden oder laden."
+
+#~ msgid ""
+#~ "The footprint library '%s' could not be found in any of the search paths."
+#~ msgstr ""
+#~ "Die Footprintbibliothek '%s' konnte in keinem der Suchpfade gefunden "
+#~ "werden."
+
+#~ msgid "Library '%s' is read only, not writable"
+#~ msgstr ""
+#~ "Auf die Bibliothek '%s' kann nur lesend und nicht schreibend zugegriffen "
+#~ "werden."
+
+#~ msgid "Footprint exported to file '%s'"
+#~ msgstr "Footprint wurde in die Datei '%s' exportiert."
+
+#~ msgid "Footprint %s deleted from library '%s'"
+#~ msgstr "Footprint %s wurde aus der Bibliothek '%s' entfernt."
+
+#~ msgid "Footprint %s already exists in library '%s'"
+#~ msgstr "Footprint %s existiert bereits in der Bibliothek '%s'."
+
+#~ msgid "Legacy foot print export files (*.emp)|*.emp"
+#~ msgstr "Alte Footprint-Exportdateien (*.emp)|*.emp"
+
+#~ msgid "Unable to create or write file '%s'"
+#~ msgstr "Konnte Datei '%s' nicht erstellen"
+
+#~ msgid ""
+#~ "Error:\n"
+#~ "one of invalid chars '%s' found\n"
+#~ "in '%s'"
+#~ msgstr ""
+#~ "Fehler:\n"
+#~ "Unzulässiges Zeichen '%s' in '%s' gefunden."
+
+#~ msgid "Component [%s] replaced in '%s'"
+#~ msgstr "Bauteil [%s] ersetzt in '%s'."
+
+#~ msgid "Component [%s] added in  '%s'"
+#~ msgstr "Bauteil [%s] hinzugefügt zu '%s'."
+
+#~ msgid "Footprint '%s' saved"
+#~ msgstr "Footprint '%s' gespeichert"
+
+#~ msgid "Footprint library '%s' saved as '%s'."
+#~ msgstr "Die Footprintbibliothek '%s' wurde gespeichert als '%s'."
+
+#~ msgid "&Display and Hide"
+#~ msgstr "&Darstellung und Anzeige"
+
+#~ msgid "Gap"
+#~ msgstr "Zwischenraum"
+
+#~ msgid "Stub"
+#~ msgstr "Stichleitung"
+
+#~ msgid "Arc Stub"
+#~ msgstr "Teilkreisbogen"
+
+#~ msgid "No footprint defined for component '%s'.\n"
+#~ msgstr "Es wurde kein Footprint für die Komponente '%s' definiert.\n"
+
+#~ msgid ""
+#~ "Footprint of component '%s' changed: board footprint '%s', netlist "
+#~ "footprint '%s'\n"
+#~ msgstr ""
+#~ "Geänderter Footprint des Bauteils '%s': Platinen Footprint '%s', "
+#~ "Netzlisten Footprint '%s'\n"
+
+#~ msgid "Component '%s' footprint ID '%s' is not valid.\n"
+#~ msgstr "Bauteil '%s' mit ungültiger Footprint-ID '%s'.\n"
+
+#~ msgid ""
+#~ "Component '%s' footprint '%s' was not found in any libraries in the "
+#~ "footprint library table.\n"
+#~ msgstr ""
+#~ "Bauteil '%s' mit Footprint '%s' konnte in keiner Bibliothek der "
+#~ "Footprintbibliothekstabelle gefunden werden.\n"
+
+#~ msgid ""
+#~ "invalid footprint ID in\n"
+#~ "file: <%s>\n"
+#~ "line: %d"
+#~ msgstr ""
+#~ "Unzulässige Footprint ID in\n"
+#~ "Datei: <%s>\n"
+#~ "Zeile: %d"
+
+#~ msgid ""
+#~ "invalid floating point number in\n"
+#~ "file: <%s>\n"
+#~ "line: %d\n"
+#~ "offset: %d"
+#~ msgstr ""
+#~ "Unzulässige Gleitkommazahl in\n"
+#~ "Datei: <%s>\n"
+#~ "Zeile: %d\n"
+#~ "Spalte: %d"
+
+#~ msgid ""
+#~ "missing floating point number in\n"
+#~ "file: <%s>\n"
+#~ "line: %d\n"
+#~ "offset: %d"
+#~ msgstr ""
+#~ "Fehlende Gleitkommazahl in\n"
+#~ "Datei: <%s>\n"
+#~ "Zeile: %d\n"
+#~ "Spalte: %d"
+
+#~ msgid "Layer '%s' in file '%s' at line %d, is not in fixed layer hash"
+#~ msgstr ""
+#~ "Lage '%s' in Datei '%s' in Zeile %d wurde nicht in der Lagensektion "
+#~ "fixiert."
+
+#~ msgid ""
+#~ "Layer '%s' in file\n"
+#~ "'%s'\n"
+#~ "at line %d, position %d\n"
+#~ "was not defined in the layers section"
+#~ msgstr ""
+#~ "Lage '%s' in Datei\n"
+#~ "'%s'\n"
+#~ "Zeile %d an Position %d\n"
+#~ "wurde nicht in der Lagensektion definiert."
+
+#~ msgid "duplicate NETCLASS name '%s' in file <%s> at line %d, offset %d"
+#~ msgstr "NETCLASS Namensduplikat '%s' in Datei <%s>, Zeile %d, Spalte %d."
+
+#~ msgid ""
+#~ "invalid net ID in\n"
+#~ "file: <%s>\n"
+#~ "line: %d\n"
+#~ "offset: %d"
+#~ msgstr ""
+#~ "Unzulässige Netz ID in\n"
+#~ "Datei: '%s'\n"
+#~ "Zeile: %d\n"
+#~ "Offset: %d"
+
+#~ msgid "The auto save file '%s' could not be removed!"
+#~ msgstr ""
+#~ "Die automatisch gespeicherte Datei '%s' konnte nicht gelöscht werden!"
+
+#~ msgid "Component with value of '%s' has empty reference id."
+#~ msgstr "Das Bauteil mit dem Wert '%s' hat keine Referenz-ID."
+
+#~ msgid "Multiple components have identical reference IDs of '%s'."
+#~ msgstr "Mehrere Bauteile verfügen über die selbe Referenz-ID '%s'."
+
+#~ msgid "Filling zone %d out of %d (net %s)..."
+#~ msgstr "Fülle Fläche %d von %d (Netz %s) ..."
+
+#~ msgid "Starting zone fill..."
+#~ msgstr "Beginne Flächen zu füllen ..."
+
+#~ msgid "Updating ratsnest..."
+#~ msgstr "Aktualisiere Netzlinien ..."
 
 #~ msgid "default "
 #~ msgstr "Voreinstellung"
@@ -27662,9 +29400,6 @@ msgstr "Aktualisiere Netzlinien ..."
 #~ msgstr ""
 #~ "Bauteilbibliothek '%s' wurde nicht geladen.\n"
 #~ "Fehler: %s"
-
-#~ msgid "New Library"
-#~ msgstr "Neue Biblliothek"
 
 #~ msgid "Export Component"
 #~ msgstr "Bauteil exportieren"

--- a/de/kicad.po
+++ b/de/kicad.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: KiCad i18n Deutsch\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-12-18 07:51+0100\n"
-"PO-Revision-Date: 2017-12-18 08:22+0100\n"
+"POT-Creation-Date: 2017-12-22 22:31+0100\n"
+"PO-Revision-Date: 2017-12-22 22:31+0100\n"
 "Last-Translator: Carsten Schoenert <c.schoenert@t-online.de>\n"
 "Language-Team: \n"
 "Language: de_DE\n"
@@ -12,7 +12,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Poedit-Basepath: /mnt/kicad\n"
 "X-Poedit-KeywordsList: _;_HKI\n"
-"X-Generator: Poedit 1.8.11\n"
+"X-Generator: Poedit 1.8.7.1\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 "X-Poedit-Bookmarks: -1,2168,-1,-1,-1,-1,-1,-1,-1,-1\n"
@@ -171,7 +171,7 @@ msgstr "Konfigurationsvariable"
 
 #: 3d-viewer/3d_cache/dialogs/dlg_3d_pathconfig_base.cpp:81
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:202
-#: eeschema/libedit.cpp:644 eeschema/viewlibs.cpp:240
+#: eeschema/libedit.cpp:652 eeschema/viewlibs.cpp:240
 msgid "Alias"
 msgstr "Alias"
 
@@ -179,7 +179,7 @@ msgstr "Alias"
 #: common/dialog_about/AboutDialog_main.cpp:114
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:117
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:163
-#: eeschema/libedit.cpp:664 eeschema/sch_component.cpp:1464
+#: eeschema/libedit.cpp:672 eeschema/sch_component.cpp:1464
 #: eeschema/viewlibs.cpp:241
 #: pcbnew/dialogs/dialog_footprint_wizard_list_base.cpp:44
 #: pcbnew/librairi.cpp:850 eeschema/bom_table_column.h:34
@@ -205,7 +205,7 @@ msgid "Move Up"
 msgstr "Nach oben bewegen"
 
 #: 3d-viewer/3d_cache/dialogs/dlg_3d_pathconfig_base.cpp:113
-#: 3d-viewer/3d_canvas/eda_3d_canvas.cpp:674
+#: 3d-viewer/3d_canvas/eda_3d_canvas.cpp:671
 #: cvpcb/dialogs/dialog_config_equfiles_base.cpp:45
 #: eeschema/dialogs/dialog_sym_lib_table_base.cpp:152
 #: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:151
@@ -367,28 +367,28 @@ msgstr "Lagen erstellen"
 msgid "Cannot determine the board outline."
 msgstr "Konnte den Platinenumriss nicht bestimmen."
 
-#: 3d-viewer/3d_canvas/create_layer_items.cpp:1264
+#: 3d-viewer/3d_canvas/create_layer_items.cpp:1198
 msgid "Create tracks and vias"
 msgstr "Erstelle Leiterbahnen und Durchkontaktierungen:"
 
-#: 3d-viewer/3d_canvas/create_layer_items.cpp:1805
+#: 3d-viewer/3d_canvas/create_layer_items.cpp:1739
 msgid "Create zones"
 msgstr "Erstelle Flächen"
 
-#: 3d-viewer/3d_canvas/create_layer_items.cpp:1814
+#: 3d-viewer/3d_canvas/create_layer_items.cpp:1748
 #, c-format
 msgid "Create zones of layer %s"
 msgstr "Erstelle Flächen von Lage %s"
 
-#: 3d-viewer/3d_canvas/create_layer_items.cpp:1881
+#: 3d-viewer/3d_canvas/create_layer_items.cpp:1815
 msgid "Simplifying polygons"
 msgstr "Vereinfachung von Polygonen"
 
-#: 3d-viewer/3d_canvas/create_layer_items.cpp:1912
+#: 3d-viewer/3d_canvas/create_layer_items.cpp:1846
 msgid "Simplify holes contours"
 msgstr "Vereinfachung Lochkonturen"
 
-#: 3d-viewer/3d_canvas/create_layer_items.cpp:1959
+#: 3d-viewer/3d_canvas/create_layer_items.cpp:1893
 msgid "Build Tech layers"
 msgstr "Erstelle technische Lagen"
 
@@ -397,47 +397,47 @@ msgstr "Erstelle technische Lagen"
 msgid "Render time %.0f ms ( %.1f fps)"
 msgstr "Wiedergabezeit %.0f ms ( %.1f fps)"
 
-#: 3d-viewer/3d_canvas/eda_3d_canvas.cpp:610
+#: 3d-viewer/3d_canvas/eda_3d_canvas.cpp:607
 msgid "Zoom +"
 msgstr "Zoom +"
 
-#: 3d-viewer/3d_canvas/eda_3d_canvas.cpp:616
+#: 3d-viewer/3d_canvas/eda_3d_canvas.cpp:613
 msgid "Zoom -"
 msgstr "Zoom -"
 
-#: 3d-viewer/3d_canvas/eda_3d_canvas.cpp:623
+#: 3d-viewer/3d_canvas/eda_3d_canvas.cpp:620
 msgid "Top View"
 msgstr "Ansicht oben"
 
-#: 3d-viewer/3d_canvas/eda_3d_canvas.cpp:628
+#: 3d-viewer/3d_canvas/eda_3d_canvas.cpp:625
 msgid "Bottom View"
 msgstr "Ansicht unten"
 
-#: 3d-viewer/3d_canvas/eda_3d_canvas.cpp:635
+#: 3d-viewer/3d_canvas/eda_3d_canvas.cpp:632
 msgid "Right View"
 msgstr "Ansicht rechts"
 
-#: 3d-viewer/3d_canvas/eda_3d_canvas.cpp:640
+#: 3d-viewer/3d_canvas/eda_3d_canvas.cpp:637
 msgid "Left View"
 msgstr "Ansicht links"
 
-#: 3d-viewer/3d_canvas/eda_3d_canvas.cpp:647
+#: 3d-viewer/3d_canvas/eda_3d_canvas.cpp:644
 msgid "Front View"
 msgstr "Vorderansicht"
 
-#: 3d-viewer/3d_canvas/eda_3d_canvas.cpp:652
+#: 3d-viewer/3d_canvas/eda_3d_canvas.cpp:649
 msgid "Back View"
 msgstr "Rückansicht"
 
-#: 3d-viewer/3d_canvas/eda_3d_canvas.cpp:659
+#: 3d-viewer/3d_canvas/eda_3d_canvas.cpp:656
 msgid "Move Left <-"
 msgstr "Nach links bewegen <-"
 
-#: 3d-viewer/3d_canvas/eda_3d_canvas.cpp:664
+#: 3d-viewer/3d_canvas/eda_3d_canvas.cpp:661
 msgid "Move Right ->"
 msgstr "Nach rechts bewegen ->"
 
-#: 3d-viewer/3d_canvas/eda_3d_canvas.cpp:669
+#: 3d-viewer/3d_canvas/eda_3d_canvas.cpp:666
 msgid "Move Up ^"
 msgstr "Nach oben bewegen ^"
 
@@ -1158,7 +1158,7 @@ msgstr "DPI"
 msgid "Load Bitmap"
 msgstr "Bitmap laden"
 
-#: bitmap2component/bitmap2cmp_gui_base.cpp:124 eeschema/libeditframe.cpp:1228
+#: bitmap2component/bitmap2cmp_gui_base.cpp:124 eeschema/libeditframe.cpp:1233
 msgid "Export"
 msgstr "Exportieren"
 
@@ -1195,7 +1195,7 @@ msgstr "Format"
 #: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:203
 #: eeschema/dialogs/dialog_edit_label_base.cpp:76
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:107
-#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:95 eeschema/libedit.cpp:654
+#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:95 eeschema/libedit.cpp:662
 #: eeschema/sch_text.cpp:663 gerbview/class_gerber_file_image.cpp:353
 #: gerbview/class_gerber_file_image.cpp:357
 #: gerbview/class_gerber_file_image.cpp:360 pcbnew/class_module.cpp:570
@@ -1466,7 +1466,7 @@ msgid "Block Paste"
 msgstr "Gruppe einfügen"
 
 #: common/block_commande.cpp:97 common/tool/zoom_tool.cpp:55
-#: eeschema/libeditframe.cpp:1175 eeschema/schedit.cpp:514
+#: eeschema/libeditframe.cpp:1180 eeschema/schedit.cpp:514
 #: eeschema/tool_lib.cpp:172 eeschema/tool_sch.cpp:121
 #: gerbview/events_called_functions.cpp:237 gerbview/toolbars_gerber.cpp:92
 #: pagelayout_editor/events_functions.cpp:136 pagelayout_editor/menubar.cpp:143
@@ -1810,7 +1810,7 @@ msgstr "Schließen"
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:318
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:321
 #: eeschema/dialogs/dialog_lib_edit_pin_table.cpp:182 eeschema/lib_pin.cpp:1703
-#: eeschema/libedit.cpp:633 eeschema/widgets/tuner_slider_base.cpp:20
+#: eeschema/libedit.cpp:641 eeschema/widgets/tuner_slider_base.cpp:20
 #: pcb_calculator/dialogs/dialog_regulator_data_base.cpp:26
 #: pcbnew/dialogs/dialog_footprint_wizard_list_base.cpp:43
 #: pcbnew/dialogs/dialog_layers_setup.cpp:336
@@ -1962,7 +1962,7 @@ msgstr "Pfade der KiCad Umgebungsvariablen"
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:225
 #: eeschema/dialogs/dialog_spice_model_base.cpp:519
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:75
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1069
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1087
 msgid "Add"
 msgstr "Hinzufügen"
 
@@ -1976,7 +1976,7 @@ msgstr "Pfadprefix hinzufügen"
 #: eeschema/libedit_onrightclick.cpp:288 eeschema/onrightclick.cpp:517
 #: eeschema/onrightclick.cpp:553 eeschema/onrightclick.cpp:589
 #: eeschema/onrightclick.cpp:623 eeschema/onrightclick.cpp:805
-#: eeschema/onrightclick.cpp:836 eeschema/widgets/cmp_tree_pane.cpp:61
+#: eeschema/onrightclick.cpp:836
 #: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:38
 #: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:54
 #: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:52
@@ -1995,7 +1995,6 @@ msgstr "Ausgewählten Pfadprefix bearbeiten"
 #: common/dialogs/dialog_env_var_config_base.cpp:44
 #: cvpcb/dialogs/dialog_config_equfiles_base.cpp:39
 #: eeschema/dialogs/dialog_spice_model_base.cpp:527
-#: eeschema/widgets/cmp_tree_pane.cpp:62
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:80
 msgid "Remove"
 msgstr "Entfernen"
@@ -2126,7 +2125,7 @@ msgstr "Spiegeln Y"
 #: common/dialogs/dialog_image_editor_base.cpp:39
 #: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:195
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:99
-#: pcbnew/onrightclick.cpp:998 pcbnew/tools/edit_tool.cpp:684
+#: pcbnew/onrightclick.cpp:998 pcbnew/tools/edit_tool.cpp:686
 msgid "Rotate"
 msgstr "Rotieren"
 
@@ -2777,8 +2776,8 @@ msgstr "Unzulässiges Zeichen in der Revision gefunden."
 
 #: common/page_layout/page_layout_reader.cpp:839
 #, c-format
-msgid "The file <%s> was not fully read"
-msgstr "Die Datei <%s> wurde nicht vollständig eingelesen."
+msgid "The file \"%s\" was not fully read"
+msgstr ""
 
 #: common/pgm_base.cpp:112 common/widgets/footprint_select_widget.cpp:275
 #: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:56
@@ -3439,18 +3438,18 @@ msgstr "Pos "
 
 #: common/wxwineda.cpp:170
 #: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:89
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:783
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:805
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:907
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:801
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:823
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:925
 #: pcbnew/dialogs/dialog_target_properties_base.cpp:54
 msgid "X"
 msgstr "X"
 
 #: common/wxwineda.cpp:183
 #: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:100
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:790
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:812
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:914
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:808
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:830
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:932
 msgid "Y"
 msgstr "Y"
 
@@ -4076,7 +4075,7 @@ msgstr "Konnte Bauteil-Footprint Zuordnungsdatei '%s' nicht öffnen."
 msgid "No item to paste."
 msgstr "Kein Element zum einfügen."
 
-#: eeschema/block.cpp:495 eeschema/files-io.cpp:478 eeschema/sheet.cpp:291
+#: eeschema/block.cpp:495 eeschema/files-io.cpp:479 eeschema/sheet.cpp:291
 #, c-format
 msgid ""
 "The sheet changes cannot be made because the destination sheet already has "
@@ -4181,7 +4180,7 @@ msgid ""
 msgstr ""
 
 #: eeschema/cmp_tree_model.cpp:122 eeschema/lib_draw_item.cpp:72
-#: eeschema/libedit.cpp:649 eeschema/onrightclick.cpp:481
+#: eeschema/libedit.cpp:657 eeschema/onrightclick.cpp:481
 #: pcbnew/dialogs/dialog_graphic_item_properties_base.cpp:37
 #: pcbnew/dialogs/dialog_graphic_item_properties_base.cpp:48
 #: pcbnew/dialogs/dialog_graphic_item_properties_base.cpp:59
@@ -4230,21 +4229,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: eeschema/cmp_tree_model_adapter_base.cpp:113 eeschema/libeditframe.cpp:1621
+#: eeschema/cmp_tree_model_adapter_base.cpp:113 eeschema/libeditframe.cpp:1626
 msgid "Loading symbol libraries"
 msgstr ""
 
-#: eeschema/cmp_tree_model_adapter_base.cpp:122 eeschema/libeditframe.cpp:1625
+#: eeschema/cmp_tree_model_adapter_base.cpp:122 eeschema/libeditframe.cpp:1630
 #, c-format
 msgid "Loading library \"%s\""
 msgstr ""
 
-#: eeschema/cmp_tree_model_adapter_base.cpp:182 eeschema/libedit.cpp:661
+#: eeschema/cmp_tree_model_adapter_base.cpp:185 eeschema/libedit.cpp:669
 #: eeschema/viewlibs.cpp:239
 msgid "Part"
 msgstr "Bauteil"
 
-#: eeschema/cmp_tree_model_adapter_base.cpp:183
+#: eeschema/cmp_tree_model_adapter_base.cpp:186
 msgid "Desc"
 msgstr "Beschreibung"
 
@@ -4285,9 +4284,9 @@ msgstr "Unterschiedliche Werte für %s%d%s (%s) und %s%d%s (%s)"
 msgid "Duplicate time stamp (%s) for %s%d and %s%d"
 msgstr "Doppelter Zeitstempel (%s) für %s%d und %s%d"
 
-#: eeschema/controle.cpp:177 eeschema/libeditframe.cpp:1355
+#: eeschema/controle.cpp:177 eeschema/libeditframe.cpp:1360
 #: pcbnew/controle.cpp:231 pcbnew/modedit.cpp:133
-#: pcbnew/tools/selection_tool.cpp:1333
+#: pcbnew/tools/selection_tool.cpp:1332
 msgid "Clarify Selection"
 msgstr "Auswahl klarstellen"
 
@@ -4827,14 +4826,14 @@ msgstr ""
 #: pcbnew/dialogs/dialog_netlist_fbp.cpp:55
 #: pcbnew/dialogs/dialog_netlist_fbp.cpp:63
 #: pcbnew/dialogs/dialog_netlist_fbp.cpp:71
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1072
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1090
 #: pcbnew/modedit_onclick.cpp:389 pcbnew/modedit_onclick.cpp:426
 #: pcbnew/onrightclick.cpp:221 pcbnew/onrightclick.cpp:286
 #: pcbnew/onrightclick.cpp:316 pcbnew/onrightclick.cpp:495
 #: pcbnew/onrightclick.cpp:642 pcbnew/onrightclick.cpp:724
 #: pcbnew/onrightclick.cpp:831 pcbnew/onrightclick.cpp:901
 #: pcbnew/onrightclick.cpp:958 pcbnew/onrightclick.cpp:1010
-#: pcbnew/tools/edit_tool.cpp:141 pcbnew/tools/edit_tool.cpp:867
+#: pcbnew/tools/edit_tool.cpp:141 pcbnew/tools/edit_tool.cpp:869
 msgid "Delete"
 msgstr "Entfernen"
 
@@ -4975,10 +4974,10 @@ msgstr "Austauschbare Einheiten:"
 #: pcbnew/dialogs/dialog_move_exact_base.cpp:64
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:131
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:391
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:911
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:918
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:932
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1100
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:929
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:936
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:950
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1118
 #: pcbnew/dialogs/dialog_position_relative_base.cpp:34
 #: pcbnew/dialogs/dialog_position_relative_base.cpp:48
 #: pcbnew/dialogs/dialog_position_relative_base.cpp:62
@@ -5228,11 +5227,11 @@ msgstr "Die Textgröße des aktuell ausgewählten Feldes"
 #: pcbnew/dialogs/dialog_modedit_options_base.cpp:65
 #: pcbnew/dialogs/dialog_modedit_options_base.cpp:76
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:253
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:797
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:819
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:859
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:921
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1103
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:815
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:837
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:877
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:939
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1121
 #: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:76
 #: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:105
 #: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:116
@@ -5550,7 +5549,7 @@ msgstr ""
 #: eeschema/dialogs/dialog_edit_line_style_base.cpp:62
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:153
 #: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:197
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:503
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:509
 msgid "Solid"
 msgstr "Solide"
 
@@ -6094,15 +6093,15 @@ msgstr "Nummer"
 #: eeschema/dialogs/dialog_spice_model_base.cpp:30
 #: eeschema/dialogs/dialog_spice_model_base.cpp:233
 #: eeschema/lib_draw_item.cpp:65 eeschema/lib_pin.cpp:1707
-#: eeschema/libedit.cpp:663 eeschema/sch_text.cpp:690
+#: eeschema/libedit.cpp:671 eeschema/sch_text.cpp:690
 #: gerbview/class_gerber_draw_item.cpp:679
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:29
 #: pcb_calculator/dialogs/dialog_regulator_data_base.cpp:47
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:163
-#: pcbnew/class_drawsegment.cpp:359 pcbnew/class_marker_pcb.cpp:98
+#: pcbnew/class_drawsegment.cpp:402 pcbnew/class_marker_pcb.cpp:98
 #: pcbnew/class_text_mod.cpp:372 pcbnew/class_track.cpp:1151
 #: pcbnew/class_track.cpp:1178 pcbnew/class_track.cpp:1227
-#: pcbnew/class_zone.cpp:828 pcbnew/dialogs/dialog_layers_setup.cpp:342
+#: pcbnew/class_zone.cpp:822 pcbnew/dialogs/dialog_layers_setup.cpp:342
 msgid "Type"
 msgstr "Typ"
 
@@ -7350,7 +7349,7 @@ msgstr ""
 msgid "Please Delete or Modify One"
 msgstr "Bitte einen Nicknamen entfernen oder ändern."
 
-#: eeschema/dialogs/dialog_sym_lib_table.cpp:350 eeschema/libeditframe.cpp:1556
+#: eeschema/dialogs/dialog_sym_lib_table.cpp:350 eeschema/libeditframe.cpp:1561
 #: pcbnew/librairi.cpp:80
 msgid "Select Library"
 msgstr "Wähle Bibliothek"
@@ -7440,7 +7439,7 @@ msgstr ""
 "Dies ist eine nicht veränderbare Tabelle, welche die entsprechenden "
 "Umgebungsvariablen anzeigt."
 
-#: eeschema/dialogs/dialog_symbol_remap.cpp:51
+#: eeschema/dialogs/dialog_symbol_remap.cpp:53
 msgid ""
 "This schematic currently uses the symbol library list look up method for "
 "loading schematic symbols.  KiCad will attempt to map the existing symbols "
@@ -7451,17 +7450,17 @@ msgid ""
 "responsible for manually remapping the symbols."
 msgstr ""
 
-#: eeschema/dialogs/dialog_symbol_remap.cpp:158
+#: eeschema/dialogs/dialog_symbol_remap.cpp:162
 #, c-format
 msgid "Adding library \"%s\", file \"%s\" to project symbol library table."
 msgstr ""
 
-#: eeschema/dialogs/dialog_symbol_remap.cpp:167
+#: eeschema/dialogs/dialog_symbol_remap.cpp:171
 #, c-format
 msgid "Library \"%s\" not found."
 msgstr ""
 
-#: eeschema/dialogs/dialog_symbol_remap.cpp:184
+#: eeschema/dialogs/dialog_symbol_remap.cpp:188
 #, c-format
 msgid ""
 "Failed to write project symbol library table. Error:\n"
@@ -7470,39 +7469,39 @@ msgstr ""
 "Konnte die Bauteilsymboltabelle des Projektes nicht erstellen.\n"
 "Fehler: %s"
 
-#: eeschema/dialogs/dialog_symbol_remap.cpp:189
+#: eeschema/dialogs/dialog_symbol_remap.cpp:193
 msgid "Created project symbol library table.\n"
 msgstr "Erstellt eine leere projektspezifische Symbolbibliothekstabelle.\n"
 
-#: eeschema/dialogs/dialog_symbol_remap.cpp:217
+#: eeschema/dialogs/dialog_symbol_remap.cpp:221
 #, c-format
 msgid "No symbol \"%s\" found in symbol library table."
 msgstr ""
 
-#: eeschema/dialogs/dialog_symbol_remap.cpp:223
+#: eeschema/dialogs/dialog_symbol_remap.cpp:227
 #, c-format
 msgid "Symbol \"%s\" mapped to symbol library \"%s\"."
 msgstr ""
 
-#: eeschema/dialogs/dialog_symbol_remap.cpp:232
+#: eeschema/dialogs/dialog_symbol_remap.cpp:236
 msgid "Symbol library table mapping complete!"
 msgstr "Kartierung der Symbolbibliothekstabelle ist fertig gestellt!"
 
-#: eeschema/dialogs/dialog_symbol_remap.cpp:303
-#: eeschema/dialogs/dialog_symbol_remap.cpp:318
-#: eeschema/dialogs/dialog_symbol_remap.cpp:338
-#: eeschema/dialogs/dialog_symbol_remap.cpp:351
-#: eeschema/dialogs/dialog_symbol_remap.cpp:365
+#: eeschema/dialogs/dialog_symbol_remap.cpp:307
+#: eeschema/dialogs/dialog_symbol_remap.cpp:322
+#: eeschema/dialogs/dialog_symbol_remap.cpp:342
+#: eeschema/dialogs/dialog_symbol_remap.cpp:355
+#: eeschema/dialogs/dialog_symbol_remap.cpp:369
 #, c-format
 msgid "Failed to back up file \"%s\".\n"
 msgstr ""
 
-#: eeschema/dialogs/dialog_symbol_remap.cpp:371
+#: eeschema/dialogs/dialog_symbol_remap.cpp:375
 msgid "Some of the project files could not be backed up."
 msgstr ""
 
 #: eeschema/dialogs/dialog_symbol_remap_base.cpp:30 eeschema/menubar.cpp:505
-#: eeschema/dialogs/dialog_symbol_remap_base.h:50
+#: eeschema/dialogs/dialog_symbol_remap_base.h:51
 msgid "Remap Symbols"
 msgstr "Symbole neu zuordnen"
 
@@ -7536,7 +7535,7 @@ msgstr ""
 msgid "Couldn't load image from \"%s\""
 msgstr ""
 
-#: eeschema/edit_component_in_schematic.cpp:82
+#: eeschema/edit_component_in_schematic.cpp:65
 #, c-format
 msgid "Edit %s Field"
 msgstr "Feld %s editieren"
@@ -7782,7 +7781,7 @@ msgstr "Datei %s gespeichert."
 msgid "File write operation failed."
 msgstr "Konnte Datei nicht schreiben."
 
-#: eeschema/files-io.cpp:210 eeschema/files-io.cpp:778
+#: eeschema/files-io.cpp:210 eeschema/files-io.cpp:779
 #, c-format
 msgid "Schematic file \"%s\" is already open."
 msgstr ""
@@ -7792,20 +7791,20 @@ msgstr ""
 msgid "Schematic \"%s\" does not exist.  Do you wish to create it?"
 msgstr ""
 
-#: eeschema/files-io.cpp:300 eeschema/files-io.cpp:450 eeschema/sheet.cpp:254
+#: eeschema/files-io.cpp:300 eeschema/files-io.cpp:451 eeschema/sheet.cpp:254
 msgid ""
 "The entire schematic could not be load.  Errors occurred attempting to load "
 "hierarchical sheet schematics."
 msgstr ""
 
-#: eeschema/files-io.cpp:314 eeschema/files-io.cpp:824
+#: eeschema/files-io.cpp:314 eeschema/files-io.cpp:825
 #, c-format
 msgid ""
 "Error loading schematic file \"%s\".\n"
 "%s"
 msgstr ""
 
-#: eeschema/files-io.cpp:318 eeschema/files-io.cpp:828
+#: eeschema/files-io.cpp:318 eeschema/files-io.cpp:829
 #, c-format
 msgid "Failed to load \"%s\""
 msgstr ""
@@ -7821,53 +7820,53 @@ msgstr ""
 "defekte Datei zu reparieren. Andernfalls kann passieren, dass die Datei in "
 "anderen Versionen von KiCad nicht benutzbar ist."
 
-#: eeschema/files-io.cpp:401
+#: eeschema/files-io.cpp:402
 msgid "Append Schematic"
 msgstr "Schaltplan hinzufügen"
 
-#: eeschema/files-io.cpp:458 eeschema/sheet.cpp:262
+#: eeschema/files-io.cpp:459 eeschema/sheet.cpp:262
 #, c-format
 msgid "Error occurred loading schematic file \"%s\"."
 msgstr ""
 
-#: eeschema/files-io.cpp:461 eeschema/sheet.cpp:265
+#: eeschema/files-io.cpp:462 eeschema/sheet.cpp:265
 #, c-format
 msgid "Failed to load schematic \"%s\""
 msgstr ""
 
-#: eeschema/files-io.cpp:526
+#: eeschema/files-io.cpp:527
 #, c-format
 msgid "An error occurred loading the symbol library table \"%s\"."
 msgstr ""
 
-#: eeschema/files-io.cpp:648
+#: eeschema/files-io.cpp:649
 msgid ""
 "This operation cannot be undone.\n"
 "\n"
 "Do you want to save the current document before proceeding?"
 msgstr ""
 
-#: eeschema/files-io.cpp:668
+#: eeschema/files-io.cpp:669
 msgid "Import Schematic"
 msgstr "Schaltplanimport"
 
-#: eeschema/files-io.cpp:699
+#: eeschema/files-io.cpp:700
 #, c-format
 msgid "Directory \"%s\" is not writable."
 msgstr ""
 
-#: eeschema/files-io.cpp:854
+#: eeschema/files-io.cpp:855
 msgid ""
 "The current schematic has been modified.  Do you wish to save the changes?"
 msgstr ""
 "Der gegenwärtige Schaltplan wurde verändert. Möchten Sie die Änderungen "
 "speichern?"
 
-#: eeschema/files-io.cpp:856 pcbnew/files.cpp:437
+#: eeschema/files-io.cpp:857 pcbnew/files.cpp:437
 msgid "Save and Load"
 msgstr "Speichern und Laden"
 
-#: eeschema/files-io.cpp:857 pcbnew/files.cpp:438
+#: eeschema/files-io.cpp:858 pcbnew/files.cpp:438
 msgid "Load Without Saving"
 msgstr "Laden ohne zu Speichern"
 
@@ -8222,10 +8221,10 @@ msgid "Add Pin"
 msgstr "Pin hinzufügen"
 
 #: eeschema/lib_arc.cpp:95 gerbview/class_gerber_draw_item.cpp:236
-#: pcbnew/class_board_item.cpp:45 pcbnew/class_drawsegment.cpp:370
+#: pcbnew/class_board_item.cpp:45 pcbnew/class_drawsegment.cpp:413
 #: pcbnew/dialogs/dialog_pad_basicshapes_properties.cpp:93
 #: pcbnew/dialogs/dialog_pad_properties.cpp:743
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1849
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1856
 msgid "Arc"
 msgstr "Kreisbogen"
 
@@ -8256,7 +8255,7 @@ msgid "Bezier"
 msgstr "Bezierkurve"
 
 #: eeschema/lib_circle.cpp:53 gerbview/class_gerber_draw_item.cpp:239
-#: pcbnew/class_board_item.cpp:46 pcbnew/class_drawsegment.cpp:366
+#: pcbnew/class_board_item.cpp:46 pcbnew/class_drawsegment.cpp:409
 #: pcbnew/class_pad.cpp:1134
 #: pcbnew/dialogs/dialog_pad_basicshapes_properties.cpp:108
 msgid "Circle"
@@ -8352,7 +8351,7 @@ msgstr ""
 msgid "Footprint"
 msgstr "Footprint"
 
-#: eeschema/lib_field.cpp:463 eeschema/libedit.cpp:666
+#: eeschema/lib_field.cpp:463 eeschema/libedit.cpp:674
 #: eeschema/template_fieldnames.cpp:48 eeschema/bom_table_column.h:37
 msgid "Datasheet"
 msgstr "Datenblatt"
@@ -8367,7 +8366,7 @@ msgstr "Feld%d"
 msgid "Field %s %s"
 msgstr "Feld %s %s"
 
-#: eeschema/lib_field.cpp:618 pcbnew/class_drawsegment.cpp:403
+#: eeschema/lib_field.cpp:618 pcbnew/class_drawsegment.cpp:446
 #: pcbnew/class_pad.cpp:707 pcbnew/class_pcb_text.cpp:149
 #: pcbnew/class_text_mod.cpp:398 pcbnew/class_track.cpp:1166
 #: pcbnew/class_track.cpp:1193 pcbnew/dialogs/dialog_design_rules_base.cpp:354
@@ -8386,7 +8385,7 @@ msgstr "Höhe"
 msgid "Pin"
 msgstr "Pin"
 
-#: eeschema/lib_pin.cpp:1724 pcbnew/class_drawsegment.cpp:384
+#: eeschema/lib_pin.cpp:1724 pcbnew/class_drawsegment.cpp:427
 #: pcbnew/class_track.cpp:1054
 msgid "Length"
 msgstr "Länge"
@@ -8398,12 +8397,12 @@ msgid "Orientation"
 msgstr "Ausrichtung"
 
 #: eeschema/lib_pin.cpp:1740 eeschema/lib_pin.cpp:1759
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1050
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1068
 msgid "Pos X"
 msgstr "Pos X"
 
 #: eeschema/lib_pin.cpp:1743 eeschema/lib_pin.cpp:1762
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1051
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1069
 msgid "Pos Y"
 msgstr "Pos Y"
 
@@ -8504,79 +8503,80 @@ msgstr ""
 msgid "Symbol \"%s\" already exists in library \"%s\""
 msgstr ""
 
-#: eeschema/libedit.cpp:480
+#: eeschema/libedit.cpp:488
 #, c-format
 msgid "Part name \"%s\" not found in library \"%s\""
 msgstr ""
 
-#: eeschema/libedit.cpp:504
+#: eeschema/libedit.cpp:512
 msgid "No library specified."
 msgstr "Keine Bibliothek angegeben."
 
-#: eeschema/libedit.cpp:521
+#: eeschema/libedit.cpp:529
 #, c-format
 msgid "Save Library \"%s\" As..."
 msgstr ""
 
-#: eeschema/libedit.cpp:559
+#: eeschema/libedit.cpp:567
 #, c-format
 msgid "Failed to save changes to symbol library file \"%s\""
 msgstr ""
 
-#: eeschema/libedit.cpp:561
+#: eeschema/libedit.cpp:569
 msgid "Error saving library"
 msgstr ""
 
-#: eeschema/libedit.cpp:568
+#: eeschema/libedit.cpp:576
 #, c-format
 msgid "Symbol library file \"%s\" saved"
 msgstr ""
 
-#: eeschema/libedit.cpp:570
+#: eeschema/libedit.cpp:578
 #, c-format
 msgid "Symbol library documentation file \"%s\" saved"
 msgstr ""
 
-#: eeschema/libedit.cpp:601
+#: eeschema/libedit.cpp:609
 msgid "Save Libraries"
 msgstr ""
 
-#: eeschema/libedit.cpp:602
+#: eeschema/libedit.cpp:610
 msgid "Select libraries to save before closing"
 msgstr ""
 
-#: eeschema/libedit.cpp:603
+#: eeschema/libedit.cpp:611
 msgid ""
 "Some libraries could not be saved to their original files.\n"
 "\n"
 "Do you want to save them to a new file?"
 msgstr ""
 
-#: eeschema/libedit.cpp:636 eeschema/viewlibs.cpp:226
+#: eeschema/libedit.cpp:644 eeschema/viewlibs.cpp:226
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:50
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:128
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:153
 #: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:197
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:327
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:503
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:509
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:558
 #: pcbnew/dialogs/dialog_plot_base.cpp:141
 msgid "None"
 msgstr "Keine"
 
-#: eeschema/libedit.cpp:652 eeschema/onrightclick.cpp:456
+#: eeschema/libedit.cpp:660 eeschema/onrightclick.cpp:456
 msgid "Convert"
 msgstr "Umwandeln"
 
-#: eeschema/libedit.cpp:656
+#: eeschema/libedit.cpp:664
 #: eeschema/widgets/widget_eeschema_color_config.cpp:71
 msgid "Body"
 msgstr "Gehäuse"
 
-#: eeschema/libedit.cpp:659
+#: eeschema/libedit.cpp:667
 msgid "Power Symbol"
 msgstr "Spannungsquellensymbol"
 
-#: eeschema/libedit.cpp:665 eeschema/viewlibs.cpp:242
+#: eeschema/libedit.cpp:673 eeschema/viewlibs.cpp:242
 msgid "Key words"
 msgstr "Schlüsselwörter"
 
@@ -8650,7 +8650,7 @@ msgstr "Linienende"
 msgid "Edit Line Options"
 msgstr "Linien Optionen editieren"
 
-#: eeschema/libedit_onrightclick.cpp:303 eeschema/libeditframe.cpp:1641
+#: eeschema/libedit_onrightclick.cpp:303 eeschema/libeditframe.cpp:1646
 msgid "Global"
 msgstr "Global"
 
@@ -8741,96 +8741,97 @@ msgstr ""
 msgid "Unit %s"
 msgstr "Einheit %s"
 
-#: eeschema/libeditframe.cpp:531
-msgid "Save [Read Only]"
+#: eeschema/libeditframe.cpp:530
+msgid "&Save Part [Read Only]"
 msgstr ""
 
-#: eeschema/libeditframe.cpp:531 eeschema/widgets/cmp_tree_pane.cpp:64
-#: eeschema/widgets/tuner_slider_base.cpp:66 pagelayout_editor/hotkeys.cpp:96
-msgid "Save"
-msgstr "Speichern"
-
-#: eeschema/libeditframe.cpp:581
-msgid "Save library [Read Only]"
+#: eeschema/libeditframe.cpp:530 eeschema/menubar_libedit.cpp:197
+#: eeschema/widgets/cmp_tree_pane.cpp:64
+msgid "&Save Part"
 msgstr ""
 
-#: eeschema/libeditframe.cpp:581 eeschema/widgets/cmp_tree_pane.cpp:52
-msgid "Save library"
+#: eeschema/libeditframe.cpp:583
+msgid "&Save Library [Read Only]"
 msgstr ""
 
-#: eeschema/libeditframe.cpp:1183
+#: eeschema/libeditframe.cpp:584 eeschema/menubar_libedit.cpp:82
+#: eeschema/widgets/cmp_tree_pane.cpp:52
+msgid "&Save Library"
+msgstr ""
+
+#: eeschema/libeditframe.cpp:1188
 msgid "Add pin"
 msgstr "Pin hinzufügen"
 
-#: eeschema/libeditframe.cpp:1187
+#: eeschema/libeditframe.cpp:1192
 msgid "Set pin options"
 msgstr "Pinoptionen festlegen"
 
-#: eeschema/libeditframe.cpp:1198 eeschema/schedit.cpp:552 pcbnew/edit.cpp:1507
+#: eeschema/libeditframe.cpp:1203 eeschema/schedit.cpp:552 pcbnew/edit.cpp:1507
 #: pcbnew/modedit.cpp:952 pcbnew/tools/drawing_tool.cpp:331
 msgid "Add text"
 msgstr "Text hinzufügen"
 
-#: eeschema/libeditframe.cpp:1202
+#: eeschema/libeditframe.cpp:1207
 msgid "Add rectangle"
 msgstr "Rechteck hinzufügen"
 
-#: eeschema/libeditframe.cpp:1206 pcbnew/modedit.cpp:948
+#: eeschema/libeditframe.cpp:1211 pcbnew/modedit.cpp:948
 msgid "Add circle"
 msgstr "Kreis hinzufügen"
 
-#: eeschema/libeditframe.cpp:1210 pcbnew/modedit.cpp:944
+#: eeschema/libeditframe.cpp:1215 pcbnew/modedit.cpp:944
 msgid "Add arc"
 msgstr "Kreisbogen hinzufügen"
 
-#: eeschema/libeditframe.cpp:1214 pcbnew/modedit.cpp:940
+#: eeschema/libeditframe.cpp:1219 pcbnew/modedit.cpp:940
 msgid "Add line"
 msgstr "Linie hinzufügen"
 
-#: eeschema/libeditframe.cpp:1218
+#: eeschema/libeditframe.cpp:1223
 msgid "Set anchor position"
 msgstr "Lege Ankerposition fest"
 
-#: eeschema/libeditframe.cpp:1222
+#: eeschema/libeditframe.cpp:1227
 msgid "Import"
 msgstr "Importieren"
 
-#: eeschema/libeditframe.cpp:1240 eeschema/schedit.cpp:588 pcbnew/edit.cpp:1519
+#: eeschema/libeditframe.cpp:1245 eeschema/schedit.cpp:588 pcbnew/edit.cpp:1519
 #: pcbnew/modedit.cpp:977 pcbnew/tool_modedit.cpp:195
 #: pcbnew/tools/pcbnew_control.cpp:720 eeschema/help_common_strings.h:48
 msgid "Delete item"
 msgstr "Element entfernen"
 
-#: eeschema/libeditframe.cpp:1521
+#: eeschema/libeditframe.cpp:1526
 #, c-format
 msgid "Library \"%s\" already exists"
 msgstr ""
 
-#: eeschema/libeditframe.cpp:1536
+#: eeschema/libeditframe.cpp:1541
 msgid "Could not create the library file. Check write permission."
 msgstr ""
 
-#: eeschema/libeditframe.cpp:1543
+#: eeschema/libeditframe.cpp:1548
 msgid "Could not open the library file."
 msgstr ""
 
-#: eeschema/libeditframe.cpp:1556
+#: eeschema/libeditframe.cpp:1561
 msgid "New Library"
 msgstr "Neue Biblliothek"
 
-#: eeschema/libeditframe.cpp:1642
+#: eeschema/libeditframe.cpp:1647
 msgid "Project"
 msgstr ""
 
-#: eeschema/libeditframe.cpp:1644
+#: eeschema/libeditframe.cpp:1649
 msgid "Select Symbol Library Table"
 msgstr ""
 
-#: eeschema/libeditframe.cpp:1645
+#: eeschema/libeditframe.cpp:1650
 msgid "Choose the Library Table to add the library:"
 msgstr ""
 
-#: eeschema/libeditframe.cpp:1667
+#: eeschema/libeditframe.cpp:1672
 msgid "Failed to save backup document to file "
 msgstr ""
 
@@ -9318,7 +9319,7 @@ msgid "Import and export settings"
 msgstr "Einstellungen Import/Export"
 
 #: eeschema/menubar_libedit.cpp:68
-msgid "&Create New Library"
+msgid "&New Library"
 msgstr ""
 
 #: eeschema/menubar_libedit.cpp:69
@@ -9326,23 +9327,19 @@ msgid "Creates an empty library"
 msgstr ""
 
 #: eeschema/menubar_libedit.cpp:74
-msgid "&Add Existing Library"
+msgid "&Add Library"
 msgstr ""
 
 #: eeschema/menubar_libedit.cpp:75
 msgid "Adds a previously created library"
 msgstr ""
 
-#: eeschema/menubar_libedit.cpp:82
-msgid "&Save Library"
-msgstr ""
-
 #: eeschema/menubar_libedit.cpp:85
 msgid "Save the current active library"
 msgstr "Momentan aktive Bauteilbibliothek speichern"
 
-#: eeschema/menubar_libedit.cpp:90
-msgid "&Save Library As.."
+#: eeschema/menubar_libedit.cpp:90 eeschema/widgets/cmp_tree_pane.cpp:53
+msgid "Save Library As..."
 msgstr ""
 
 #: eeschema/menubar_libedit.cpp:91
@@ -9350,7 +9347,7 @@ msgid "Save the current library to a new file"
 msgstr ""
 
 #: eeschema/menubar_libedit.cpp:96
-msgid "&Save All Libraries"
+msgid "Save All &Libraries"
 msgstr ""
 
 #: eeschema/menubar_libedit.cpp:97
@@ -9398,31 +9395,27 @@ msgid "Toggles the search tree visibility"
 msgstr ""
 
 #: eeschema/menubar_libedit.cpp:193
-msgid "Create &New"
+msgid "&New Part"
 msgstr ""
 
 #: eeschema/menubar_libedit.cpp:194
 msgid "Create a new empty part"
 msgstr ""
 
-#: eeschema/menubar_libedit.cpp:197
-msgid "&Save Part"
-msgstr ""
-
 #: eeschema/menubar_libedit.cpp:201
 msgid "Saves the current part to the library"
 msgstr ""
 
-#: eeschema/menubar_libedit.cpp:208 pcbnew/menubar_pcbframe.cpp:762
-msgid "&Import"
-msgstr "&Importieren"
+#: eeschema/menubar_libedit.cpp:208
+msgid "&Import Part"
+msgstr ""
 
 #: eeschema/menubar_libedit.cpp:209
 msgid "Import a part to the current library"
 msgstr ""
 
 #: eeschema/menubar_libedit.cpp:214
-msgid "&Export"
+msgid "&Export Part"
 msgstr ""
 
 #: eeschema/menubar_libedit.cpp:215
@@ -9512,7 +9505,7 @@ msgid "Contribute to KiCad (opens a web browser)"
 msgstr "Zu KiCad beitragen (öffnet einen Webbrowser)"
 
 #: eeschema/menubar_libedit.cpp:355
-msgid "&Part"
+msgid "P&art"
 msgstr ""
 
 #: eeschema/netform.cpp:111
@@ -9658,7 +9651,7 @@ msgstr "%s Verschieben"
 #: eeschema/onrightclick.cpp:371 eeschema/onrightclick.cpp:507
 #: eeschema/onrightclick.cpp:544 eeschema/onrightclick.cpp:580
 #: eeschema/onrightclick.cpp:775 pcbnew/onrightclick.cpp:803
-#: pcbnew/tools/edit_tool.cpp:565
+#: pcbnew/tools/edit_tool.cpp:567
 msgid "Drag"
 msgstr "Ziehen"
 
@@ -9678,12 +9671,11 @@ msgstr "Rücksetzen auf Standardeinstellungen"
 
 #: eeschema/onrightclick.cpp:394 eeschema/onrightclick.cpp:510
 #: eeschema/onrightclick.cpp:582 eeschema/onrightclick.cpp:616
-#: eeschema/widgets/cmp_tree_pane.cpp:69 pcbnew/modedit_onclick.cpp:366
-#: pcbnew/modedit_onclick.cpp:409 pcbnew/onrightclick.cpp:200
-#: pcbnew/onrightclick.cpp:276 pcbnew/onrightclick.cpp:307
-#: pcbnew/onrightclick.cpp:492 pcbnew/onrightclick.cpp:545
-#: pcbnew/onrightclick.cpp:843 pcbnew/tools/edit_tool.cpp:106
-#: pcbnew/tools/edit_tool.cpp:110
+#: pcbnew/modedit_onclick.cpp:366 pcbnew/modedit_onclick.cpp:409
+#: pcbnew/onrightclick.cpp:200 pcbnew/onrightclick.cpp:276
+#: pcbnew/onrightclick.cpp:307 pcbnew/onrightclick.cpp:492
+#: pcbnew/onrightclick.cpp:545 pcbnew/onrightclick.cpp:843
+#: pcbnew/tools/edit_tool.cpp:106 pcbnew/tools/edit_tool.cpp:110
 msgid "Duplicate"
 msgstr "Duplizieren"
 
@@ -9730,8 +9722,8 @@ msgstr "Zu Text ändern"
 msgid "Change Type"
 msgstr "Typ ändern"
 
-#: eeschema/onrightclick.cpp:546 eeschema/widgets/cmp_tree_pane.cpp:68
-#: pcbnew/onrightclick.cpp:993 pcbnew/tools/edit_tool.cpp:169
+#: eeschema/onrightclick.cpp:546 pcbnew/onrightclick.cpp:993
+#: pcbnew/tools/edit_tool.cpp:169
 msgid "Copy"
 msgstr "Kopieren"
 
@@ -10070,12 +10062,12 @@ msgstr "Bus an eine elektr. Verbindung führen"
 msgid "Bus to Bus Entry"
 msgstr "Bus zu Buseingang"
 
-#: eeschema/sch_collectors.cpp:457
+#: eeschema/sch_collectors.cpp:426
 #, c-format
 msgid "Child item %s of parent item %s found in sheet %s"
 msgstr "Unterelement %s von Elternelement %s wurde in Schaltplan %s gefunden"
 
-#: eeschema/sch_collectors.cpp:464
+#: eeschema/sch_collectors.cpp:433
 #, c-format
 msgid "Item %s found in sheet %s"
 msgstr "Element %s im Schaltplan %s gefunden"
@@ -10213,30 +10205,30 @@ msgstr ""
 msgid "library \"%s\" cannot be deleted"
 msgstr ""
 
-#: eeschema/sch_line.cpp:594
+#: eeschema/sch_line.cpp:615
 msgid "Vert."
 msgstr "Vert."
 
-#: eeschema/sch_line.cpp:596
+#: eeschema/sch_line.cpp:617
 msgid "Horiz."
 msgstr "Horiz."
 
-#: eeschema/sch_line.cpp:601
+#: eeschema/sch_line.cpp:622
 #, c-format
 msgid "%s Graphic Line from (%s,%s) to (%s,%s)"
 msgstr "%s grafische Linie von (%s,%s) nach (%s,%s) "
 
-#: eeschema/sch_line.cpp:605
+#: eeschema/sch_line.cpp:626
 #, c-format
 msgid "%s Wire from (%s,%s) to (%s,%s)"
 msgstr "%s elektr. Verbindung von (%s,%s) nach (%s,%s)"
 
-#: eeschema/sch_line.cpp:609
+#: eeschema/sch_line.cpp:630
 #, c-format
 msgid "%s Bus from (%s,%s) to (%s,%s)"
 msgstr "%s Bus von (%s,%s) nach (%s,%s)"
 
-#: eeschema/sch_line.cpp:613
+#: eeschema/sch_line.cpp:634
 #, c-format
 msgid "%s Line on Unknown Layer from (%s,%s) to (%s,%s)"
 msgstr "%s Linie auf unbekannter Lage von (%s,%s) nach (%s,%s)"
@@ -10508,7 +10500,7 @@ msgstr "Füge Simulationssonde hinzu"
 msgid "Select a value to be tuned"
 msgstr "Abstimmungswert wählen"
 
-#: eeschema/schframe.cpp:176 pcbnew/class_zone.cpp:1088
+#: eeschema/schframe.cpp:176 pcbnew/class_zone.cpp:1082
 msgid "Not Found"
 msgstr "Nicht gefunden"
 
@@ -11122,52 +11114,68 @@ msgid "Choose Component (%d items loaded)"
 msgstr "Bauteilauswahl (%d Elemente geladen)"
 
 #: eeschema/widgets/cmp_tree_pane.cpp:50 eeschema/widgets/cmp_tree_pane.cpp:74
-msgid "New library..."
+msgid "&New Library..."
 msgstr ""
 
 #: eeschema/widgets/cmp_tree_pane.cpp:51 eeschema/widgets/cmp_tree_pane.cpp:75
-msgid "Add existing library..."
-msgstr ""
-
-#: eeschema/widgets/cmp_tree_pane.cpp:53
-msgid "Save library as..."
+msgid "&Add Library..."
 msgstr ""
 
 #: eeschema/widgets/cmp_tree_pane.cpp:54
-msgid "Revert library"
+msgid "&Revert Library"
 msgstr ""
 
 #: eeschema/widgets/cmp_tree_pane.cpp:56
-msgid "New part..."
+msgid "New &Part..."
 msgstr ""
 
 #: eeschema/widgets/cmp_tree_pane.cpp:57
-msgid "Import part..."
+msgid "Import Part..."
 msgstr ""
 
 #: eeschema/widgets/cmp_tree_pane.cpp:58
-msgid "Paste part"
+msgid "Paste Part"
+msgstr ""
+
+#: eeschema/widgets/cmp_tree_pane.cpp:61
+msgid "Edit Part"
+msgstr ""
+
+#: eeschema/widgets/cmp_tree_pane.cpp:62
+msgid "Remove Part"
 msgstr ""
 
 #: eeschema/widgets/cmp_tree_pane.cpp:63
-msgid "Export..."
+msgid "Export Part..."
 msgstr ""
 
 #: eeschema/widgets/cmp_tree_pane.cpp:65
-msgid "Revert"
+msgid "&Revert Part"
 msgstr ""
 
-#: eeschema/widgets/cmp_tree_pane.cpp:67 pcbnew/tools/edit_tool.cpp:174
-msgid "Cut"
-msgstr "Ausschneiden"
+#: eeschema/widgets/cmp_tree_pane.cpp:67
+msgid "Cut Part"
+msgstr ""
 
-#: eeschema/widgets/component_tree.cpp:105
+#: eeschema/widgets/cmp_tree_pane.cpp:68
+msgid "Copy Part"
+msgstr ""
+
+#: eeschema/widgets/cmp_tree_pane.cpp:69
+msgid "Duplicate Part"
+msgstr ""
+
+#: eeschema/widgets/component_tree.cpp:104
 msgid "Search"
 msgstr "Suchen"
 
 #: eeschema/widgets/tuner_slider_base.cpp:24
 msgid " X "
 msgstr " X "
+
+#: eeschema/widgets/tuner_slider_base.cpp:66 pagelayout_editor/hotkeys.cpp:96
+msgid "Save"
+msgstr "Speichern"
 
 #: eeschema/widgets/widget_eeschema_color_config.cpp:59
 msgid "Wire"
@@ -11178,7 +11186,7 @@ msgid "Bus"
 msgstr "Bus"
 
 #: eeschema/widgets/widget_eeschema_color_config.cpp:61
-#: eeschema/sch_junction.h:82
+#: eeschema/sch_junction.h:88
 msgid "Junction"
 msgstr "Knotenpunkt"
 
@@ -11276,7 +11284,7 @@ msgstr "Grafische Lage"
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:350
 #: pcbnew/class_module.cpp:564
 #: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:68
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:925
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:943
 msgid "Rotation"
 msgstr "Drehung"
 
@@ -11300,7 +11308,7 @@ msgstr "Polarität"
 #: pcbnew/dialogs/dialog_dimension_editor_base.cpp:78
 #: pcbnew/dialogs/dialog_print_using_printer_base.cpp:115
 #: pcbnew/modedit_onclick.cpp:296 pcbnew/tools/edit_tool.cpp:137
-#: pcbnew/tools/edit_tool.cpp:793
+#: pcbnew/tools/edit_tool.cpp:795
 msgid "Mirror"
 msgstr "Spiegeln"
 
@@ -11360,10 +11368,10 @@ msgstr "Grafische Lage %d"
 #: gerbview/class_gerbview_layer_widget.cpp:95
 #: gerbview/dialogs/dialog_print_using_printer.cpp:163
 #: gerbview/dialogs/dialog_select_one_pcb_layer.cpp:163
-#: pcbnew/class_drawsegment.cpp:401 pcbnew/class_pad.cpp:701
+#: pcbnew/class_drawsegment.cpp:444 pcbnew/class_pad.cpp:701
 #: pcbnew/class_pcb_layer_widget.cpp:365 pcbnew/class_pcb_text.cpp:135
 #: pcbnew/class_text_mod.cpp:382 pcbnew/class_track.cpp:1161
-#: pcbnew/class_track.cpp:1188 pcbnew/class_zone.cpp:874
+#: pcbnew/class_track.cpp:1188 pcbnew/class_zone.cpp:868
 #: pcbnew/dialogs/dialog_dimension_editor_base.cpp:84
 #: pcbnew/dialogs/dialog_modedit_options_base.cpp:113
 #: pcbnew/dialogs/dialog_modedit_options_base.cpp:142
@@ -11709,7 +11717,7 @@ msgid "Flashed items"
 msgstr "Hervorgehobene Elemente"
 
 #: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:50
-#: pcbnew/class_zone.cpp:882
+#: pcbnew/class_zone.cpp:876
 msgid "Polygons"
 msgstr "Polygone"
 
@@ -13200,7 +13208,7 @@ msgstr "Kommentar"
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:325
 #: pcbnew/class_pcb_text.cpp:146 pcbnew/class_text_mod.cpp:395
 #: pcbnew/dialogs/dialog_edit_module_text_base.cpp:67
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:843
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:861
 msgid "Thickness"
 msgstr "Stärke"
 
@@ -14194,11 +14202,11 @@ msgid "Z"
 msgstr "Z"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:945
-#: pcbnew/class_drawsegment.cpp:372 pcbnew/class_drawsegment.cpp:390
+#: pcbnew/class_drawsegment.cpp:415 pcbnew/class_drawsegment.cpp:433
 #: pcbnew/class_pad.cpp:736 pcbnew/class_pcb_text.cpp:143
 #: pcbnew/class_text_mod.cpp:392
 #: pcbnew/dialogs/dialog_pad_basicshapes_properties.cpp:100
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:823
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:841
 msgid "Angle"
 msgstr "Winkel"
 
@@ -14380,7 +14388,7 @@ msgstr "Änderung in der Liste der Spannungsregler"
 #: pcb_calculator/pcb_calculator_frame.cpp:157
 #, c-format
 msgid ""
-"Unable to write file\"%s\"\n"
+"Unable to write file \"%s\"\n"
 "Do you want to exit and abandon your change?"
 msgstr ""
 
@@ -15193,27 +15201,27 @@ msgstr "Polygon"
 msgid "Dimension \"%s\" on %s"
 msgstr "Abmessungen\"%s\" auf %s"
 
-#: pcbnew/class_drawsegment.cpp:357
+#: pcbnew/class_drawsegment.cpp:400
 msgid "Drawing"
 msgstr "Zeichnung"
 
-#: pcbnew/class_drawsegment.cpp:361
+#: pcbnew/class_drawsegment.cpp:404
 msgid "Shape"
 msgstr "Form"
 
-#: pcbnew/class_drawsegment.cpp:376
+#: pcbnew/class_drawsegment.cpp:419
 msgid "Curve"
 msgstr "Bogen"
 
-#: pcbnew/class_drawsegment.cpp:381
+#: pcbnew/class_drawsegment.cpp:424
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:202
 #: pcbnew/dialogs/dialog_pad_basicshapes_properties.cpp:82
 #: pcbnew/dialogs/dialog_pad_properties.cpp:737
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1849
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1856
 msgid "Segment"
 msgstr "Segment"
 
-#: pcbnew/class_drawsegment.cpp:645
+#: pcbnew/class_drawsegment.cpp:688
 #, c-format
 msgid "Pcb Graphic: %s, length %s on %s"
 msgstr "PCB-Grafik: %s, Länge %s auf %s"
@@ -15925,11 +15933,11 @@ msgstr "NC-DuKo-Größe"
 msgid "NC Via Drill"
 msgstr "NC-DuKo-Bohrung"
 
-#: pcbnew/class_track.cpp:1100 pcbnew/class_zone.cpp:859
+#: pcbnew/class_track.cpp:1100 pcbnew/class_zone.cpp:853
 msgid "NetName"
 msgstr "Netz-Name"
 
-#: pcbnew/class_track.cpp:1104 pcbnew/class_zone.cpp:863
+#: pcbnew/class_track.cpp:1104 pcbnew/class_zone.cpp:857
 msgid "NetCode"
 msgstr "Netz-Code"
 
@@ -15975,72 +15983,72 @@ msgstr "Nicht gefunden."
 msgid "Track %s, net [%s] (%d) on layer %s, length: %s"
 msgstr "Leiterbahn %s, Netz [%s] (%d) auf Lage %s, Länge: %s"
 
-#: pcbnew/class_zone.cpp:820
+#: pcbnew/class_zone.cpp:814
 msgid "Zone Outline"
 msgstr "Flächenumriss"
 
-#: pcbnew/class_zone.cpp:826 pcbnew/class_zone.cpp:1058
+#: pcbnew/class_zone.cpp:820 pcbnew/class_zone.cpp:1052
 msgid "(Cutout)"
 msgstr "(Ausschnitt)"
 
-#: pcbnew/class_zone.cpp:835
+#: pcbnew/class_zone.cpp:829
 msgid "No via"
 msgstr "Keine DuKo"
 
-#: pcbnew/class_zone.cpp:838
+#: pcbnew/class_zone.cpp:832
 msgid "No track"
 msgstr "Keine Leiterbahn"
 
-#: pcbnew/class_zone.cpp:841
+#: pcbnew/class_zone.cpp:835
 #: pcbnew/dialogs/dialog_keepout_area_properties_base.cpp:67
 msgid "No copper pour"
 msgstr "Kein Auffüllen von Kupferflächen"
 
-#: pcbnew/class_zone.cpp:843
+#: pcbnew/class_zone.cpp:837
 msgid "Keepout"
 msgstr "Sperrfläche"
 
-#: pcbnew/class_zone.cpp:854
+#: pcbnew/class_zone.cpp:848
 msgid "<unknown>"
 msgstr "<unbekannt>"
 
-#: pcbnew/class_zone.cpp:867
+#: pcbnew/class_zone.cpp:861
 msgid "Priority"
 msgstr "Priorität"
 
-#: pcbnew/class_zone.cpp:871
+#: pcbnew/class_zone.cpp:865
 msgid "Non Copper Zone"
 msgstr "Keine Kupferfläche"
 
-#: pcbnew/class_zone.cpp:877
+#: pcbnew/class_zone.cpp:871
 msgid "Corners"
 msgstr "Ecken"
 
-#: pcbnew/class_zone.cpp:880
+#: pcbnew/class_zone.cpp:874
 msgid "Segments"
 msgstr "Segmente"
 
-#: pcbnew/class_zone.cpp:884
+#: pcbnew/class_zone.cpp:878
 msgid "Fill Mode"
 msgstr "Füllmodus"
 
-#: pcbnew/class_zone.cpp:888
+#: pcbnew/class_zone.cpp:882
 msgid "Hatch Lines"
 msgstr "Schraffurlinien"
 
-#: pcbnew/class_zone.cpp:893
+#: pcbnew/class_zone.cpp:887
 msgid "Corner Count"
 msgstr "Anzahl Löcher"
 
-#: pcbnew/class_zone.cpp:1061
+#: pcbnew/class_zone.cpp:1055
 msgid "(Keepout)"
 msgstr "(Sperrfläche)"
 
-#: pcbnew/class_zone.cpp:1081
+#: pcbnew/class_zone.cpp:1075
 msgid "** NO BOARD DEFINED **"
 msgstr "** KEINE PLATINE DEFINIERT **"
 
-#: pcbnew/class_zone.cpp:1093
+#: pcbnew/class_zone.cpp:1087
 #, c-format
 msgid "Zone Outline %s on %s"
 msgstr "Flächenumriss %s auf %s"
@@ -16453,7 +16461,7 @@ msgstr ""
 
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:153
 #: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:197
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:503
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:509
 msgid "Thermal relief"
 msgstr "Thermische Abführung [Alle]"
 
@@ -17637,7 +17645,7 @@ msgstr ""
 #: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:243
 #: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:184
 #: pcbnew/dialogs/dialog_mask_clearance_base.cpp:40
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:446
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:452
 msgid "Solder mask clearance:"
 msgstr "Abstand Lötstoppmaske:"
 
@@ -17657,7 +17665,7 @@ msgstr ""
 #: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:256
 #: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:197
 #: pcbnew/dialogs/dialog_mask_clearance_base.cpp:77
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:459
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:465
 msgid "Solder paste clearance:"
 msgstr "Abstand Lötpaste:"
 
@@ -17682,7 +17690,7 @@ msgstr ""
 #: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:269
 #: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:210
 #: pcbnew/dialogs/dialog_mask_clearance_base.cpp:91
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:472
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:478
 msgid "Solder paste ratio clearance:"
 msgstr "Abstandsverhältnis der Lötstoppmaske:"
 
@@ -17712,7 +17720,7 @@ msgstr ""
 #: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:219
 #: pcbnew/dialogs/dialog_mask_clearance_base.cpp:101
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:237
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:481
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:487
 #: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:138
 msgid "%"
 msgstr "%"
@@ -17813,11 +17821,11 @@ msgstr "Lokales Flächenabstandsmaß"
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:202
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:296
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:307
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:442
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:455
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:468
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:519
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:530
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:448
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:461
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:474
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:525
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:536
 msgid "Inch"
 msgstr "Zoll"
 
@@ -19107,48 +19115,53 @@ msgstr "Ändere Pads im Footprint"
 msgid "Change Pads on Identical Footprints"
 msgstr "Ändere Pads an gleichen Footprints"
 
-#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:146
-#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:149
+#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:156
+#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:158
 msgid "Circle Properties"
 msgstr "Kreiseigenschaften"
 
-#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:147
-#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:158
+#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:157
+#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:165
 msgid "Center X:"
 msgstr "Mittelpunkt X:"
 
-#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:148
-#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:159
+#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:158
+#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:166
 msgid "Center Y:"
 msgstr "Mittelpunkt Y:"
 
-#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:149
+#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:159
 msgid "Point X:"
 msgstr "Punkt X:"
 
-#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:150
+#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:160
 msgid "Point Y:"
 msgstr "Punkt Y:"
 
-#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:157
-#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:160
+#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:164
+#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:166
 msgid "Arc Properties"
 msgstr "Eigenschaften Kreisbogen"
 
-#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:160
+#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:167
 msgid "Start Point X:"
 msgstr "Startpunkt X:"
 
-#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:161
+#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:168
 msgid "Start Point Y:"
 msgstr "Startpunkt Y:"
 
-#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:167
-#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:170
+#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:174
+#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:176
+msgid "Polygon Properties"
+msgstr ""
+
+#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:179
+#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:181
 msgid "Line Segment Properties"
 msgstr "Liniensegmenteigenschaften:"
 
-#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:204
+#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:213
 msgid ""
 "This item was on an unknown layer.\n"
 "It has been moved to the drawings layer. Please fix it."
@@ -19157,35 +19170,35 @@ msgstr ""
 "Es wurde auf der Lage für Symbole und Zeichnungen platziert.\n"
 "Bitte korrigieren Sie dies ggfs."
 
-#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:269
+#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:278
 msgid "Modify drawing properties"
 msgstr "Darstellungs Eigenschaften"
 
-#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:302
+#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:311
 msgid "The arc angle must be greater than zero."
 msgstr "Der Winkel des Bogens muss größer als 0 sein."
 
-#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:311
-#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:305
+#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:319
+#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:317
 msgid "The radius must be greater than zero."
 msgstr "Der Radius muss größer als 0 sein."
 
-#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:324
-#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:313
+#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:331
+#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:328
 msgid "The start and end points cannot be the same."
 msgstr "Der Startpunkt und der Endpunkt müssen verschieden sein."
 
-#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:334
-#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:322
+#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:341
+#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:337
 msgid "The item thickness must be greater than zero."
 msgstr "Die Breite des Elements muss größer als 0 sein."
 
-#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:340
-#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:328
+#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:347
+#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:343
 msgid "The default thickness must be greater than zero."
 msgstr "Die Standardbreite muss größer als 0 sein."
 
-#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:344
+#: pcbnew/dialogs/dialog_graphic_item_properties.cpp:351
 msgid "Error List"
 msgstr "Fehlerliste"
 
@@ -19221,33 +19234,33 @@ msgstr "Elementstärke:"
 msgid "Default thickness:"
 msgstr "Voreinstellung für Stärke:"
 
-#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:150
-#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:161
+#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:159
+#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:167
 msgid "Center X"
 msgstr "Mittelpunkt X"
 
-#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:151
-#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:162
+#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:160
+#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:168
 msgid "Center Y"
 msgstr "Mittelpunkt Y"
 
-#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:152
+#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:161
 msgid "Point X"
 msgstr "Punkt X"
 
-#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:153
+#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:162
 msgid "Point Y"
 msgstr "Punkt Y"
 
-#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:163
+#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:169
 msgid "Start Point X"
 msgstr "Startpunkt X"
 
-#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:164
+#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:170
 msgid "Start Point Y"
 msgstr "Startpunkt Y"
 
-#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:200
+#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:208
 msgid ""
 "This item was on an unknown layer.\n"
 "It has been moved to the front silk screen layer. Please fix it."
@@ -19256,24 +19269,18 @@ msgstr ""
 "Es wurde auf die vordere Siebdrucklage verschoben.\n"
 "Bitte dies entsprechend beheben."
 
-#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:229
+#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:239
 msgid ""
-"The graphic item will be on a copper layer. This is very dangerous. Are you "
-"sure?"
+"The graphic item will be on a copper layer.\n"
+"This is very dangerous because DRC does not handle it.\n"
+"Are you sure?"
 msgstr ""
-"Das grafische Element wird auf einer Kupferlage sein. Dies ist sehr "
-"gefährlich.\n"
-"Sind Sie sich sicher?"
 
-#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:265
-msgid "Modify module graphic item"
-msgstr "Grafische Linie hinzufügen"
-
-#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:297
+#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:309
 msgid "The arc angle cannot be zero."
 msgstr "Der Bogenwinkel darf nicht Null sein."
 
-#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:332
+#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:347
 msgid "Error list"
 msgstr "Fehlerliste"
 
@@ -20485,8 +20492,8 @@ msgid "Zone min thickness value:"
 msgstr "Flächenmindeststärke"
 
 #: pcbnew/dialogs/dialog_pad_basicshapes_properties.cpp:101
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:839
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:941
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:857
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:959
 msgid "degree"
 msgstr "Grad"
 
@@ -20574,43 +20581,43 @@ msgstr "Radius %s"
 msgid "corners count %d"
 msgstr "Anzahl Ecken %d"
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1014
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1016
 msgid "Pad size must be greater than zero"
 msgstr "Padgröße muss größer als Null sein"
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1020
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1022
 msgid "Incorrect value for pad drill: pad drill bigger than pad size"
 msgstr ""
 "Inkorrekter Wert für Pad Bohrdurchmesser: Bohrdurchmesser ist größer als Pad."
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1027
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1029
 msgid "Pad local clearance must be zero or greater than zero"
 msgstr "Lokaler Padabstand muss gleich oder größer als Null sein."
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1038
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1040
 msgid "Pad local solder mask clearance must be zero or greater than zero"
 msgstr "Lokale Pad Lötstoppmaske muss gleich oder größer als Null sein."
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1046
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1048
 #, c-format
 msgid "Pad local solder mask clearance must be greater than %s"
 msgstr ""
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1054
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1056
 msgid "Pad local solder paste clearance must be zero or less than zero"
 msgstr "Lokale Pad-Lötpaste muss gleich oder größer als Null sein."
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1060
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1062
 msgid "Error: pad has no layer"
 msgstr "Fehler: Sie müssen für das Pad eine Lage wählen"
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1067
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1069
 msgid "Error: the pad is not on a copper layer and has a hole"
 msgstr ""
 "Fehler: Das Pad befindet sich nicht auf einer Kupferlage und besitzt ein "
 "Bohrung"
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1072
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1074
 msgid ""
 "For NPTH pad, set pad size value to pad drill value, if you do not want this "
 "pad plotted in gerber files"
@@ -20618,19 +20625,19 @@ msgstr ""
 "Setze für ein NPTH-Pad die Padgröße auf den Padbohrdurchmesser,\n"
 "wenn dieses Pad nicht in Gerberdateien geplottet werden soll."
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1092
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1094
 msgid "Incorrect value for pad offset"
 msgstr "Inkorrekter Wert für Padoffset"
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1098
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1100
 msgid "Too large value for pad delta size"
 msgstr "Zu großer Wert für das Pad-Delta"
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1106
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1108
 msgid "Error: Through hole pad: drill diameter set to 0"
 msgstr "Fehler: Durchgangsbohrung Pad: Bohrdurchmesser gleich 0"
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1111
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1113
 msgid ""
 "Error: Connector pads are not on the solder paste layer\n"
 "Use SMD pads instead"
@@ -20638,54 +20645,54 @@ msgstr ""
 "Fehler: Anschlusspads befinden sich nicht auf der Lage der Lötstopppaste\n"
 "Verwende stattdessen SMD-Pads"
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1120
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1122
 msgid "Error: only one external copper layer allowed for SMD or Connector pads"
 msgstr "Fehler: Für SMD oder Anschlusspads ist nur eine Kupferlage zulässig"
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1132
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1134
 msgid "Incorrect corner size value"
 msgstr "Inkorrekte Größe für Eckwert"
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1136
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1138
 msgid "Incorrect (negative) corner size value"
 msgstr "Inkorrekte (negative) Größe für Eckwert"
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1138
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1140
 msgid "Corner size value must be smaller than 50%"
 msgstr "Größe Eckwert muss kleiner 50% sein."
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1146
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1148
 msgid "Incorrect pad shape: the shape must be equivalent to only one polygon"
 msgstr ""
 "Ungültige Padform: Die Form darf nur äquivalent zu einem der Polygone sein"
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1152
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1154
 msgid "Pad setup errors list"
 msgstr "Fehlerliste der Padeinstellungen"
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1389
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1391
 msgid "Unknown netname, netname not changed"
 msgstr "Unbekannter Netzname. Keine Änderung durchgeführt."
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1426
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1433
 msgid "Modify pad"
 msgstr "Pad modifizieren"
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1758
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1901
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1942
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1765
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1908
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1949
 msgid "No shape selected"
 msgstr "Keine Form gewählt"
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1849
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1856
 msgid "ring/circle"
 msgstr "Ring/Kreis"
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1849
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1856
 msgid "polygon"
 msgstr "Polygon"
 
-#: pcbnew/dialogs/dialog_pad_properties.cpp:1852
+#: pcbnew/dialogs/dialog_pad_properties.cpp:1859
 msgid "Select shape type:"
 msgstr "Wähle Formtyp:"
 
@@ -20912,15 +20919,21 @@ msgstr "Platinenseite:"
 msgid "Front side"
 msgstr "Vorderansicht"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:425
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:424
+msgid "Set fields to 0 to use parent or global values"
+msgstr ""
+"Felder mit einem Wert von 0 benutzen übergeordnete oder global definierte "
+"Werte."
+
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:431
 msgid "Clearances"
 msgstr "Abstandsmaße"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:433
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:439
 msgid "Net pad clearance:"
 msgstr "Netz-Pad Abstand:"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:435
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:441
 msgid ""
 "This is the local net clearance for  pad.\n"
 "If 0, the footprint local value or the Netclass value is used"
@@ -20929,7 +20942,7 @@ msgstr ""
 "Wenn auf 0 gesetzt wird der lokale Wert des Footprints oder der Netzklasse "
 "verwendet."
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:448
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:454
 msgid ""
 "This is the local clearance between this  pad and the solder mask\n"
 "If 0, the footprint local value or the global value is used"
@@ -20938,7 +20951,7 @@ msgstr ""
 "Wenn auf 0 gesetzt wird der lokale Wert des Footprints oder der globale Wert "
 "verwendet."
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:461
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:467
 msgid ""
 "This is the local clearance between this pad and the solder paste.\n"
 "If 0 the footprint value or the global value is used..\n"
@@ -20954,7 +20967,7 @@ msgstr ""
 "Ein negativer Wert bedeutet, dass die Maskengröße kleiner als die Padgröße "
 "ist."
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:474
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:480
 msgid ""
 "This is the local clearance ratio in per cent between this pad and the "
 "solder paste.\n"
@@ -20974,86 +20987,82 @@ msgstr ""
 "Ein negativer Wert bedeutet, dass die Maskengröße kleiner als die Padgröße "
 "ist."
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:491
-msgid "Copper Zones"
-msgstr "Kupferflächen"
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:497
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:546
+msgid "Connection to Copper Zones"
+msgstr ""
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:499
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:505
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:554
 msgid "Pad connection:"
 msgstr "Padverbindung:"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:503
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:509
 msgid "From parent footprint"
 msgstr "Vom Ursprungs-Footprint"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:512
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:518
 msgid "Thermal relief width:"
 msgstr "Breite der thermischen Abführung:"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:523
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:529
 msgid "Thermal relief gap:"
 msgstr "Abstand zur thermischen Abführung:"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:534
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:561
 msgid "Custom pad shape in zone:"
 msgstr "Benutzerdefinierte Padform in Zone:"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:538
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:565
 msgid "Use pad shape"
 msgstr "Benutze Padform"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:538
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:565
 msgid "Use pad convex hull"
 msgstr "Benutze konvexe Padformhülle"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:553
-msgid "Set fields to 0 to use parent or global values"
-msgstr ""
-"Felder mit einem Wert von 0 benutzen übergeordnete oder global definierte "
-"Werte."
-
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:566
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:584
 msgid "Local Clearance and Settings"
 msgstr "Lokale Abstände und Einstellungen"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:570
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:588
 msgid "Primitives list"
 msgstr "Primitives Liste"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:576
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1016
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:594
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1034
 msgid "Coordinates are relative to anchor pad, orientation 0"
 msgstr " Koordinaten sind relativ zum Ankerpad, Ausrichtung 0"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:591
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:609
 msgid "Delete Primitive"
 msgstr "Primitive entfernen"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:594
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:612
 msgid "Edit Primitive"
 msgstr "Primitive editieren"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:597
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:615
 msgid "Add Primitive"
 msgstr "Primitive hinzufügen"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:600
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:618
 msgid "Duplicate Primitive"
 msgstr "Primitive duplizieren"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:609
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:627
 msgid "Geometry Transform"
 msgstr "Geometrische Transformation"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:612
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:630
 msgid "Import Primitives"
 msgstr "Primitives importieren"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:625
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:643
 msgid "Custom Shape Primitives"
 msgstr "Individuelle Primitives Formen"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:647
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:665
 msgid ""
 "Warning:\n"
 "This pad is flipped on board.\n"
@@ -21063,7 +21072,7 @@ msgstr ""
 "Dieses Pad ist auf der Platine verkehrt herum.\n"
 "Rück- und Vorderseite werden vertauscht sein."
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:766
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:784
 msgid ""
 "Filled circle: set thickness to 0\n"
 "Ring:  set thickness to the width of the ring"
@@ -21071,39 +21080,39 @@ msgstr ""
 "Gefüllter Kreis: Setze Stärke auf 0\n"
 "Ring: Setze Stärke auf die Breite des Rings"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:779
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:797
 msgid "Start point"
 msgstr "Startpunkt"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:801
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:819
 msgid "End point"
 msgstr "Endpunkt"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:903
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:921
 msgid "Move vector"
 msgstr "Verschiebe Vektor"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:945
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:963
 msgid "Scaling factor"
 msgstr "Skalierungsfaktor"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:952
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:970
 msgid "1.0"
 msgstr "1.0"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:964
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:982
 msgid "Duplicate count"
 msgstr "Anzahl duplizieren"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1022
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1040
 msgid "Incorrect polygon"
 msgstr "Ungültiges Polygon"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1096
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1114
 msgid "Outline thickness"
 msgstr "Strichstärke Kontur"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1110
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:1128
 msgid "(Thickness outline is usually set to 0)"
 msgstr "(Konturstärke ist üblicher Weise auf 0 gesetzt)"
 
@@ -22786,8 +22795,8 @@ msgstr ""
 msgid "library \"%s\" has no footprint \"%s\" to delete"
 msgstr ""
 
-#: pcbnew/gpcb_plugin.cpp:458 pcbnew/pcb_parser.cpp:458
-#: pcbnew/pcb_parser.cpp:563
+#: pcbnew/gpcb_plugin.cpp:458 pcbnew/pcb_parser.cpp:473
+#: pcbnew/pcb_parser.cpp:578
 #, c-format
 msgid "unknown token \"%s\""
 msgstr "Unbekanntes Vorkommnis \"%s\""
@@ -23139,7 +23148,7 @@ msgstr "Inhalt der Zwischenablage ist nicht kompatibel mit KiCad"
 msgid "Cannot find component with reference \"%s\" in netlist."
 msgstr "Konnte in der Netzliste kein Bauteil mit der Referenz \"%s\" finden."
 
-#: pcbnew/kicad_netlist_reader.cpp:369 pcbnew/pcb_parser.cpp:1787
+#: pcbnew/kicad_netlist_reader.cpp:369 pcbnew/pcb_parser.cpp:1802
 #, c-format
 msgid ""
 "invalid footprint ID in\n"
@@ -24285,6 +24294,10 @@ msgstr "Eine entflechtete \"Specctra Session\" Datei (*.ses) importieren"
 msgid "&DXF File"
 msgstr "D&XF-Datei"
 
+#: pcbnew/menubar_pcbframe.cpp:762
+msgid "&Import"
+msgstr "&Importieren"
+
 #: pcbnew/menubar_pcbframe.cpp:763
 msgid "Import files"
 msgstr "Dateien importieren"
@@ -24883,7 +24896,7 @@ msgstr "Gruppe heran zoomen"
 
 #: pcbnew/onrightclick.cpp:493 pcbnew/onrightclick.cpp:813
 #: pcbnew/onrightclick.cpp:1000 pcbnew/tools/edit_tool.cpp:133
-#: pcbnew/tools/edit_tool.cpp:824
+#: pcbnew/tools/edit_tool.cpp:826
 msgid "Flip"
 msgstr "Wenden"
 
@@ -25151,22 +25164,22 @@ msgstr ""
 msgid "cannot interpret date code %d"
 msgstr "Die Datumsangaben sind nicht korrekt %d"
 
-#: pcbnew/pcb_parser.cpp:669
+#: pcbnew/pcb_parser.cpp:684
 #, c-format
 msgid "page type \"%s\" is not valid "
 msgstr "Ungültiger Seitentyp \"%s\""
 
-#: pcbnew/pcb_parser.cpp:901
+#: pcbnew/pcb_parser.cpp:916
 #, c-format
 msgid "Layer \"%s\" in file \"%s\" at line %d, is not in fixed layer hash"
 msgstr ""
 
-#: pcbnew/pcb_parser.cpp:934
+#: pcbnew/pcb_parser.cpp:949
 #, c-format
 msgid "%d is not a valid layer count"
 msgstr "%d ist keine gültige Lagenanzahl"
 
-#: pcbnew/pcb_parser.cpp:965
+#: pcbnew/pcb_parser.cpp:980
 #, c-format
 msgid ""
 "Layer \"%s\" in file\n"
@@ -25175,19 +25188,19 @@ msgid ""
 "was not defined in the layers section"
 msgstr ""
 
-#: pcbnew/pcb_parser.cpp:1351
+#: pcbnew/pcb_parser.cpp:1366
 #, c-format
 msgid "duplicate NETCLASS name \"%s\" in file \"%s\" at line %d, offset %d"
 msgstr ""
 
-#: pcbnew/pcb_parser.cpp:2038
+#: pcbnew/pcb_parser.cpp:2053
 #, c-format
 msgid "cannot handle footprint text type %s"
 msgstr "Kann den Footprint-Texttyp %s nicht verarbeiten."
 
-#: pcbnew/pcb_parser.cpp:2463 pcbnew/pcb_parser.cpp:2469
-#: pcbnew/pcb_parser.cpp:2698 pcbnew/pcb_parser.cpp:2780
-#: pcbnew/pcb_parser.cpp:2844
+#: pcbnew/pcb_parser.cpp:2478 pcbnew/pcb_parser.cpp:2484
+#: pcbnew/pcb_parser.cpp:2713 pcbnew/pcb_parser.cpp:2795
+#: pcbnew/pcb_parser.cpp:2859
 #, c-format
 msgid ""
 "invalid net ID in\n"
@@ -25196,7 +25209,7 @@ msgid ""
 "offset: %d"
 msgstr ""
 
-#: pcbnew/pcb_parser.cpp:3170
+#: pcbnew/pcb_parser.cpp:3185
 #, c-format
 msgid ""
 "There is a zone that belongs to a not existing net\n"
@@ -25822,7 +25835,7 @@ msgid "Add graphic polygon"
 msgstr "Grafisches Polygon hinzufügen"
 
 #: pcbnew/tool_modedit.cpp:204 pcbnew/tool_pcb.cpp:495
-#: pcbnew/tools/edit_tool.cpp:1128
+#: pcbnew/tools/edit_tool.cpp:1130
 msgid "Measure distance"
 msgstr "Abstandsmessung"
 
@@ -26359,27 +26372,31 @@ msgid "Copy selected content to clipboard"
 msgstr "Kopiert die Auswahl in die Zwischenablage"
 
 #: pcbnew/tools/edit_tool.cpp:174
+msgid "Cut"
+msgstr "Ausschneiden"
+
+#: pcbnew/tools/edit_tool.cpp:174
 msgid "Cut selected content to clipboard"
 msgstr "Ausschneiden der Auswahl in die Zwischenablage"
 
-#: pcbnew/tools/edit_tool.cpp:604
+#: pcbnew/tools/edit_tool.cpp:606
 msgid "Edit track width/via size"
 msgstr "Eigenschaften der Leiterbahnbreite und Größe der Durchkontaktierung"
 
-#: pcbnew/tools/edit_tool.cpp:631
+#: pcbnew/tools/edit_tool.cpp:633
 msgid "Edit track/via properties"
 msgstr "Eigenschaften des Leiterzuges/DoKu editieren"
 
-#: pcbnew/tools/edit_tool.cpp:913
+#: pcbnew/tools/edit_tool.cpp:915
 msgid "Move exact"
 msgstr "Exakt verschieben"
 
-#: pcbnew/tools/edit_tool.cpp:988
+#: pcbnew/tools/edit_tool.cpp:990
 #, c-format
 msgid "Duplicated %d item(s)"
 msgstr "%d doppelte(s) Element(e)"
 
-#: pcbnew/tools/edit_tool.cpp:1326
+#: pcbnew/tools/edit_tool.cpp:1328
 msgid "Select reference point for the block being copied..."
 msgstr "Setzen des Referenzpunktes für den Block der kopiert werden soll..."
 
@@ -26698,15 +26715,15 @@ msgstr "Rundung entfernen"
 msgid "Drag a line ending"
 msgstr "Linienende ziehen"
 
-#: pcbnew/tools/point_editor.cpp:903
+#: pcbnew/tools/point_editor.cpp:912
 msgid "Add a zone corner"
 msgstr "Gefüllte Flächen hinzufügen"
 
-#: pcbnew/tools/point_editor.cpp:942
+#: pcbnew/tools/point_editor.cpp:951
 msgid "Split segment"
 msgstr "Segment aufsplitten"
 
-#: pcbnew/tools/point_editor.cpp:1011
+#: pcbnew/tools/point_editor.cpp:1020
 msgid "Remove a zone/polygon corner"
 msgstr "Gefüllte Fläche/Polygon entfernen"
 
@@ -26778,37 +26795,37 @@ msgstr "Filtern der Art der Elemente in der Auswahl"
 msgid "Select..."
 msgstr "Wähle ..."
 
-#: pcbnew/tools/selection_tool.cpp:685
+#: pcbnew/tools/selection_tool.cpp:684
 msgid "Selection contains locked items. Do you want to continue?"
 msgstr ""
 "Die Auswahl enthält gesperrte Elemente.\n"
 "Möchten Sie trotzdem fortfahren?"
 
-#: pcbnew/tools/selection_tool.cpp:1256
+#: pcbnew/tools/selection_tool.cpp:1255
 msgid "Filter selection"
 msgstr "Filter Auswahl"
 
-#: pcbnew/tools/size_menu.cpp:47
+#: pcbnew/tools/size_menu.cpp:130
 msgid "Track "
 msgstr "Leiterbahn "
 
-#: pcbnew/tools/size_menu.cpp:50
+#: pcbnew/tools/size_menu.cpp:133
 msgid "net class width"
 msgstr "Breite Netzklasse"
 
-#: pcbnew/tools/size_menu.cpp:66
+#: pcbnew/tools/size_menu.cpp:146
 msgid "Via "
 msgstr "DuKo "
 
-#: pcbnew/tools/size_menu.cpp:70
+#: pcbnew/tools/size_menu.cpp:150
 msgid "net class size"
 msgstr "Wert Netzklasse"
 
-#: pcbnew/tools/size_menu.cpp:79
+#: pcbnew/tools/size_menu.cpp:159
 msgid ", drill: default"
 msgstr ", Bohrung: Voreinstellung"
 
-#: pcbnew/tools/size_menu.cpp:81
+#: pcbnew/tools/size_menu.cpp:163
 msgid ", drill: "
 msgstr ", Bohrung:"
 
@@ -27211,7 +27228,7 @@ msgstr "Bil&d"
 msgid "ERC Marker"
 msgstr "ERC Marker"
 
-#: eeschema/sch_no_connect.h:84
+#: eeschema/sch_no_connect.h:90
 msgid "No Connect"
 msgstr "Keine-Verbindung"
 
@@ -27367,7 +27384,7 @@ msgstr "Einstellungen der Textgröße"
 msgid "Global Pads Edition"
 msgstr "Globale Pad-Einstellungen"
 
-#: pcbnew/dialogs/dialog_graphic_item_properties_base.h:78
+#: pcbnew/dialogs/dialog_graphic_item_properties_base.h:80
 msgid "Graphic Item Properties"
 msgstr "Eigenschaften grafischer Elemente"
 
@@ -27399,15 +27416,15 @@ msgstr "Footprinteditor Optionen"
 msgid "Non Copper Zones Properties"
 msgstr "Eigenschaften für Zonen ohne Kupfer"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.h:207
+#: pcbnew/dialogs/dialog_pad_properties_base.h:210
 msgid "Pad Properties"
 msgstr "Pad Eigenschaften"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.h:279
+#: pcbnew/dialogs/dialog_pad_properties_base.h:282
 msgid "Pad Custom Shape Geometry Transform"
 msgstr "Individuelle Geometrische Padform Transformierung"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.h:318
+#: pcbnew/dialogs/dialog_pad_properties_base.h:321
 msgid "Basic Shape Polygon"
 msgstr "Basisform Polygon"
 
@@ -27466,6 +27483,23 @@ msgstr ""
 #: pcbnew/import_dxf/dialog_dxf_import_base.h:78
 msgid "Import DXF File"
 msgstr "DXF-Datei importieren"
+
+#~ msgid "The file <%s> was not fully read"
+#~ msgstr "Die Datei <%s> wurde nicht vollständig eingelesen."
+
+#~ msgid ""
+#~ "The graphic item will be on a copper layer. This is very dangerous. Are "
+#~ "you sure?"
+#~ msgstr ""
+#~ "Das grafische Element wird auf einer Kupferlage sein. Dies ist sehr "
+#~ "gefährlich.\n"
+#~ "Sind Sie sich sicher?"
+
+#~ msgid "Modify module graphic item"
+#~ msgstr "Grafische Linie hinzufügen"
+
+#~ msgid "Copper Zones"
+#~ msgstr "Kupferflächen"
 
 #~ msgid "Create a logo file"
 #~ msgstr "Logodatei erstellen"

--- a/de/kicad.po
+++ b/de/kicad.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: KiCad i18n Deutsch\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-12-22 22:31+0100\n"
-"PO-Revision-Date: 2017-12-22 22:31+0100\n"
+"PO-Revision-Date: 2017-12-22 23:14+0100\n"
 "Last-Translator: Carsten Schoenert <c.schoenert@t-online.de>\n"
 "Language-Team: \n"
 "Language: de_DE\n"
@@ -2777,7 +2777,7 @@ msgstr "Unzulässiges Zeichen in der Revision gefunden."
 #: common/page_layout/page_layout_reader.cpp:839
 #, c-format
 msgid "The file \"%s\" was not fully read"
-msgstr ""
+msgstr "Die Datei \"%s\" wurde nicht vollständig gelesen"
 
 #: common/pgm_base.cpp:112 common/widgets/footprint_select_widget.cpp:275
 #: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:56
@@ -4082,6 +4082,9 @@ msgid ""
 "the sheet \"%s\" or one of it's subsheets as a parent somewhere in the "
 "schematic hierarchy."
 msgstr ""
+"Die Änderungen am Blatt konnten nicht durchgeführt werden, da das Zielblatt "
+"bereits das Batt \"%s\" (oder eines seiner Unterblätter) in seiner "
+"Hierarchie enthält."
 
 #: eeschema/class_drc_erc_item.cpp:40
 msgid "ERC err unspecified"
@@ -4151,11 +4154,14 @@ msgid ""
 "This may cause some unexpected behavior when loading components into a "
 "schematic."
 msgstr ""
+"Bauteilbibliothek \"%s\" has einen doppelten Eintrag \"%s\".\n"
+"Dies könnte zu unerwartetem Verhalten beim Laden von Komponenten im "
+"Schaltplan führen."
 
 #: eeschema/class_library.cpp:537
 #, c-format
 msgid "Unable to load project's \"%s\" file"
-msgstr ""
+msgstr "Kann die Datei \"%s\" des Projektes nicht laden."
 
 #: eeschema/class_library.cpp:592
 msgid "Loading Symbol Libraries"
@@ -4171,6 +4177,8 @@ msgid ""
 "Part library \"%s\" failed to load. Error:\n"
 " %s"
 msgstr ""
+"Bauteilbibliothek \"%s\" konnte nicht geladen werden. Fehler:\n"
+"%s"
 
 #: eeschema/class_library.cpp:676
 #, c-format
@@ -4178,6 +4186,8 @@ msgid ""
 "Part library \"%s\" failed to load.\n"
 "Error: %s"
 msgstr ""
+"Bauteilbibliothek \"%s\" konnte nicht geladen werden. Fehler:\n"
+"%s"
 
 #: eeschema/cmp_tree_model.cpp:122 eeschema/lib_draw_item.cpp:72
 #: eeschema/libedit.cpp:657 eeschema/onrightclick.cpp:481
@@ -4231,12 +4241,12 @@ msgstr ""
 
 #: eeschema/cmp_tree_model_adapter_base.cpp:113 eeschema/libeditframe.cpp:1626
 msgid "Loading symbol libraries"
-msgstr ""
+msgstr "Lade Bauteilsymbolbibliotheken"
 
 #: eeschema/cmp_tree_model_adapter_base.cpp:122 eeschema/libeditframe.cpp:1630
 #, c-format
 msgid "Loading library \"%s\""
-msgstr ""
+msgstr "Lade Bibliothek \"%s\""
 
 #: eeschema/cmp_tree_model_adapter_base.cpp:185 eeschema/libedit.cpp:669
 #: eeschema/viewlibs.cpp:239
@@ -4421,7 +4431,7 @@ msgstr "Annotation"
 #: eeschema/dialogs/dialog_bom.cpp:356
 #, c-format
 msgid "Failed to open file \"%s\""
-msgstr ""
+msgstr "Konnte Datei %s\" nicht öffnen\t"
 
 #: eeschema/dialogs/dialog_bom.cpp:489
 msgid "Plugin name in plugin list"
@@ -4574,7 +4584,7 @@ msgstr "Kein gültiger Footprint angegeben"
 msgid ""
 "Double click here to select a symbol\n"
 "from the library browser"
-msgstr ""
+msgstr "Hier doppelklicken, um ein Schaltplansymbol auszuwählen."
 
 #: eeschema/dialogs/dialog_edit_component_in_lib.cpp:73
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.h:115
@@ -4601,6 +4611,7 @@ msgstr "Anzahl der Einheiten (max. %d erlaubt)"
 #, c-format
 msgid "Alias \"%s\" cannot be removed while it is being edited!"
 msgstr ""
+"Alias \"%s\" kann nicht entfernt werden während dieser bearbeitet wird."
 
 #: eeschema/dialogs/dialog_edit_component_in_lib.cpp:306
 msgid "Remove all aliases from list?"
@@ -4617,12 +4628,12 @@ msgstr "Symbol Alias:"
 #: eeschema/dialogs/dialog_edit_component_in_lib.cpp:342
 #, c-format
 msgid "Alias or component name \"%s\" already in use."
-msgstr ""
+msgstr "Alias oder Bauteilname \"%s\" wird bereits verwendet."
 
 #: eeschema/dialogs/dialog_edit_component_in_lib.cpp:351
 #, c-format
 msgid "Symbol name \"%s\" already exists in library \"%s\"."
-msgstr ""
+msgstr "Bauteilsymbolname \"%s\" existiert bereits in Bibliothek \"%s\"."
 
 #: eeschema/dialogs/dialog_edit_component_in_lib.cpp:406
 msgid "Delete extra parts from component?"
@@ -4655,7 +4666,7 @@ msgstr "Footprint-Filter"
 #: eeschema/dialogs/dialog_edit_component_in_lib.cpp:530
 #, c-format
 msgid "Foot print filter \"%s\" is already defined."
-msgstr ""
+msgstr "Footprintfilter \"%s\" ist bereits definiert."
 
 #: eeschema/dialogs/dialog_edit_component_in_lib.cpp:566
 msgid "Edit footprint filter"
@@ -4861,27 +4872,28 @@ msgstr ""
 #: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:258
 #, c-format
 msgid "\"%s\" is not a valid library symbol indentifier."
-msgstr ""
+msgstr "\"%s\" ist keine gültige Bezeichnung für ein Bauteilsymbol."
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:275
 #, c-format
 msgid "Symbol \"%s\" not found in library \"%s\""
-msgstr ""
+msgstr "Bauteilsymbol \"%s\" wurde in Bibliothek \"%s\" nicht gefunden."
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:281
 #, c-format
 msgid "Symbol \"%s\" found in library \"%s\""
-msgstr ""
+msgstr "Bauteilsymbol \"%s\" wurde in Bibliothek \"%s\" gefunden."
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:355
 #, c-format
 msgid "Symbol library identifier \"%s\" is not valid!"
 msgstr ""
+"Bezeichner \"%s\" ist für eine Schaltplansymbolbibliothek nicht zulässig."
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:372
 #, c-format
 msgid "Symbol \"%s\" not found in library \"%s\"!"
-msgstr ""
+msgstr "Bauteilsymbol \"%s\" wurde in Bibliothek \"%s\" nicht gefunden."
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:447
 msgid "Illegal reference. A reference must start with a letter"
@@ -4895,6 +4907,10 @@ msgid ""
 "template list.  Empty field values are invalid an will be removed from the "
 "component.  Do you wish to remove this and all remaining undefined fields?"
 msgstr ""
+"Das Feld \"%s\" hat keinen gültigen Wert und wird auch nicht in der Vorlage "
+"definiert. Felder mit leeren Werten sind ungültig und werden vom "
+"Bauteilsymbol entfernt. Soll dieses und alle weiteren undefinierten Felder "
+"entfernt werden?"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:480
 msgid "Remove Fields"
@@ -5121,7 +5137,7 @@ msgstr "Links ausrichten"
 #: eeschema/dialogs/dialog_lib_edit_text_base.cpp:101
 #: eeschema/dialogs/dialog_lib_edit_text_base.cpp:107
 msgid "Align Center"
-msgstr ""
+msgstr "Zentrieren"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:169
 #: eeschema/dialogs/dialog_lib_edit_text_base.cpp:101
@@ -5267,30 +5283,32 @@ msgstr "Position Y:"
 #, c-format
 msgid "Symbol library identifier \"%s\" is not valid at row %d!"
 msgstr ""
+"Bezeichner \"%s\" in Zeile \"%d\" ist für eine Schaltplansymbolbibliothek "
+"nicht zulässig."
 
 #: eeschema/dialogs/dialog_edit_components_libid.cpp:485
 #, c-format
 msgid "Available Candidates for %s "
-msgstr ""
+msgstr "Verfügbare Kandidaten für %s "
 
 #: eeschema/dialogs/dialog_edit_components_libid.cpp:489
 #, c-format
 msgid "Candidates count %d "
-msgstr ""
+msgstr "Anzahl Kandidaten %d "
 
 #: eeschema/dialogs/dialog_edit_components_libid.cpp:499
 #, c-format
 msgid "%u link(s) mapped, %d not found"
-msgstr ""
+msgstr "%u Verbindungen zugeordnet, %d wurden nicht gefunden"
 
 #: eeschema/dialogs/dialog_edit_components_libid.cpp:503
 #, c-format
 msgid "All %u link(s) resolved"
-msgstr ""
+msgstr "Alle %u Verbindungen wurden aufgelöst"
 
 #: eeschema/dialogs/dialog_edit_components_libid.cpp:526
 msgid "Invalid symbol library identifier"
-msgstr ""
+msgstr "Ungültige Bezeichnung für ein Bibliothekssymbol"
 
 #: eeschema/dialogs/dialog_edit_components_libid_base.cpp:39
 #: pcbnew/netlist.cpp:204
@@ -5299,16 +5317,18 @@ msgstr "Bauteile"
 
 #: eeschema/dialogs/dialog_edit_components_libid_base.cpp:40
 msgid "Current Symbol"
-msgstr ""
+msgstr "Aktuelles Symbol"
 
 #: eeschema/dialogs/dialog_edit_components_libid_base.cpp:41
 msgid "New Symbol"
-msgstr ""
+msgstr "Neues Symbol"
 
 #: eeschema/dialogs/dialog_edit_components_libid_base.cpp:69
 msgid ""
 "Warning: Changes made from this dialog cannot be undone, after closing it."
 msgstr ""
+"Achtung: Änderungen, die in diesem Dialog gemacht werden, können nach dem "
+"Schließen nicht rückgängig gemacht werden."
 
 #: eeschema/dialogs/dialog_edit_components_libid_base.cpp:95
 msgid "Browse Libraries"
@@ -5901,7 +5921,7 @@ msgstr "Wähle bitte eine Symbolbibliotheksdatei."
 #: eeschema/dialogs/dialog_global_sym_lib_table_config.cpp:110
 #, c-format
 msgid "File \"%s\" not found."
-msgstr ""
+msgstr "Datei %s nicht gefunden."
 
 #: eeschema/dialogs/dialog_global_sym_lib_table_config.cpp:124
 #, c-format
@@ -5910,6 +5930,9 @@ msgid ""
 "\n"
 "%s"
 msgstr ""
+"Datei \"%s\" ist keine gültige Symbolbibliothekstabelle.\n"
+"\n"
+"%s"
 
 #: eeschema/dialogs/dialog_global_sym_lib_table_config.cpp:144
 #, c-format
@@ -5922,6 +5945,13 @@ msgid ""
 "\n"
 "\"%s\"."
 msgstr ""
+"Konnte die globale Symbolbibliothekstabelle nicht kopieren:\n"
+"\n"
+"\"%s\"\n"
+"\n"
+"to:\n"
+"\n"
+"\"%s\"."
 
 #: eeschema/dialogs/dialog_global_sym_lib_table_config.cpp:161
 #, c-format
@@ -6343,7 +6373,7 @@ msgstr "Wähle das Ausgabeverzeichnis"
 msgid ""
 "Do you want to use a path relative to\n"
 "\"%s\""
-msgstr ""
+msgstr "Soll ein Pfad relativ zu \"%s\" verwendet werden"
 
 #: eeschema/dialogs/dialog_plot_schematic.cpp:185
 #: eeschema/dialogs/dialog_plot_schematic.cpp:193
@@ -7385,7 +7415,7 @@ msgstr "Projektspezifische Bibliotheken"
 
 #: eeschema/dialogs/dialog_sym_lib_table_base.cpp:134
 msgid "Browse Libraries..."
-msgstr ""
+msgstr "Bibliotheken ansehen..."
 
 #: eeschema/dialogs/dialog_sym_lib_table_base.cpp:137
 #: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:136
@@ -7454,11 +7484,13 @@ msgstr ""
 #, c-format
 msgid "Adding library \"%s\", file \"%s\" to project symbol library table."
 msgstr ""
+"Füge Bibliothek \"%s\", Datei \"%s\" der Symbolbibliothekstabelle des "
+"Projektes hinzu."
 
 #: eeschema/dialogs/dialog_symbol_remap.cpp:171
 #, c-format
 msgid "Library \"%s\" not found."
-msgstr ""
+msgstr "Bibliothek \"%s\" wurde nicht gefunden."
 
 #: eeschema/dialogs/dialog_symbol_remap.cpp:188
 #, c-format
@@ -7477,11 +7509,12 @@ msgstr "Erstellt eine leere projektspezifische Symbolbibliothekstabelle.\n"
 #, c-format
 msgid "No symbol \"%s\" found in symbol library table."
 msgstr ""
+"Bauteilsymbol \"%s\" wurde in der Symbolbibliothekstabelle nicht gefunden."
 
 #: eeschema/dialogs/dialog_symbol_remap.cpp:227
 #, c-format
 msgid "Symbol \"%s\" mapped to symbol library \"%s\"."
-msgstr ""
+msgstr "Bauteilsymbol \"%s\" wurde der Bibliothek \"%s\" zugeordnet."
 
 #: eeschema/dialogs/dialog_symbol_remap.cpp:236
 msgid "Symbol library table mapping complete!"
@@ -7494,11 +7527,12 @@ msgstr "Kartierung der Symbolbibliothekstabelle ist fertig gestellt!"
 #: eeschema/dialogs/dialog_symbol_remap.cpp:369
 #, c-format
 msgid "Failed to back up file \"%s\".\n"
-msgstr ""
+msgstr "Konnte kein Backup der Datei \"%s\" erstellen.\n"
 
 #: eeschema/dialogs/dialog_symbol_remap.cpp:375
 msgid "Some of the project files could not be backed up."
 msgstr ""
+"Für einige der Dateien des Projektes konnte kein Backup angelegt werden."
 
 #: eeschema/dialogs/dialog_symbol_remap_base.cpp:30 eeschema/menubar.cpp:505
 #: eeschema/dialogs/dialog_symbol_remap_base.h:51
@@ -7533,7 +7567,7 @@ msgstr ""
 #: pagelayout_editor/pl_editor_frame.cpp:653
 #, c-format
 msgid "Couldn't load image from \"%s\""
-msgstr ""
+msgstr "Konnte keine Bilddatei von \"%s\" laden."
 
 #: eeschema/edit_component_in_schematic.cpp:65
 #, c-format
@@ -7734,22 +7768,22 @@ msgstr ""
 #: eeschema/erc.cpp:817
 #, c-format
 msgid "Global label \"%s\" (sheet \"%s\") looks like:"
-msgstr ""
+msgstr "Globales Label \"%s\" (Schaltplanblatt \"%s\") sieht wie folgt aus:"
 
 #: eeschema/erc.cpp:818
 #, c-format
 msgid "Local label \"%s\" (sheet \"%s\") looks like:"
-msgstr ""
+msgstr "Lokales Label \"%s\" (Schaltplanblatt \"%s\") sieht wie folgt aus:"
 
 #: eeschema/erc.cpp:826
 #, c-format
 msgid "Global label \"%s\" (sheet \"%s\")"
-msgstr ""
+msgstr "Globales Label \"%s\" (Schaltplanblatt \"%s\")"
 
 #: eeschema/erc.cpp:827
 #, c-format
 msgid "Local label \"%s\" (sheet \"%s\")"
-msgstr ""
+msgstr "Lokales Label \"%s\" (Schaltplanblatt \"%s\")"
 
 #: eeschema/files-io.cpp:74
 msgid "Schematic Files"
@@ -7758,7 +7792,7 @@ msgstr "Schaltplan Dateien"
 #: eeschema/files-io.cpp:104
 #, c-format
 msgid "Could not save backup of file \"%s\""
-msgstr ""
+msgstr "Konnte die Sicherungskopie der Datei '%s' nicht erstellen."
 
 #: eeschema/files-io.cpp:123
 #, c-format
@@ -7766,11 +7800,13 @@ msgid ""
 "Error saving schematic file \"%s\".\n"
 "%s"
 msgstr ""
+"Beim Schreiben der Schaltplandatei \"%s\" ist folgender Fehler aufgetreten:\n"
+"%s"
 
 #: eeschema/files-io.cpp:127
 #, c-format
 msgid "Failed to save \"%s\""
-msgstr ""
+msgstr "Fehler beim Speichern von \"%s\""
 
 #: eeschema/files-io.cpp:155
 #, c-format
@@ -7784,18 +7820,20 @@ msgstr "Konnte Datei nicht schreiben."
 #: eeschema/files-io.cpp:210 eeschema/files-io.cpp:779
 #, c-format
 msgid "Schematic file \"%s\" is already open."
-msgstr ""
+msgstr "Die Schaltplandatei \"%s\" ist bereits geöffnet."
 
 #: eeschema/files-io.cpp:230
 #, c-format
 msgid "Schematic \"%s\" does not exist.  Do you wish to create it?"
-msgstr ""
+msgstr "Schaltplan \"%s\" existiert nicht. Soll er angelegt werden?"
 
 #: eeschema/files-io.cpp:300 eeschema/files-io.cpp:451 eeschema/sheet.cpp:254
 msgid ""
 "The entire schematic could not be load.  Errors occurred attempting to load "
 "hierarchical sheet schematics."
 msgstr ""
+"Der gesamte Schaltplan konnte nicht geladen werden. Beim Laden der "
+"hierarchischen Schaltplanblätter sind Fehler aufgetreten."
 
 #: eeschema/files-io.cpp:314 eeschema/files-io.cpp:825
 #, c-format
@@ -7803,11 +7841,13 @@ msgid ""
 "Error loading schematic file \"%s\".\n"
 "%s"
 msgstr ""
+"Fehler beim Laden der Schaltplandatei \"%s\".\n"
+"%s"
 
 #: eeschema/files-io.cpp:318 eeschema/files-io.cpp:829
 #, c-format
 msgid "Failed to load \"%s\""
-msgstr ""
+msgstr "Fehler beim Laden von \"%s\""
 
 #: eeschema/files-io.cpp:333
 msgid ""
@@ -7827,17 +7867,19 @@ msgstr "Schaltplan hinzufügen"
 #: eeschema/files-io.cpp:459 eeschema/sheet.cpp:262
 #, c-format
 msgid "Error occurred loading schematic file \"%s\"."
-msgstr ""
+msgstr "Fehler beim Laden der Schaltplandatei \"%s\"."
 
 #: eeschema/files-io.cpp:462 eeschema/sheet.cpp:265
 #, c-format
 msgid "Failed to load schematic \"%s\""
-msgstr ""
+msgstr "Konnte Schaltplan \"%s\" nicht laden"
 
 #: eeschema/files-io.cpp:527
 #, c-format
 msgid "An error occurred loading the symbol library table \"%s\"."
 msgstr ""
+"Bei dem Versuch die Symbolbibliothekstabelle \"%s\" zu laden ist ein Fehler "
+"aufgetreten."
 
 #: eeschema/files-io.cpp:649
 msgid ""
@@ -7845,6 +7887,9 @@ msgid ""
 "\n"
 "Do you want to save the current document before proceeding?"
 msgstr ""
+"Der Vorgang kann nicht rückgängig gemacht werden.\n"
+"\n"
+"Soll das aktuelle Dokument vorher gespeichert werden?"
 
 #: eeschema/files-io.cpp:669
 msgid "Import Schematic"
@@ -7853,7 +7898,7 @@ msgstr "Schaltplanimport"
 #: eeschema/files-io.cpp:700
 #, c-format
 msgid "Directory \"%s\" is not writable."
-msgstr ""
+msgstr "Das Verzeichnis \"%s\" ist nicht schreibbar."
 
 #: eeschema/files-io.cpp:855
 msgid ""
@@ -8179,7 +8224,7 @@ msgstr "Bibliothek speichern"
 
 #: eeschema/hotkeys.cpp:222
 msgid "Save Part"
-msgstr ""
+msgstr "Bauteil speichern"
 
 #: eeschema/hotkeys.cpp:223
 msgid "Save Schematic"
@@ -8294,17 +8339,17 @@ msgstr "Symbol importieren"
 #: eeschema/lib_export.cpp:80 eeschema/symbedit.cpp:92
 #, c-format
 msgid "Cannot import symbol library \"%s\"."
-msgstr ""
+msgstr "Kann Schaltplansymboltabelle \"%s\" nicht importieren."
 
 #: eeschema/lib_export.cpp:87 eeschema/symbedit.cpp:99
 #, c-format
 msgid "Symbol library file \"%s\" is empty."
-msgstr ""
+msgstr "Die Symbolbibliothek \"%s\" ist leer."
 
 #: eeschema/lib_export.cpp:97
 #, c-format
 msgid "Symbol \"%s\" already exists in library \"%s\"."
-msgstr ""
+msgstr "Bauteilsymbol \"%s\" existiert bereits in Bibliothek \"%s\"."
 
 #: eeschema/lib_export.cpp:114
 msgid "There is no symbol selected to save."
@@ -8318,16 +8363,17 @@ msgstr "Symbol exportieren"
 #, c-format
 msgid "Error occurred attempting to load symbol library file \"%s\""
 msgstr ""
+"Beim Laden der Schaltplansymboltabelle \"%s\" ist ein Fehler aufgetreten"
 
 #: eeschema/lib_export.cpp:155
 #, c-format
 msgid "Symbol \"%s\" already exists. Overwrite it?"
-msgstr ""
+msgstr "Bauteilsymbol \"%s\" existiert bereits. Soll es überschrieben werden?"
 
 #: eeschema/lib_export.cpp:164
 #, c-format
 msgid "Write permissions are required to save library \"%s\"."
-msgstr ""
+msgstr "Keine Schreibrechte zum Speichern der Bibliothek '%s'."
 
 #: eeschema/lib_export.cpp:178
 msgid "Failed to create symbol library file "
@@ -8336,12 +8382,12 @@ msgstr "Konnte die Symbolbibliothek nicht erstellen"
 #: eeschema/lib_export.cpp:180
 #, c-format
 msgid "Error creating symbol library \"%s\""
-msgstr ""
+msgstr "Ein Fehler ist aufgetreten beim Erstellen der Symbolbibliothek '%s'."
 
 #: eeschema/lib_export.cpp:188
 #, c-format
 msgid "Symbol \"%s\" saved in library \"%s\""
-msgstr ""
+msgstr "Bauteilsymbol \"%s\" wurde in der Bibliothek \"%s\" gespeichert"
 
 #: eeschema/lib_field.cpp:456 eeschema/sch_component.cpp:1461
 #: eeschema/template_fieldnames.cpp:45 pcbnew/class_edge_mod.cpp:248
@@ -8457,7 +8503,7 @@ msgstr "Ein Fehler ist aufgetreten beim Erstellen der Symbolbibliothek '%s'."
 #: eeschema/libarch.cpp:155
 #, c-format
 msgid "Failed to save symbol library file \"%s\""
-msgstr ""
+msgstr "Fehler beim Speichern der Symbolbibliothek \"%s\""
 
 #: eeschema/libedit.cpp:62
 msgid "Symbol Library Editor - "
@@ -8485,6 +8531,8 @@ msgstr ""
 #, c-format
 msgid "Error occurred loading symbol \"%s\" from library \"%s\"."
 msgstr ""
+"Bei dem Versuch das Symbol %s aus der Bibliothek %s zu laden ist ein Fehler "
+"aufgetreten."
 
 #: eeschema/libedit.cpp:257
 msgid ""
@@ -8501,12 +8549,12 @@ msgstr ""
 #: eeschema/libedit.cpp:302
 #, c-format
 msgid "Symbol \"%s\" already exists in library \"%s\""
-msgstr ""
+msgstr "Bauteilsymbol \"%s\" existiert bereits in Bibliothek \"%s\"."
 
 #: eeschema/libedit.cpp:488
 #, c-format
 msgid "Part name \"%s\" not found in library \"%s\""
-msgstr ""
+msgstr "Bauteil \"%s\" wurde in Bibliothek \"%s\" nicht gefunden."
 
 #: eeschema/libedit.cpp:512
 msgid "No library specified."
@@ -8515,12 +8563,12 @@ msgstr "Keine Bibliothek angegeben."
 #: eeschema/libedit.cpp:529
 #, c-format
 msgid "Save Library \"%s\" As..."
-msgstr ""
+msgstr "Bibliothek \"%s\" speichern als..."
 
 #: eeschema/libedit.cpp:567
 #, c-format
 msgid "Failed to save changes to symbol library file \"%s\""
-msgstr ""
+msgstr "Fehler beim Speichern der Symbolbibliothekstabelle \"%s\""
 
 #: eeschema/libedit.cpp:569
 msgid "Error saving library"


### PR DESCRIPTION
Upstream source made massive changes in quoting in the english original strings.
This commit remappes the german strings against the english ones.

Additionally it unifies german quoting to use single quotes instead of "<>" in
the re-matched strings.

Signed-off-by: Chris Fiege <c.fiege@pengutronix.de>