### PR TITLE
de: fixed unit for electrical resistivity

### DIFF
--- a/de/kicad.po
+++ b/de/kicad.po
@@ -14883,7 +14883,7 @@ msgstr "Spez. Widerstand:"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:305
 msgid "Ohm-meter"
-msgstr "Ohm pro Meter"
+msgstr "Ohm x Meter"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:328
 msgid "External layer traces:"


### PR DESCRIPTION
The SI unit for electrical resistivity is [Ohm * mm² / m] or [Ohm * m], not "Ohm per meter".