### PR TITLE
Support wxPLURAL( singular, plural, number )

### DIFF
--- a/update-po-files.sh
+++ b/update-po-files.sh
@@ -67,7 +67,7 @@ do
 done
 
 #Generate/update template pot file
-xgettext -f $LOCALDIR/POTFILES -k_ -k_HKI --force-po --from-code utf-8 -o $LOCALDIR/kicad.pot
+xgettext -f $LOCALDIR/POTFILES -k_ -k_HKI -kwxPLURAL:1,2 --force-po --from-code utf-8 -o $LOCALDIR/kicad.pot
 
 rm $LOCALDIR/POTFILES
 


### PR DESCRIPTION
This allows selecting the appropriate form for messages that use plural
forms that depend on the preceding number:

Old:

    _( "%d item(s)" )

New:

    wxPLURAL( "%d item", "%d items", num )