### PR TITLE
Update Polish GUI translation to fix file filters

### DIFF
--- a/pl/kicad.po
+++ b/pl/kicad.po
@@ -2,33 +2,42 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kicad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-07-18 21:11+0200\n"
-"PO-Revision-Date: 2018-03-10 21:28+0100\n"
-"Last-Translator: Krzysztof Kawa <christophorus72@gmail.com>\n"
-"Language-Team: Polish KiCAD Team: Mateusz Skowroński, Krzysztof Kawa, "
+"POT-Creation-Date: 2018-07-22 19:01+0200\n"
+"PO-Revision-Date: 2018-07-22 19:04+0200\n"
+"Last-Translator: Kerusey Karyu <keruseykaryu@o2.pl>\n"
+"Language-Team: Polish KiCad Translators: Mateusz Skowroński, Krzysztof Kawa, "
 "Kerusey Karyu, Daniel Dawid Majewski\n"
 "Language: pl_PL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Poedit-Basepath: ../kicad-source-mirror-master\n"
+"X-Poedit-Basepath: D:/Programy/GITHUB/kicad-source-mirror\n"
 "X-Poedit-KeywordsList: _;_HKI\n"
-"X-Generator: Poedit 1.8.7.1\n"
+"X-Generator: Poedit 2.0.9\n"
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
 "|| n%100>=20) ? 1 : 2);\n"
-"X-Poedit-SearchPath-0: .\n"
+"X-Poedit-SearchPath-0: kicad\n"
+"X-Poedit-SearchPath-1: eeschema\n"
+"X-Poedit-SearchPath-2: pcbnew\n"
+"X-Poedit-SearchPath-3: cvpcb\n"
+"X-Poedit-SearchPath-4: gerbview\n"
+"X-Poedit-SearchPath-5: 3d-viewer\n"
+"X-Poedit-SearchPath-6: common\n"
+"X-Poedit-SearchPath-7: bitmap2component\n"
+"X-Poedit-SearchPath-8: pcb_calculator\n"
+"X-Poedit-SearchPath-9: pagelayout_editor\n"
 
 #: 3d-viewer/3d_cache/3d_cache.cpp:529
 msgid "path exists but is not a regular file"
-msgstr "Ścieżka istnieje, ale nie jest zwykłym plikiem"
+msgstr "ścieżka jest prawidłowa ale nie prowadzi do pliku"
 
 #: 3d-viewer/3d_cache/3d_cache.cpp:564
 msgid "failed to create 3D configuration directory"
-msgstr "Nie udało się utworzyć katalogu konfiguracji 3D"
+msgstr "nie można utworzyć folderu konfiguracji 3D"
 
 #: 3d-viewer/3d_cache/3d_cache.cpp:566
 msgid "config directory"
-msgstr "Katalog konfiguracyjny"
+msgstr "folder konfiguracji"
 
 #: 3d-viewer/3d_cache/3d_filename_resolver.cpp:473
 msgid "The given path does not exist"
@@ -36,41 +45,41 @@ msgstr "Podana ścieżka nie istnieje"
 
 #: 3d-viewer/3d_cache/3d_filename_resolver.cpp:476
 msgid "3D model search path"
-msgstr "Ścieżka wyszukiwania modelu 3D"
+msgstr "Ścieżka przeszukiwań modeli 3D"
 
 #: 3d-viewer/3d_cache/3d_filename_resolver.cpp:502
 msgid "Alias: "
-msgstr ""
+msgstr "Alias: "
 
 #: 3d-viewer/3d_cache/3d_filename_resolver.cpp:505
 msgid "This path: "
-msgstr "Ta ścieżka:"
+msgstr "Ścieżka obecna: "
 
 #: 3d-viewer/3d_cache/3d_filename_resolver.cpp:508
 msgid "Existing path: "
-msgstr "Istniejąca ścieżka:"
+msgstr "Istniejąca ścieżka: "
 
 #: 3d-viewer/3d_cache/3d_filename_resolver.cpp:510
 msgid "Bad alias (duplicate name)"
-msgstr ""
+msgstr "Niepoprawny alias (zduplikowana nazwa)"
 
 #: 3d-viewer/3d_cache/3d_filename_resolver.cpp:635
 msgid "3D configuration directory is unknown"
-msgstr "Katalog konfiguracji 3D jest nieznany"
+msgstr "Folder konfiguracji 3D nie jest znany"
 
 #: 3d-viewer/3d_cache/3d_filename_resolver.cpp:638
 #: 3d-viewer/3d_cache/3d_filename_resolver.cpp:663
 #: 3d-viewer/3d_cache/3d_filename_resolver.cpp:688
 msgid "Write 3D search path list"
-msgstr ""
+msgstr "Zapisuje listę ścieżek poszukiwań modeli 3D"
 
 #: 3d-viewer/3d_cache/3d_filename_resolver.cpp:660
 msgid "Could not open configuration file"
-msgstr ""
+msgstr "Nie można otworzyć pliku konfigurującego"
 
 #: 3d-viewer/3d_cache/3d_filename_resolver.cpp:687
 msgid "Problems writing configuration file"
-msgstr ""
+msgstr "Wystąpił problem przy zapisie pliku konfiguracyjnego"
 
 #: 3d-viewer/3d_cache/3d_plugin_manager.cpp:51
 msgid "All Files (*.*)|*.*"
@@ -78,22 +87,22 @@ msgstr "Wszystkie pliki (*.*)|*.*"
 
 #: 3d-viewer/3d_cache/dialogs/dlg_3d_pathconfig.cpp:133
 msgid "[BUG] No valid resolver; data will not be updated"
-msgstr ""
+msgstr "[BUG] Brak poprawnego resolvera; dane nie zostaną zaktualizowane"
 
 #: 3d-viewer/3d_cache/dialogs/dlg_3d_pathconfig.cpp:134
 msgid "Update 3D search path list"
-msgstr ""
+msgstr "Uaktualnia listę ścieżek poszukiwań modeli 3D"
 
 #: 3d-viewer/3d_cache/dialogs/dlg_3d_pathconfig.cpp:193
 #: 3d-viewer/3d_cache/dialogs/dlg_3d_pathconfig.cpp:233
 #: 3d-viewer/3d_cache/dialogs/dlg_3d_pathconfig.cpp:274
 msgid "No entry selected"
-msgstr ""
+msgstr "Nie wybrano"
 
 #: 3d-viewer/3d_cache/dialogs/dlg_3d_pathconfig.cpp:193
 #: 3d-viewer/3d_cache/dialogs/dlg_3d_pathconfig.cpp:200
 msgid "Delete alias entry"
-msgstr ""
+msgstr "Usuń alias"
 
 #: 3d-viewer/3d_cache/dialogs/dlg_3d_pathconfig.cpp:199
 #: 3d-viewer/3d_cache/dialogs/dlg_3d_pathconfig.cpp:239
@@ -102,26 +111,31 @@ msgid ""
 "Multiple entries selected; please\n"
 "select only one entry"
 msgstr ""
+"Zaznaczenie wielokrotne; proszę\n"
+"wybrać tylko jeden wpis"
 
 #: 3d-viewer/3d_cache/dialogs/dlg_3d_pathconfig.cpp:233
 #: 3d-viewer/3d_cache/dialogs/dlg_3d_pathconfig.cpp:240
 msgid "Move alias up"
-msgstr "Przesuń alias w górę"
+msgstr "Przesuń w górę"
 
 #: 3d-viewer/3d_cache/dialogs/dlg_3d_pathconfig.cpp:274
 #: 3d-viewer/3d_cache/dialogs/dlg_3d_pathconfig.cpp:281
 msgid "Move alias down"
-msgstr "Przesuń alias w dół"
+msgstr "Przesuń w dół"
 
 #: 3d-viewer/3d_cache/dialogs/dlg_3d_pathconfig.cpp:370
 msgid ""
 "Enter the name and path for each 3D alias variable.<br>KiCad environment "
 "variables and their values are shown for reference only and cannot be edited."
 msgstr ""
+"Wpisz nazwę oraz ścieżkę dla każdej zmiennej aliasu 3D.<br>Zmienne programu "
+"KiCad i ich wartości są wyświetlane tylko jako pomoc i nie mogą być z tego "
+"miejsca zmieniane."
 
 #: 3d-viewer/3d_cache/dialogs/dlg_3d_pathconfig.cpp:374
 msgid "Alias names may not contain any of the characters "
-msgstr ""
+msgstr "Nazwy aliasów nie mogą zawierać żadnego z podanych znaków "
 
 #: 3d-viewer/3d_cache/dialogs/dlg_3d_pathconfig.cpp:378
 #: common/dialogs/dialog_env_var_config.cpp:325
@@ -150,7 +164,7 @@ msgstr "Ścieżka"
 
 #: 3d-viewer/3d_cache/dialogs/dlg_3d_pathconfig_base.cpp:54
 msgid "Configure Environment Variables"
-msgstr "Konfiguracja zmiennych środowiskowych"
+msgstr "Konfiguruj zmienne środowiskowe"
 
 #: 3d-viewer/3d_cache/dialogs/dlg_3d_pathconfig_base.cpp:82
 #: eeschema/libedit.cpp:680 eeschema/viewlibs.cpp:242
@@ -161,7 +175,7 @@ msgstr "Alias"
 #: common/dialog_about/AboutDialog_main.cpp:114
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:160
 #: eeschema/libedit.cpp:700 eeschema/sch_component.cpp:1428
-#: eeschema/viewlibs.cpp:243 include/lib_table_grid.h:196
+#: eeschema/viewlibs.cpp:243
 #: pcbnew/dialogs/dialog_footprint_wizard_list_base.cpp:44
 #: pcbnew/footprint_libraries_utils.cpp:714
 #: pcbnew/footprint_libraries_utils.cpp:903
@@ -196,7 +210,7 @@ msgstr "Przesuń w dół"
 
 #: 3d-viewer/3d_cache/dialogs/dlg_3d_pathconfig_base.h:62
 msgid "3D Search Path Configuration"
-msgstr "Konfiguracja ścieżki wyszukiwania 3D"
+msgstr "Konfiguracja ścieżek dostępu modeli 3D"
 
 #: 3d-viewer/3d_cache/dialogs/dlg_select_3dmodel.cpp:52
 msgid "Select 3D Model"
@@ -204,13 +218,13 @@ msgstr "Wybierz model 3D"
 
 #: 3d-viewer/3d_cache/dialogs/dlg_select_3dmodel.cpp:136
 msgid "Paths:"
-msgstr "Ścieżka"
+msgstr "Ścieżki:"
 
 #: 3d-viewer/3d_cache/dialogs/dlg_select_3dmodel.cpp:137
 #: pcbnew/dialogs/dialog_edit_footprint_for_BoardEditor_base.cpp:362
 #: pcbnew/dialogs/dialog_edit_footprint_for_fp_editor_base.cpp:307
 msgid "Configure Paths"
-msgstr "Konfiguracja ścieżek"
+msgstr "Konfiguracja ścieżek dostępu"
 
 #: 3d-viewer/3d_cache/dialogs/dlg_select_3dmodel.cpp:142
 #: common/dialog_about/dialog_about_base.cpp:75
@@ -277,7 +291,7 @@ msgstr "Z:"
 
 #: 3d-viewer/3d_cache/dialogs/panel_prev_3d_base.cpp:71
 msgid "Rotation (degrees)"
-msgstr "Obrót (stopnie)"
+msgstr "Obrót (w stopniach)"
 
 #: 3d-viewer/3d_cache/dialogs/panel_prev_3d_base.cpp:143
 msgid "Offset"
@@ -285,11 +299,11 @@ msgstr "Przesunięcie"
 
 #: 3d-viewer/3d_cache/dialogs/panel_prev_3d_base.cpp:214
 msgid "Change to isometric perspective"
-msgstr "Zmień perspektywę na izometryczną"
+msgstr "Zamiana na perspektywę izometryczną"
 
 #: 3d-viewer/3d_cache/dialogs/panel_prev_3d_base.cpp:228
 msgid "Reload board and 3D models"
-msgstr "Wczytaj ponownie płytkę i modele 3D"
+msgstr "Przeładuj płytkę oraz modele 3D"
 
 #: 3d-viewer/3d_cache/dialogs/panel_prev_model.cpp:139
 #: common/base_units.cpp:465 common/dialogs/dialog_page_settings.cpp:472
@@ -363,23 +377,23 @@ msgstr "Przesunięcie (%s)"
 
 #: 3d-viewer/3d_cache/dialogs/panel_prev_model.cpp:641
 msgid "Invalid X scale"
-msgstr "Nieprawidłowa skala X"
+msgstr "Niepoprawna skala X"
 
 #: 3d-viewer/3d_cache/dialogs/panel_prev_model.cpp:652
 msgid "Invalid Y scale"
-msgstr "Nieprawidłowa skala Y"
+msgstr "Niepoprawna skala Y"
 
 #: 3d-viewer/3d_cache/dialogs/panel_prev_model.cpp:663
 msgid "Invalid Z scale"
-msgstr "Nieprawidłowa skala Z"
+msgstr "Niepoprawna skala Z"
 
 #: 3d-viewer/3d_cache/sg/ifsg_api.cpp:333
 msgid "no such file"
-msgstr "nie ma takiego pliku"
+msgstr "brak pliku"
 
 #: 3d-viewer/3d_cache/sg/ifsg_api.cpp:364
 msgid "failed to open file"
-msgstr "nie udało się otworzyć pliku"
+msgstr "nie można otworzyć pliku"
 
 #: 3d-viewer/3d_canvas/cinfo3d_visu.cpp:425
 msgid "Build board body"
@@ -387,7 +401,7 @@ msgstr "Budowanie ciała płytki"
 
 #: 3d-viewer/3d_canvas/cinfo3d_visu.cpp:435
 msgid "Create layers"
-msgstr "Tworzenie warstwy"
+msgstr "Utwórz warstwy"
 
 #: 3d-viewer/3d_canvas/cinfo3d_visu.cpp:461
 #: pcbnew/dialogs/dialog_export_step.cpp:233
@@ -400,33 +414,33 @@ msgstr "Tworzenie ścieżek i przelotek"
 
 #: 3d-viewer/3d_canvas/create_layer_items.cpp:787
 msgid "Create zones"
-msgstr "Tworzenie strefy"
+msgstr "Tworzenie stref wypełnień"
 
 #: 3d-viewer/3d_canvas/create_layer_items.cpp:796
 #, c-format
 msgid "Create zones of layer %s"
-msgstr "Utwórz strefy warstwy %s"
+msgstr "Tworzenie strefy na warstwie %s"
 
 #: 3d-viewer/3d_canvas/create_layer_items.cpp:863
 msgid "Simplifying copper layers polygons"
-msgstr "Upraszczanie wypełnień na warstwach miedzi"
+msgstr "Upraszczanie poligonów na warstwach miedzi"
 
 #: 3d-viewer/3d_canvas/create_layer_items.cpp:894
 msgid "Simplify holes contours"
-msgstr "Uproszczenie konturów otworów"
+msgstr "Uprość kontury otworów"
 
 #: 3d-viewer/3d_canvas/create_layer_items.cpp:940
 msgid "Build Tech layers"
-msgstr "Utwórz warstwy techniczne"
+msgstr "Budowanie warstw technicznych"
 
 #: 3d-viewer/3d_canvas/create_layer_items.cpp:1170
 msgid "Build BVH for holes and vias"
-msgstr ""
+msgstr "Tworzenie BVH dla otworów i przelotek"
 
 #: 3d-viewer/3d_canvas/eda_3d_canvas.cpp:415
 #, c-format
 msgid "Render time %.0f ms ( %.1f fps)"
-msgstr ""
+msgstr "Czas renderowania %.0f ms ( %.1f fps)"
 
 #: 3d-viewer/3d_canvas/eda_3d_canvas.cpp:612
 msgid "Zoom +"
@@ -442,7 +456,7 @@ msgstr "Widok z góry"
 
 #: 3d-viewer/3d_canvas/eda_3d_canvas.cpp:630
 msgid "Bottom View"
-msgstr "Widok z dołu"
+msgstr "Widok od spodu"
 
 #: 3d-viewer/3d_canvas/eda_3d_canvas.cpp:637
 msgid "Right View"
@@ -462,31 +476,31 @@ msgstr "Widok z tyłu"
 
 #: 3d-viewer/3d_canvas/eda_3d_canvas.cpp:661
 msgid "Move Left <-"
-msgstr "Przesuń w lewo ←"
+msgstr "Przesuń w lewo <-"
 
 #: 3d-viewer/3d_canvas/eda_3d_canvas.cpp:666
 msgid "Move Right ->"
-msgstr "Przesuń w prawo →"
+msgstr "Przesuń w prawo ->"
 
 #: 3d-viewer/3d_canvas/eda_3d_canvas.cpp:671
 msgid "Move Up ^"
-msgstr "Przesuń w górę ↑"
+msgstr "Przesuń w górę ^"
 
 #: 3d-viewer/3d_rendering/3d_render_ogl_legacy/c3d_render_createscene_ogl_legacy.cpp:366
 msgid "Load OpenGL: board"
-msgstr "Wczytywanie OpenGL: płytka"
+msgstr "Ładowanie OpenGL: płytka"
 
 #: 3d-viewer/3d_rendering/3d_render_ogl_legacy/c3d_render_createscene_ogl_legacy.cpp:437
 msgid "Load OpenGL: holes and vias"
-msgstr "Wczytywanie OpenGL: otwory i przelotki"
+msgstr "Ładowanie OpenGL: otwory i przelotki"
 
 #: 3d-viewer/3d_rendering/3d_render_ogl_legacy/c3d_render_createscene_ogl_legacy.cpp:536
 msgid "Load OpenGL: layers"
-msgstr "Wczytywanie OpenGL: warstwy"
+msgstr "Ładownie OpenGL: warstwy"
 
 #: 3d-viewer/3d_rendering/3d_render_ogl_legacy/c3d_render_createscene_ogl_legacy.cpp:643
 msgid "Loading 3D models"
-msgstr "Wczytywanie modeli 3D"
+msgstr "Ładowanie modeli 3D"
 
 #: 3d-viewer/3d_rendering/3d_render_ogl_legacy/c3d_render_createscene_ogl_legacy.cpp:667
 #: 3d-viewer/3d_rendering/3d_render_raytracing/c3d_render_createscene.cpp:963
@@ -495,9 +509,9 @@ msgid "Reload time %.3f s"
 msgstr "Czas przeładowania %.3f s"
 
 #: 3d-viewer/3d_rendering/3d_render_ogl_legacy/c3d_render_createscene_ogl_legacy.cpp:954
-#, fuzzy, c-format
+#, c-format
 msgid "Loading %s"
-msgstr "Wczytywanie '%s'"
+msgstr "Wczytywanie %s"
 
 #: 3d-viewer/3d_rendering/3d_render_ogl_legacy/c3d_render_ogl_legacy.cpp:479
 #: 3d-viewer/3d_rendering/3d_render_raytracing/c3d_render_raytracing.cpp:177
@@ -508,16 +522,16 @@ msgstr "Wczytywanie..."
 #: 3d-viewer/3d_rendering/3d_render_raytracing/c3d_render_raytracing.cpp:357
 #, c-format
 msgid "Rendering time %.3f s"
-msgstr "Czas renderingu %.3f s"
+msgstr "Czas renderowania %.3f s"
 
 #: 3d-viewer/3d_rendering/3d_render_raytracing/c3d_render_raytracing.cpp:415
 #, c-format
 msgid "Rendering: %.0f %%"
-msgstr "Rendering: %.0F %%"
+msgstr "Renderowanie: %.0f %%"
 
 #: 3d-viewer/3d_rendering/3d_render_raytracing/c3d_render_raytracing.cpp:926
 msgid "Rendering: Post processing shader"
-msgstr "Rendering: Cieniowanie przetwarzania końcowego"
+msgstr "Renderowanie: Post-produkcja cieni"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:52 cvpcb/menubar.cpp:108
 #: eeschema/menubar.cpp:114 eeschema/menubar_libedit.cpp:356
@@ -533,7 +547,7 @@ msgstr "Eksportuj bieżący widok jako plik PNG..."
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:59
 msgid "Export Current View as JPEG..."
-msgstr "Eksportuj bieżący widok jako plik  JPEG..."
+msgstr "Eksportuj bieżący widok jako plik JPEG..."
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:64 eeschema/menubar.cpp:468
 #: kicad/menubar.cpp:297 pcbnew/menubar_footprint_editor.cpp:150
@@ -549,7 +563,7 @@ msgstr "&Edytuj"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:70
 msgid "Copy 3D Image"
-msgstr "Kopiuj obraz 3D"
+msgstr "Kopiuj obraz 3D do schowka"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:73 eeschema/menubar.cpp:116
 #: eeschema/menubar_libedit.cpp:358 eeschema/tool_viewlib.cpp:229
@@ -575,9 +589,8 @@ msgstr "P&omniejsz"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:84 gerbview/menubar.cpp:203
 #: pcbnew/menubar_pcb_editor.cpp:621
-#, fuzzy
 msgid "Zoom to &Fit"
-msgstr "Pomniejsz"
+msgstr "Dopasuj powiększenie"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:88 eeschema/menubar.cpp:183
 #: eeschema/menubar_libedit.cpp:171 eeschema/tool_viewlib.cpp:192
@@ -587,38 +600,32 @@ msgid "&Redraw"
 msgstr "Odśwież widok"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:94 3d-viewer/3d_viewer/3d_toolbar.cpp:92
-#, fuzzy
 msgid "Rotate X Clockwise"
-msgstr "Obróć blok w prawo"
+msgstr "Obróć X w prawo"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:98 3d-viewer/3d_viewer/3d_toolbar.cpp:96
-#, fuzzy
 msgid "Rotate X Counterclockwise"
-msgstr "Obróć blok w lewo"
+msgstr "Obróć X w lewo"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:104
 #: 3d-viewer/3d_viewer/3d_toolbar.cpp:101
-#, fuzzy
 msgid "Rotate Y Clockwise"
-msgstr "Obróć blok w prawo"
+msgstr "Obróć Y w prawo"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:108
 #: 3d-viewer/3d_viewer/3d_toolbar.cpp:105
-#, fuzzy
 msgid "Rotate Y Counterclockwise"
-msgstr "Obróć blok w lewo"
+msgstr "Obróć Y w lewo"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:114
 #: 3d-viewer/3d_viewer/3d_toolbar.cpp:110
-#, fuzzy
 msgid "Rotate Z Clockwise"
-msgstr "Obróć blok w prawo"
+msgstr "Obróć Z w prawo"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:118
 #: 3d-viewer/3d_viewer/3d_toolbar.cpp:114
-#, fuzzy
 msgid "Rotate Z Counterclockwise"
-msgstr "Obróć blok w lewo"
+msgstr "Obróć Z w lewo"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:124
 #: 3d-viewer/3d_viewer/3d_toolbar.cpp:118
@@ -647,7 +654,7 @@ msgstr "&Ustawienia"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:142
 msgid "Use Touchpad to Pan"
-msgstr ""
+msgstr "Użyj płytki dotykowej by panoramować"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:148
 #: cvpcb/dialogs/dialog_display_options_base.h:60
@@ -658,7 +665,7 @@ msgstr "Opcje wyświetlania"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:153
 msgid "Render Engine"
-msgstr "Silnik renderingu"
+msgstr "Silnik renderowania"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:156
 msgid "OpenGL"
@@ -674,7 +681,7 @@ msgstr "Opcje renderingu"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:175
 msgid "Material Properties"
-msgstr "Właściwości materiału"
+msgstr "Właściwości materiałów"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:178
 msgid "Use All Properties"
@@ -682,15 +689,15 @@ msgstr "Użyj wszystkich właściwości"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:179
 msgid "Use all material properties from each 3D model file"
-msgstr ""
+msgstr "Używa wszystkich właściwości materiałów z każdego pliku modelu 3D"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:182
 msgid "Use Diffuse Only"
-msgstr "Użyj tylko rozproszenia"
+msgstr "Użyj tylko rozpraszania"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:183
 msgid "Use only the diffuse color property from model 3D model file "
-msgstr ""
+msgstr "Używa tylko właściwości rozpraszania koloru z pliku modelu 3D "
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:186
 msgid "CAD Color Style"
@@ -698,7 +705,7 @@ msgstr "Styl kolorów CAD"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:187
 msgid "Use a CAD color style based on the diffuse color of the material"
-msgstr "Użyj stylu kolorów CAD na podstawie rozproszonego koloru materiału"
+msgstr "Użyj stylu kolorów CAD jako koloru dyfuzyjnego materiałów"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:194
 msgid "OpenGL Options"
@@ -710,7 +717,7 @@ msgstr "Pokaż grubość miedzi"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:198
 msgid "Shows the copper thickness on copper layers (slower loading)"
-msgstr "Pokazuje grubość miedzi na warstwach miedzi (wolniejsze ładowanie)"
+msgstr "Pokazuje grubość warstwy miedzi na warstwach miedzi (wolne)"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:202
 msgid "Show Model Bounding Boxes"
@@ -718,7 +725,7 @@ msgstr "Pokaż bryły brzegowe modeli"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:210
 msgid "Raytracing Options"
-msgstr "Opcje Raytracingu"
+msgstr "Opcje raytracingu"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:213
 msgid "Render Shadows"
@@ -734,45 +741,51 @@ msgstr "Zastosuj tekstury proceduralne do materiałów (wolno)"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:222
 msgid "Add Floor"
-msgstr ""
+msgstr "Dodaj podłoże"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:223
 msgid "Adds a floor plane below the board (slow)"
-msgstr ""
+msgstr "Dodaje podkład poniżej płytki (wolne)"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:227
 msgid "Refractions"
-msgstr "Załamania"
+msgstr "Odbicia"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:228
 msgid "Render materials with refractions properties on final render (slow)"
 msgstr ""
+"Renderuje materiały z właściwościami załamań światła na końcowym renderingu "
+"(wolne)"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:232
 msgid "Reflections"
-msgstr "Odbicia"
+msgstr "Refleksy"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:233
 msgid "Render materials with reflections properties on final render (slow)"
 msgstr ""
+"Renderuje materiały z właściwościami odbić światła na końcowym renderingu "
+"(wolne)"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:237
 msgid "Anti-aliasing"
-msgstr "Wygładzanie krawędzi"
+msgstr "Anty-aliasing"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:238
 msgid "Render with improved quality on final render (slow)"
-msgstr ""
+msgstr "Renderuj ze zwiększoną jakością na finalnym renderingu (wolne)"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:242
 msgid "Post-processing"
-msgstr "Przetwarzanie końcowe"
+msgstr "Post-produkcja"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:243
 msgid ""
 "Apply Screen Space Ambient Occlusion and Global Illumination reflections on "
 "final render (slow)"
 msgstr ""
+"Zastosuj refleksy Apply Screen Space Ambient Occlusion oraz Global "
+"Illumination na końcowym renderingu (wolne)"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:255
 msgid "Choose Colors"
@@ -785,27 +798,27 @@ msgstr "Kolor Tła"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:262
 msgid "Background Top Color..."
-msgstr "Górny kolor tła..."
+msgstr "Kolor górnej części tła..."
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:265
 msgid "Background Bottom Color..."
-msgstr "Dolny kolor tła..."
+msgstr "Kolor dolnej części tła..."
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:268
 msgid "Silkscreen Color..."
-msgstr "Kolor napisów płytki..."
+msgstr "Kolor warstwy opisowej..."
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:271
 msgid "Solder Mask Color..."
-msgstr "Kolor maski lutowniczej..."
+msgstr "Kolor soldermaski..."
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:274
 msgid "Solder Paste Color..."
-msgstr "Kolor pasty lutowniczej..."
+msgstr "Kolor warstwy pasty..."
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:277
 msgid "Copper/Surface Finish Color..."
-msgstr "Kolor wykończenia powierzchni miedzi..."
+msgstr "Kolor wykończenia miedzi/powierzchni..."
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:280
 msgid "Board Body Color..."
@@ -841,7 +854,7 @@ msgstr "Siatka 1mm"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:314
 msgid "Reset to Default Settings"
-msgstr "Zresetuj do ustawień domyślnych"
+msgstr "Resetuj do ustawień domyślnych"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:319 cvpcb/menubar.cpp:110
 #: eeschema/menubar.cpp:121 eeschema/menubar_libedit.cpp:362
@@ -859,7 +872,7 @@ msgstr "Podręcznik programu Pcbnew"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:323 pcbnew/menubar_pcb_editor.cpp:473
 msgid "Open Pcbnew Manual"
-msgstr "Otwórz podręcznik programu Pcbnew"
+msgstr "Otwórz podręcznik Pcbnew"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:327 cvpcb/menubar.cpp:97
 #: eeschema/menubar.cpp:642 eeschema/menubar_libedit.cpp:329
@@ -874,14 +887,14 @@ msgstr "Pierwsze kroki w pro&gramie KiCad"
 #: pagelayout_editor/menubar.cpp:208 pcbnew/menubar_pcb_editor.cpp:478
 msgid "Open \"Getting Started in KiCad\" guide for beginners"
 msgstr ""
-"Otwiera przewodnik dla początkujących zatytułowany \"Pierwsze kroki w "
-"programie KiCad\""
+"Otwiera przewodnik \"Pierwsze kroki w programie KiCad\" przeznaczony dla "
+"początkujących"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:331 eeschema/menubar.cpp:646
 #: eeschema/menubar_libedit.cpp:333 gerbview/menubar.cpp:368
 #: pcbnew/menubar_footprint_editor.cpp:500 pcbnew/menubar_pcb_editor.cpp:481
 msgid "&List Hotkeys..."
-msgstr "&Lista skrótów klawiszowych..."
+msgstr "&Lista klawiszy skrótów..."
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:334 eeschema/menubar_libedit.cpp:337
 #: gerbview/menubar.cpp:371 kicad/menubar.cpp:452
@@ -895,7 +908,7 @@ msgstr "Wyświetl bieżące skróty klawiszowe i odpowiadające im polecenia"
 #: pagelayout_editor/menubar.cpp:218 pcbnew/menubar_footprint_editor.cpp:509
 #: pcbnew/menubar_pcb_editor.cpp:490
 msgid "Get &Involved"
-msgstr "Twórcy"
+msgstr "Zostań współtwórcą"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:341 eeschema/menubar.cpp:656
 #: eeschema/menubar_libedit.cpp:343 eeschema/tool_viewlib.cpp:217
@@ -903,7 +916,7 @@ msgstr "Twórcy"
 #: pagelayout_editor/menubar.cpp:219 pcbnew/menubar_footprint_editor.cpp:510
 #: pcbnew/menubar_pcb_editor.cpp:491
 msgid "Contribute to KiCad (opens a web browser)"
-msgstr "Twórcy Kicada (otwiera przeglądarkę internetową)"
+msgstr "Współtworzenie programu KiCad (otwiera przeglądarkę)"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:347 cvpcb/menubar.cpp:103
 #: eeschema/menubar.cpp:662 eeschema/menubar_libedit.cpp:351
@@ -915,7 +928,7 @@ msgstr "O progr&amie KiCad"
 
 #: 3d-viewer/3d_viewer/3d_menubar.cpp:348 pcbnew/menubar_pcb_editor.cpp:498
 msgid "Display KiCad About dialog"
-msgstr "Wyświetla okno z informacjami o programie KiCad"
+msgstr "Wyświetla okno dialogowe z informacjami o programie KiCad"
 
 #: 3d-viewer/3d_viewer/3d_toolbar.cpp:55
 msgid "Reload board"
@@ -927,11 +940,11 @@ msgstr "Kopiuj obraz 3D do schowka"
 
 #: 3d-viewer/3d_viewer/3d_toolbar.cpp:67
 msgid "Set display options, and some layers visibility"
-msgstr "Ustawia opcje wyświetlania i widoczność poszczególnych grup warstw"
+msgstr "Ustawia opcje wyświetlania oraz widoczność warstw"
 
 #: 3d-viewer/3d_viewer/3d_toolbar.cpp:72
 msgid "Render current view using Raytracing"
-msgstr "Renderuj bieżący widok za pomocą Raytracingu"
+msgstr "Renderuj bieżący widok z użyciem raytracingu"
 
 #: 3d-viewer/3d_viewer/3d_toolbar.cpp:77 eeschema/help_common_strings.h:43
 #: eeschema/tool_viewlib.cpp:66 gerbview/menubar.cpp:197
@@ -958,9 +971,8 @@ msgid "Redraw view"
 msgstr "Odśwież widok"
 
 #: 3d-viewer/3d_viewer/3d_toolbar.cpp:87
-#, fuzzy
 msgid "Zoom to fit 3D model"
-msgstr "Powiększ, aby dopasować płytkę do ekranu"
+msgstr "Powiększa by widoczny była cały model 3D"
 
 #: 3d-viewer/3d_viewer/3d_toolbar.cpp:131
 msgid "Enable/Disable orthographic projection"
@@ -984,7 +996,7 @@ msgstr "Pokaż grubość miedzi"
 
 #: 3d-viewer/3d_viewer/dialogs/dialog_3D_view_option_base.cpp:69
 msgid "Show model bounding boxes"
-msgstr "Pokaż ramki ograniczające model"
+msgstr "Pokaż bryły brzegowe modeli"
 
 #: 3d-viewer/3d_viewer/dialogs/dialog_3D_view_option_base.cpp:78
 #: pcbnew/menubar_pcb_editor.cpp:689 pcbnew/tool_pcb_editor.cpp:383
@@ -993,19 +1005,19 @@ msgstr "Pokaż wypełnione obszary w strefach"
 
 #: 3d-viewer/3d_viewer/dialogs/dialog_3D_view_option_base.cpp:95
 msgid "3D model visibility:"
-msgstr "Widoczność modelu 3D:"
+msgstr "Widoczność modeli 3D:"
 
 #: 3d-viewer/3d_viewer/dialogs/dialog_3D_view_option_base.cpp:112
 msgid "Show 3D through hole models"
-msgstr ""
+msgstr "Pokaż modele komponentów przewlekanych"
 
 #: 3d-viewer/3d_viewer/dialogs/dialog_3D_view_option_base.cpp:121
 msgid "Show 3D SMD models"
-msgstr "Pokaż modele 3D SMD"
+msgstr "Pokaż modele komponentów SMD"
 
 #: 3d-viewer/3d_viewer/dialogs/dialog_3D_view_option_base.cpp:130
 msgid "Show 3D virtual models"
-msgstr "Pokaż wirtualne modele 3D"
+msgstr "Pokaż modele 3D komponentów wirtualnych"
 
 #: 3d-viewer/3d_viewer/dialogs/dialog_3D_view_option_base.cpp:148
 msgid "Board layers:"
@@ -1029,7 +1041,7 @@ msgstr "Pokaż warstwy kleju"
 
 #: 3d-viewer/3d_viewer/dialogs/dialog_3D_view_option_base.cpp:201
 msgid "User layers (not shown in realistic mode):"
-msgstr ""
+msgstr "Warstwy użytkownika (nie pokazywane w trybie realistycznym):"
 
 #: 3d-viewer/3d_viewer/dialogs/dialog_3D_view_option_base.cpp:218
 msgid "Show comments and drawings layers"
@@ -1091,7 +1103,7 @@ msgstr "Pomoc (To okno)"
 
 #: 3d-viewer/3d_viewer/hotkeys.cpp:35
 msgid "Center pivot rotation (Middle mouse click)"
-msgstr ""
+msgstr "Obrót środka obrotu wokół osi (Środkowy przycisk myszy)"
 
 #: 3d-viewer/3d_viewer/hotkeys.cpp:36
 msgid "Move board Left"
@@ -1111,7 +1123,7 @@ msgstr "Przesuń płytkę w dół"
 
 #: 3d-viewer/3d_viewer/hotkeys.cpp:40
 msgid "Home view"
-msgstr ""
+msgstr "Widok początkowy"
 
 #: 3d-viewer/3d_viewer/hotkeys.cpp:41
 msgid "Reset view"
@@ -1119,47 +1131,47 @@ msgstr "Resetuj widok"
 
 #: 3d-viewer/3d_viewer/hotkeys.cpp:43
 msgid "View Front"
-msgstr "Widok z przody"
+msgstr "Pokaż stronę górną"
 
 #: 3d-viewer/3d_viewer/hotkeys.cpp:44
 msgid "View Back"
-msgstr "Widok z tyłu"
+msgstr "Pokaż stronę dolną"
 
 #: 3d-viewer/3d_viewer/hotkeys.cpp:45
 msgid "View Left"
-msgstr "Widok z lewej"
+msgstr "Pokaż lewo"
 
 #: 3d-viewer/3d_viewer/hotkeys.cpp:46
 msgid "View Right"
-msgstr "Widok z prawej"
+msgstr "Pokaż prawo"
 
 #: 3d-viewer/3d_viewer/hotkeys.cpp:47
 msgid "View Top"
-msgstr "Widok z góry"
+msgstr "Pokaż górę"
 
 #: 3d-viewer/3d_viewer/hotkeys.cpp:48
 msgid "View Bot"
-msgstr "Widok z dołu"
+msgstr "Pokaż dół"
 
 #: 3d-viewer/3d_viewer/hotkeys.cpp:50
 msgid "Rotate 45 degrees over Z axis"
-msgstr ""
+msgstr "Obróć o 45 stopni w osi X"
 
 #: 3d-viewer/3d_viewer/hotkeys.cpp:51
 msgid "Zoom in "
-msgstr "Powiększ"
+msgstr "Przybliż "
 
 #: 3d-viewer/3d_viewer/hotkeys.cpp:53
 msgid "Toggle 3D models with type Through Hole"
-msgstr ""
+msgstr "Włącz/wyłącz modele 3D z typem Do montażu przewlekanego (THT)"
 
 #: 3d-viewer/3d_viewer/hotkeys.cpp:54
 msgid "Toggle 3D models with type Surface Mount"
-msgstr ""
+msgstr "Włącz/wyłącz modele 3D z typem Do montażu powierzchniowego (SMT)"
 
 #: 3d-viewer/3d_viewer/hotkeys.cpp:55
 msgid "Toggle 3D models with type Virtual"
-msgstr ""
+msgstr "Włącz/wyłącz modele 3D z typem Wirtualny"
 
 #: 3d-viewer/3d_viewer/hotkeys.cpp:57
 msgid "Viewer 3D"
@@ -1173,11 +1185,11 @@ msgstr "Wybierz obraz"
 #: bitmap2component/bitmap2cmp_gui.cpp:271 eeschema/edit_bitmap.cpp:104
 #: pagelayout_editor/pl_editor_frame.cpp:625
 msgid "Image Files "
-msgstr "Pliki obrazów"
+msgstr "Pliki obrazów "
 
 #: bitmap2component/bitmap2cmp_gui.cpp:491
 msgid "Create Logo File"
-msgstr "Utwórz plik LOGO"
+msgstr "Utwórz plik z logotypem"
 
 #: bitmap2component/bitmap2cmp_gui.cpp:509
 #: bitmap2component/bitmap2cmp_gui.cpp:547
@@ -1185,11 +1197,11 @@ msgstr "Utwórz plik LOGO"
 #: bitmap2component/bitmap2cmp_gui.cpp:621
 #, c-format
 msgid "File \"%s\" could not be created."
-msgstr "Nie można utworzyć pliku \"%s\"."
+msgstr "Plik \"%s\" nie może zostać utworzony."
 
 #: bitmap2component/bitmap2cmp_gui.cpp:527
 msgid "Create Postscript File"
-msgstr "Utwórz plik postscriptowy"
+msgstr "Utwórz plik Postsctipt"
 
 #: bitmap2component/bitmap2cmp_gui.cpp:565
 msgid "Create Symbol Library"
@@ -1201,7 +1213,7 @@ msgstr "Utwórz bibliotekę footprintów"
 
 #: bitmap2component/bitmap2cmp_gui.cpp:642
 msgid "Error allocating memory for potrace bitmap"
-msgstr ""
+msgstr "Błąd alokacji w pamięci dla bitmapy potrace"
 
 #: bitmap2component/bitmap2cmp_gui_base.cpp:24
 msgid "Original Picture"
@@ -1300,13 +1312,12 @@ msgid "Format:"
 msgstr "Format:"
 
 #: bitmap2component/bitmap2cmp_gui_base.cpp:136
-#, fuzzy
 msgid "Image Options:"
-msgstr "Opcje obrazu"
+msgstr "Opcje obrazu:"
 
 #: bitmap2component/bitmap2cmp_gui_base.cpp:138
 msgid "Black / White Threshold:"
-msgstr "Prób czerni / bieli:"
+msgstr "Próg przejścia Czarne/Białe:"
 
 #: bitmap2component/bitmap2cmp_gui_base.cpp:143
 msgid ""
@@ -1314,7 +1325,7 @@ msgid ""
 "picture."
 msgstr ""
 "Ustawia poziom odniesienia dla konwersji obrazów w skali szarości na obrazy "
-"czarno-białe"
+"czarno-białe."
 
 #: bitmap2component/bitmap2cmp_gui_base.cpp:147
 #: gerbview/gerber_file_image.cpp:353
@@ -1337,7 +1348,7 @@ msgstr "Warstwa użytkownika ECO1"
 
 #: bitmap2component/bitmap2cmp_gui_base.cpp:153
 msgid "User layer Eco2"
-msgstr "Warstwa użytkownika ECO2"
+msgstr "Użyj warstwy ECO2"
 
 #: bitmap2component/bitmap2cmp_gui_base.cpp:155
 msgid "Board Layer for Outline:"
@@ -1359,7 +1370,7 @@ msgstr "Konwerter map bitowych na symbole"
 
 #: common/base_screen.cpp:188
 msgid "Custom User Grid"
-msgstr "Rozmiar siatki użytkownika"
+msgstr "Siatka użytkownika"
 
 #: common/base_screen.cpp:194
 #, c-format
@@ -1376,11 +1387,15 @@ msgstr "Siatka: %.2f mils (%.4f mm)"
 msgid ""
 "Grid size( %f, %f ) not in grid list, falling back to grid size( %f, %f )."
 msgstr ""
+"Siatka o rozmiarze (%f, %f) nie znajduje się na liście, przywracam rozmiar "
+"siatki na (%f, %f)."
 
 #: common/base_screen.cpp:271
 #, c-format
 msgid "Grid ID %d not in grid list, falling back to grid size( %g, %g )."
 msgstr ""
+"ID siatki %d nie znajduje się na liście, przywracam rozmiar siatki na (%g, "
+"%g)."
 
 #: common/base_units.cpp:162
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:53
@@ -1418,11 +1433,11 @@ msgstr "\""
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:150
 #: pcbnew/dialogs/dialog_position_relative_base.cpp:73
 msgid "deg"
-msgstr "st."
+msgstr "st"
 
 #: common/base_units.cpp:469
 msgid "millimeters"
-msgstr "Milimetry"
+msgstr "milimetry"
 
 #: common/base_units.cpp:473 eeschema/dialogs/dialog_edit_label_base.cpp:56
 #: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:124
@@ -1440,7 +1455,7 @@ msgstr "jednostki"
 #: common/base_units.cpp:477
 #: pcbnew/dialogs/dialog_graphic_item_properties_base.cpp:96
 msgid "degrees"
-msgstr "stopni"
+msgstr "stopnie"
 
 #: common/block_commande.cpp:69
 msgid "Block Move"
@@ -1479,7 +1494,7 @@ msgstr "Wklej blok"
 #: pcbnew/footprint_editor_utils.cpp:941 pcbnew/tool_footprint_editor.cpp:133
 #: pcbnew/tool_pcb_editor.cpp:295
 msgid "Zoom to selection"
-msgstr "Powiększ zazanaczenie"
+msgstr "Przybliż zaznaczenie"
 
 #: common/block_commande.cpp:101
 msgid "Block Rotate"
@@ -1515,7 +1530,7 @@ msgstr "Biały"
 
 #: common/colors.cpp:44
 msgid "L.Yellow"
-msgstr "Jasny zółty"
+msgstr "Jasny Żółty"
 
 #: common/colors.cpp:45
 msgid "Blue 1"
@@ -1527,7 +1542,7 @@ msgstr "Zielony 1"
 
 #: common/colors.cpp:47
 msgid "Cyan 1"
-msgstr "Turkusowy 1"
+msgstr "Lazurowy 1"
 
 #: common/colors.cpp:48
 msgid "Red 1"
@@ -1551,7 +1566,7 @@ msgstr "Zielony 2"
 
 #: common/colors.cpp:53
 msgid "Cyan 2"
-msgstr "Turkusowy 2"
+msgstr "Lazurowy 2"
 
 #: common/colors.cpp:54
 msgid "Red 2"
@@ -1559,7 +1574,7 @@ msgstr "Czerwony 2"
 
 #: common/colors.cpp:55
 msgid "Magenta 2"
-msgstr "Fioletowy 2"
+msgstr "Filoetowy 2"
 
 #: common/colors.cpp:56
 msgid "Brown 2"
@@ -1571,11 +1586,11 @@ msgstr "Niebieski 3"
 
 #: common/colors.cpp:58
 msgid "Green 3"
-msgstr "Zielony 1"
+msgstr "Zielony 3"
 
 #: common/colors.cpp:59
 msgid "Cyan 3"
-msgstr "Turkusowy 3"
+msgstr "Lazurowy 3"
 
 #: common/colors.cpp:60
 msgid "Red 3"
@@ -1599,7 +1614,7 @@ msgstr "Zielony 4"
 
 #: common/colors.cpp:65
 msgid "Cyan 4"
-msgstr "Turkusowy 4"
+msgstr "Lazurowy 4"
 
 #: common/colors.cpp:66
 msgid "Red 4"
@@ -1616,17 +1631,17 @@ msgstr "Żółty 4"
 #: common/common.cpp:295
 #, c-format
 msgid "Cannot make path \"%s\" absolute with respect to \"%s\"."
-msgstr ""
+msgstr "Nie można określić ścieżki \"%s\" jako bezwzględnej wobec \"%s\"."
 
 #: common/common.cpp:313
 #, c-format
 msgid "Output directory \"%s\" created.\n"
-msgstr ""
+msgstr "Folder wyjściowy \"%s\" został utworzony.\n"
 
 #: common/common.cpp:322
 #, c-format
 msgid "Cannot create output directory \"%s\".\n"
-msgstr ""
+msgstr "Nie można utworzyć folderu wyjściowego \"%s\".\n"
 
 #: common/confirm.cpp:125
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:234
@@ -1662,59 +1677,55 @@ msgstr "Potwierdzenie"
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:111
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:153
 msgid "Select All"
-msgstr "Zaznacz wszystko"
+msgstr "Wybierz wszystkie"
 
 #: common/confirm.cpp:306
 msgid "Unselect All"
-msgstr "Odznacz wszystko"
+msgstr "Odznacz wszystkie"
 
 #: common/dialog_about/AboutDialog_main.cpp:118
 msgid ""
 "The KiCad EDA Suite is a set of open source applications for the creation of "
 "electronic schematics and printed circuit boards."
 msgstr ""
-"KiCad EDA Suite jest zespołem aplikacji o otwartym kodzie, służącym do "
-"tworzenia schematów elektronicznych i projektowania płytek drukowanych."
+"KiCad EDA Suite to zestaw otwartoźródłowych narzędzi do tworzenia schematów "
+"elektronicznych i obwodów drukowanych."
 
 #: common/dialog_about/AboutDialog_main.cpp:126
 msgid "KiCad on the web"
 msgstr "KiCad w sieci"
 
 #: common/dialog_about/AboutDialog_main.cpp:132
-#, fuzzy
 msgid "The official KiCad website - "
-msgstr "Oficjalna witryna programu KiCad"
+msgstr "Oficjalna witryna programu KiCad - "
 
 #: common/dialog_about/AboutDialog_main.cpp:136
-#, fuzzy
 msgid "Developer website on Launchpad - "
-msgstr "Witryna deweloperów na platformie Launchpad"
+msgstr "Witryna deweloperów programu na platformie Launchpad - "
 
 #: common/dialog_about/AboutDialog_main.cpp:141
 msgid "Official KiCad library repositories - "
-msgstr ""
+msgstr "Oficjalne repozytoria bibliotek programu KiCad - "
 
 #: common/dialog_about/AboutDialog_main.cpp:148
 msgid "Bug tracker"
-msgstr ""
+msgstr "Bug tracker"
 
 #: common/dialog_about/AboutDialog_main.cpp:154
 msgid "Report or examine bugs - "
-msgstr ""
+msgstr "Raportowanie lub przeglądanie błędów - "
 
 #: common/dialog_about/AboutDialog_main.cpp:161
 msgid "KiCad user's groups and community"
-msgstr "Grupy i społeczność użytkowników KiCad"
+msgstr "Wspólnota użytkowników programu KiCad"
 
 #: common/dialog_about/AboutDialog_main.cpp:166
-#, fuzzy
 msgid "KiCad forum - "
-msgstr "Błąd KiCada"
+msgstr "Forum programu KiCad - "
 
 #: common/dialog_about/AboutDialog_main.cpp:171
-#, fuzzy
 msgid "KiCad user's group - "
-msgstr "Grupy i społeczność użytkowników KiCad"
+msgstr "Wspólnota użytkowników programu KiCad - "
 
 #: common/dialog_about/AboutDialog_main.cpp:185
 msgid "The complete KiCad EDA Suite is released under the"
@@ -1726,23 +1737,23 @@ msgstr "GNU General Public License (GPL) version 3 lub póżniejsze"
 
 #: common/dialog_about/AboutDialog_main.cpp:374
 msgid "Others"
-msgstr "Pozostali"
+msgstr "Pozostałe"
 
 #: common/dialog_about/AboutDialog_main.cpp:393
 msgid "Icons by"
-msgstr "Twórcy ikon"
+msgstr "Ikony"
 
 #: common/dialog_about/AboutDialog_main.cpp:411
 msgid "3D models by"
-msgstr "Twórcy modeli 3D"
+msgstr "Modele 3D"
 
 #: common/dialog_about/AboutDialog_main.cpp:428
 msgid "Symbols by"
-msgstr "Twórcy symboli"
+msgstr "Według symboli"
 
 #: common/dialog_about/AboutDialog_main.cpp:435
 msgid "Footprints by"
-msgstr "Twórcy footprintów"
+msgstr "Według footprintów"
 
 #: common/dialog_about/dialog_about.cpp:124
 msgid "Information"
@@ -1774,7 +1785,7 @@ msgstr "Licencja"
 
 #: common/dialog_about/dialog_about.cpp:592
 msgid "Version Info"
-msgstr "Informacje o wersji"
+msgstr "Informacja o wersji"
 
 #: common/dialog_about/dialog_about.cpp:604
 msgid "Could not open clipboard to write version information."
@@ -1786,7 +1797,7 @@ msgstr "Błąd Schowka"
 
 #: common/dialog_about/dialog_about.cpp:614
 msgid "Copied..."
-msgstr "Kopiuj..."
+msgstr "Skopiowano..."
 
 #: common/dialog_about/dialog_about_base.cpp:31
 msgid "App Title"
@@ -1806,7 +1817,7 @@ msgstr "Informacja o wersji biblioteki"
 
 #: common/dialog_about/dialog_about_base.cpp:67
 msgid "Show Version Info"
-msgstr "Pokaż informacje owersji"
+msgstr "Pokazuje informacje o wersji"
 
 #: common/dialog_about/dialog_about_base.cpp:70
 msgid "Copy Version Info"
@@ -1814,11 +1825,11 @@ msgstr "Kopiuj informacje o wersji"
 
 #: common/dialog_about/dialog_about_base.cpp:71
 msgid "Copy KiCad version info to the clipboard"
-msgstr "Kopiuj informacje o wersji KiCada do schowka"
+msgstr "Kopiuje informacje o wersji programu KiCad do schowka"
 
 #: common/dialog_about/dialog_about_base.h:56
 msgid "About"
-msgstr "&O programie..."
+msgstr "O programie"
 
 #: common/dialogs/dialog_env_var_config.cpp:137
 #: common/dialogs/dialog_env_var_config_base.cpp:107
@@ -1836,18 +1847,20 @@ msgstr "Ścieżka:"
 
 #: common/dialogs/dialog_env_var_config.cpp:207
 msgid "Path already exists."
-msgstr "Ścieżka już istnieje."
+msgstr "Podana ścieżka już istnieje."
 
 #: common/dialogs/dialog_env_var_config.cpp:261
 #, c-format
 msgid "Environment variable \"%s\" cannot be renamed."
-msgstr ""
+msgstr "Nie można zmienić nazwy zmiennej środowiskowej \"%s\"."
 
 #: common/dialogs/dialog_env_var_config.cpp:264
 msgid ""
 "The selected environment variable name is required for KiCad functionality "
 "and can not be renamed."
 msgstr ""
+"Zaznaczona zmienna systemowa jest wymagana do poprawnego działania programu "
+"KiCad i nie może zostać zmieniona."
 
 #: common/dialogs/dialog_env_var_config.cpp:291
 msgid ""
@@ -1857,6 +1870,11 @@ msgid ""
 "over the ones defined in this table.  This means the values in this table "
 "are ignored."
 msgstr ""
+"Wprowadź nazwę oraz wartość dla każdej zmiennej środowiskowej.  Wpisy z "
+"szarym tłem to nazwy jakie zostały zdefiniowane na poziomie systemu lub "
+"profilu użytkownika.  Zmienne środowiskowe zdefiniowane na poziomie "
+"systemowym mają pierwszeństwo przed tymi zdefiniowanymi tutaj.  Oznacza to, "
+"że wartości nadane im w tej tabeli są ignorowane."
 
 #: common/dialogs/dialog_env_var_config.cpp:297
 msgid ""
@@ -1872,25 +1890,26 @@ msgid ""
 "<b>KICAD_SYMBOL_DIR</b> is the base path of the locally installed symbol "
 "libraries."
 msgstr ""
-"<b>KICAD_SYMBOL_DIR</b> jest ścieżką podstawową zainstalowanych lokalnie "
+"<b>KICAD_SYMBOL_DIR</b> zawiera bazową ścieżkę do zainstalowanych w systemie "
 "bibliotek symboli."
 
 #: common/dialogs/dialog_env_var_config.cpp:303
-#, fuzzy
 msgid ""
 "<b>KIGITHUB</b> is used by KiCad to define the URL of the repository of the "
 "official KiCad footprint libraries.  This is only required if the Github "
 "plugin is used to access footprint libraries"
 msgstr ""
-"<b>KIGITHUB</b> jest używany przez KiCad do definiowania adresu URL "
-"repozytorium oficjalnych bibliotek KiCad."
+"<b>KIGITHUB</b> jest używana przez program do określania adresu URL "
+"repozytorium z oficjalnymi bibliotekami footprintów programu KiCad.  Jest "
+"wymagana wyłączne gdy używana jest wtyczka Github przy dostępie do zdalnych "
+"bibliotek"
 
 #: common/dialogs/dialog_env_var_config.cpp:307
 msgid ""
 "<b>KISYS3DMOD</b> is the base path of system footprint 3D shapes (.3Dshapes "
 "folders)."
 msgstr ""
-"<b>KISYS3DMOD</b> zawiera ścieżkę bazową do plików kształtów 3D "
+"<b>KISYS3DMOD</b> zawera ścieżkę bazową do plików kształtów 3D "
 "(foldery .3Dshapes)."
 
 #: common/dialogs/dialog_env_var_config.cpp:310
@@ -1910,32 +1929,33 @@ msgid ""
 "defined as a folder containing a project specific footprint library named "
 "footprints.pretty."
 msgstr ""
-"Zmienna <b>KIPRJMOD</b> jest definiowana automatycznie przez program KiCad "
-"(nie można jej zmieniać) i zawiera absolutną ścieżkę prowadzącą do aktualnie "
-"załadowanego projektu. Zmienna ta może być używana do określania położenia "
-"plików względem obecnie załadowanego projektu. Na przykład, ${KIPRJMOD}/libs/"
-"footprints.pretty może być użyta do określenia położenia biblioteki "
+"<b>KIPRJMOD</b> jest definiowana automatycznie przez program KiCad (nie "
+"można jej zmieniać) i zawiera absolutną ścieżkę prowadzącą do aktualnie "
+"załadowanego projektu.  Zmienna ta może być używana do określania położenia "
+"plików względem obecnie załadowanego projektu.  Na przykład, ${KIPRJMOD}/"
+"libs/footprints.pretty może być użyta do określenia położenia biblioteki "
 "'footprints.pretty' będącej częścią danego projektu, zawierającą jego "
 "specyficzne definicje footprintów."
 
 #: common/dialogs/dialog_env_var_config.cpp:319
-#, fuzzy
 msgid ""
 "<b>KICAD_TEMPLATE_DIR</b> is required and is the path containing the project "
 "templates installed with KiCad."
 msgstr ""
-"<b>KICAD_SYMBOL_DIR</b> jest ścieżką podstawową zainstalowanych lokalnie "
-"bibliotek symboli."
+"<b>KICAD_TEMPLATE_DIR</b> jest wymagana i zawiera ścieżkę dostępu do "
+"szablonów projektów instalowanych razem z programem KiCad."
 
 #: common/dialogs/dialog_env_var_config.cpp:322
 msgid ""
 "<b>KICAD_USER_TEMPLATE_DIR</b> is required and is the path containing any "
 "user specific project templates."
 msgstr ""
+"<b>KICAD_USER_TEMPLATE_DIR</b> jest wymagana i zawiera ścieżkę do szablonów "
+"projektów użytkownika."
 
 #: common/dialogs/dialog_env_var_config.cpp:432
 msgid "Select Path for Environment Variable"
-msgstr ""
+msgstr "Wybierz ścieżkę dla zmiennej środowiskowej"
 
 #: common/dialogs/dialog_env_var_config.cpp:465
 msgid "Environment variable name cannot be empty."
@@ -1947,7 +1967,7 @@ msgstr "Zawartość zmiennej środowiskowej nie może być pusta."
 
 #: common/dialogs/dialog_env_var_config.cpp:480
 msgid "Environment variable names cannot start with a digit (0-9)."
-msgstr ""
+msgstr "Nazwa zmiennej środowiskowej nie może rozpoczynać się od liczby (0-9)."
 
 #: common/dialogs/dialog_env_var_config.cpp:492
 msgid ""
@@ -1960,6 +1980,15 @@ msgid ""
 "allowed in environment variable names and the environment variable name "
 "cannot start with a digit (0-9)."
 msgstr ""
+"Zmienne systemowe są używane w zastępstwie ciągów znaków.<br>Zmienne "
+"systemowe są używane głównie w przypadku ścieżek dostępu, tak by program "
+"KiCad był przenośny pomiędzy platformami.<br><br>Jeśli zmienna systemowa "
+"została zdefiniowana jako <b>MYLIBPATH</b> z wartością <b>e:/kicad_libs</b>, "
+"wtedy nazwa biblioteki <b>${MYLIBPATH}/mylib.lib</b> zostaje rozszerzana na "
+"ciąg <b>e:/kicad_libs/mylib.lib</b><br><br><b>Uwaga!</b><br>Tylko znaki z "
+"zestawu <i>ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_</i> są dopuszczalne w "
+"nazwie zmiennej, przy czym zmienna ta nie może rozpoczynać się od liczby "
+"(0-9)."
 
 #: common/dialogs/dialog_env_var_config_base.cpp:28
 #: cvpcb/dialogs/dialog_config_equfiles_base.cpp:36
@@ -1973,7 +2002,7 @@ msgstr "Dodaj"
 
 #: common/dialogs/dialog_env_var_config_base.cpp:29
 msgid "Add path prefix"
-msgstr "Dodaj prefiks ścieżki"
+msgstr "Dodaje prefiks ścieżki"
 
 #: common/dialogs/dialog_env_var_config_base.cpp:33
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:186
@@ -1987,7 +2016,7 @@ msgstr "Edytuj"
 
 #: common/dialogs/dialog_env_var_config_base.cpp:34
 msgid "Edit selected path prefix"
-msgstr "Edytuj zaznaczony prefiks ścieżki"
+msgstr "Edytuje wybrany prefiks ścieżki"
 
 #: common/dialogs/dialog_env_var_config_base.cpp:38
 #: cvpcb/dialogs/dialog_config_equfiles_base.cpp:39
@@ -1998,7 +2027,7 @@ msgstr "Usuń"
 
 #: common/dialogs/dialog_env_var_config_base.cpp:39
 msgid "Remove selected path prefix"
-msgstr "Usuń zaznaczony prefiks ścieżki"
+msgstr "Usuwa wybrany prefiks ścieżki"
 
 #: common/dialogs/dialog_env_var_config_base.cpp:114
 #: eeschema/dialogs/dialog_bom_base.cpp:65
@@ -2026,11 +2055,11 @@ msgstr "Przeglądaj"
 
 #: common/dialogs/dialog_env_var_config_base.h:65
 msgid "Environment Variable Configuration"
-msgstr ""
+msgstr "Konfiguracja zmiennych środowiskowych"
 
 #: common/dialogs/dialog_env_var_config_base.h:97
 msgid "Edit Environment Variable"
-msgstr ""
+msgstr "Edycja zmiennej środowiskowej"
 
 #: common/dialogs/dialog_exit_base.cpp:34
 msgid "Save the changes before closing?"
@@ -2053,7 +2082,7 @@ msgstr "Wyjście bez zapisania danych"
 #: common/dialogs/dialog_hotkeys_editor_base.cpp:18
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:275
 msgid "Double-click to edit"
-msgstr "Kliknij dwukrotnie aby edytować"
+msgstr "Kliknij dwukrotnie by edytować"
 
 #: common/dialogs/dialog_hotkeys_editor_base.cpp:30
 #: gerbview/dialogs/dialog_layers_select_to_pcb_base.cpp:109
@@ -2068,7 +2097,7 @@ msgstr "Resetuj"
 
 #: common/dialogs/dialog_hotkeys_editor_base.cpp:33
 msgid "Defaults"
-msgstr "Domyślnie"
+msgstr "Domyślne"
 
 #: common/dialogs/dialog_hotkeys_editor_base.h:53
 msgid "Hotkeys Editor"
@@ -2131,7 +2160,7 @@ msgid ""
 "Only names containing this string will be listed"
 msgstr ""
 "Wpisz ciąg by odfiltrować elementy.\n"
-"Tylko nazwy zawierające ten ciąg zostaną wyświetlone na liście."
+"Tylko nazwy zawierające ten ciąg zostaną wyświetlone na liście"
 
 #: common/dialogs/dialog_list_selector_base.cpp:28
 msgid "Items:"
@@ -2210,7 +2239,7 @@ msgstr "Pionowo"
 #: common/dialogs/dialog_page_settings.cpp:435
 #, c-format
 msgid "Page layout description file \"%s\" not found. Abort"
-msgstr ""
+msgstr "Plik z definicją strony \"%s\" nie został znaleziony. Przerwano"
 
 #: common/dialogs/dialog_page_settings.cpp:466
 #, c-format
@@ -2231,7 +2260,7 @@ msgstr "Ostrzeżenie!"
 
 #: common/dialogs/dialog_page_settings.cpp:532
 msgid "the translation for paper size must preserve original spellings"
-msgstr ""
+msgstr "tłumaczenie rozmiaru papieru musi zachować oryginalne znaczenie"
 
 #: common/dialogs/dialog_page_settings.cpp:722
 #: common/dialogs/dialog_page_settings_base.cpp:46
@@ -2240,10 +2269,10 @@ msgstr "Poziomo"
 
 #: common/dialogs/dialog_page_settings.cpp:822
 msgid "Select Page Layout Description File"
-msgstr ""
+msgstr "Wybiera plik z obrysem strony"
 
 #: common/dialogs/dialog_page_settings.cpp:839
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "The page layout description file name has changed.\n"
 "Do you want to use the relative path:\n"
@@ -2251,11 +2280,11 @@ msgid ""
 "instead of\n"
 "\"%s\"?"
 msgstr ""
-"Nazwa pliku układu strony została zmieniona.\n"
+"Nastąpiła zmiana nazwy pliku z definicją obramowania strony.\n"
 "Czy chcesz użyć ścieżki względnej:\n"
-"'%s'\n"
+"\"%s\"\n"
 "zamiast\n"
-"'%s'"
+"\"%s\"?"
 
 #: common/dialogs/dialog_page_settings_base.cpp:25
 msgid "Paper"
@@ -2376,24 +2405,23 @@ msgid "Page Settings"
 msgstr "Ustawienia strony"
 
 #: common/dialogs/dialog_text_entry_base.cpp:22
-#, fuzzy
 msgid "MyLabel"
-msgstr "Etykieta"
+msgstr "MojaEtykieta"
 
 #: common/dialogs/wx_html_report_panel.cpp:255
 #: common/dialogs/wx_html_report_panel.cpp:282
 msgid "Error: "
-msgstr "Błąd:"
+msgstr "Błąd: "
 
 #: common/dialogs/wx_html_report_panel.cpp:259
 #: common/dialogs/wx_html_report_panel.cpp:284
 msgid "Warning: "
-msgstr "Ostrzeżenie:"
+msgstr "Ostrzeżenie: "
 
 #: common/dialogs/wx_html_report_panel.cpp:263
 #: common/dialogs/wx_html_report_panel.cpp:286
 msgid "Info: "
-msgstr "Informacja:"
+msgstr "Informacja: "
 
 #: common/dialogs/wx_html_report_panel.cpp:387
 msgid "Save Report to File"
@@ -2402,7 +2430,7 @@ msgstr "Zapisz raport do pliku"
 #: common/dialogs/wx_html_report_panel.cpp:404
 #, c-format
 msgid "Cannot write report to file \"%s\"."
-msgstr "Nie można zapisać raportu do pliku '%s'."
+msgstr "Nie można zapisać pliku raportu \"%s\"."
 
 #: common/dialogs/wx_html_report_panel.cpp:406
 msgid "File save error"
@@ -2414,7 +2442,7 @@ msgstr "Komunikaty wyjściowe:"
 
 #: common/dialogs/wx_html_report_panel_base.cpp:34
 msgid "Show:"
-msgstr "Pokaż"
+msgstr "Pokaż:"
 
 #: common/dialogs/wx_html_report_panel_base.cpp:38
 #: eeschema/lib_draw_item.cpp:66 eeschema/lib_draw_item.cpp:73
@@ -2440,7 +2468,7 @@ msgstr "Akcje"
 
 #: common/dialogs/wx_html_report_panel_base.cpp:60
 msgid "Save Report File"
-msgstr "Zapisuje raport do pliku"
+msgstr "Zapisz plik raportu"
 
 #: common/draw_frame.cpp:197 common/draw_frame.cpp:565
 #: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:30
@@ -2450,7 +2478,7 @@ msgstr "Zapisuje raport do pliku"
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:116
 #: pcbnew/dialogs/dialog_modedit_options_base.cpp:97
 msgid "Inches"
-msgstr "cale"
+msgstr "Cale"
 
 #: common/draw_frame.cpp:407 cvpcb/display_footprints_frame.cpp:174
 #: pcbnew/tool_footprint_editor.cpp:215 pcbnew/tool_pcb_editor.cpp:354
@@ -2473,12 +2501,12 @@ msgstr "schowek"
 #: common/dsnlexer.cpp:356 common/dsnlexer.cpp:364
 #, c-format
 msgid "Expecting \"%s\""
-msgstr "Spodziewano się '%s'"
+msgstr "Spodziewano się \"%s\""
 
 #: common/dsnlexer.cpp:372 common/dsnlexer.cpp:388
 #, c-format
 msgid "Unexpected \"%s\""
-msgstr "Niespodziewano się '%s'"
+msgstr "Nie spodziewano się \"%s\""
 
 #: common/dsnlexer.cpp:380
 #, c-format
@@ -2488,7 +2516,7 @@ msgstr "%s jest duplikatem"
 #: common/dsnlexer.cpp:433
 #, c-format
 msgid "need a NUMBER for \"%s\""
-msgstr "potrzebny NUMER dla '%s'"
+msgstr "potrzebny NUMBER dla \"%s\""
 
 #: common/dsnlexer.cpp:705 common/dsnlexer.cpp:765
 msgid "Un-terminated delimited string"
@@ -2511,15 +2539,15 @@ msgid ""
 " or\n"
 "\"%s\" could not be found."
 msgstr ""
-"Plik pomocy html lub pdf \n"
-"'%s'\n"
-"lub\n"
-"'%s' nie może zostać odnaleziony."
+"Plik pomocy w formacie HTML lub PDF\n"
+"\"%s\"\n"
+" lub\n"
+"\"%s\" nie został znaleziony."
 
 #: common/eda_base_frame.cpp:498
 #, c-format
 msgid "Help file \"%s\" could not be found."
-msgstr "Nie można odnaleźć pliku pomocy \"%s\"."
+msgstr "Plik pomocy \"%s\" nie został odnaleziony."
 
 #: common/eda_base_frame.cpp:532
 #, c-format
@@ -2527,25 +2555,28 @@ msgid ""
 "Could not launch the default browser.\n"
 "For information on how to help the KiCad project, visit %s"
 msgstr ""
+"Nie można uruchomić domyślnej przeglądarki.\n"
+"Informacje jak wspomóc proces tworzenia programu KiCad, przejdź do %s"
 
 #: common/eda_base_frame.cpp:535
 msgid "Get involved with KiCad"
-msgstr "Zaangażuj się w tworzenie KiCada"
+msgstr "Zostań współtwórcą programu KiCad"
 
 #: common/eda_base_frame.cpp:567
 #, c-format
 msgid "You do not have write permissions to folder \"%s\"."
-msgstr ""
+msgstr "Nie masz wystarczających uprawnień by zapisywać w folderze \"%s\"."
 
 #: common/eda_base_frame.cpp:572
 #, c-format
 msgid "You do not have write permissions to save file \"%s\" to folder \"%s\"."
 msgstr ""
+"Nie masz wystarczających uprawnień by zapisać plik \"%s\" w folderze \"%s\"."
 
 #: common/eda_base_frame.cpp:577
 #, c-format
 msgid "You do not have write permissions to save file \"%s\"."
-msgstr ""
+msgstr "Nie masz wystarczających uprawnień by zapisać plik \"%s\"."
 
 #: common/eda_base_frame.cpp:609
 #, c-format
@@ -2556,11 +2587,16 @@ msgid ""
 "it was not saved properly.  Do you wish to restore the last saved edits you "
 "made?"
 msgstr ""
+"Sytuacja potencjalnie niebezpieczna!\n"
+"Wygląda na to, że ostatnie zmiany w pliku\n"
+"\"%s\"\n"
+"nie zostały zapisane poprawnie.  Czy chcesz przywrócić ostatnie zapisane "
+"zmiany?"
 
 #: common/eda_base_frame.cpp:637
 #, c-format
 msgid "Could not create backup file \"%s\""
-msgstr ""
+msgstr "Nie można utworzyć pliku kopii zapasowej \"%s\""
 
 #: common/eda_base_frame.cpp:645
 msgid "The auto save file could not be renamed to the board file name."
@@ -2577,7 +2613,7 @@ msgstr "Opcje ikon"
 
 #: common/eda_base_frame.cpp:704
 msgid "Select show icons in menus and icons sizes"
-msgstr ""
+msgstr "Wybiera sposób pokazywania ikon w menu i ich rozmiar"
 
 #: common/eda_doc.cpp:148 eeschema/dialogs/dialog_edit_component_in_lib.cpp:467
 msgid "Doc Files"
@@ -2586,12 +2622,12 @@ msgstr "Pliki dokumentacji"
 #: common/eda_doc.cpp:163
 #, c-format
 msgid "Doc File \"%s\" not found"
-msgstr "Nie znaleziono pliku dokumentacji \"%s\""
+msgstr "Plik z dokumentacją \"%s\" nie został znaleziony"
 
 #: common/eda_doc.cpp:206
 #, c-format
 msgid "Unknown MIME type for doc file \"%s\""
-msgstr ""
+msgstr "Nieznany typ MIME dla pliku dokumentacji \"%s\""
 
 #: common/eda_graphic_text_ctrl.cpp:61
 #, c-format
@@ -2654,7 +2690,7 @@ msgstr "Pogrubiona kursywa"
 #: common/exceptions.cpp:29
 #, c-format
 msgid "from %s : %s() line:%d"
-msgstr ""
+msgstr "z %s : %s() linia:%d"
 
 #: common/exceptions.cpp:30
 #, c-format
@@ -2663,6 +2699,9 @@ msgid ""
 "\"%s\"\n"
 "line %d, offset %d"
 msgstr ""
+"%s w wejściu/źródle\n"
+"\"%s\"\n"
+"linia %d, przesunięcie %d"
 
 #: common/exceptions.cpp:104
 #, c-format
@@ -2676,6 +2715,14 @@ msgid ""
 "Full error text:\n"
 "%s"
 msgstr ""
+"KiCad nie potrafił otworzyć tego pliku, ponieważ został utworzony\n"
+"w nowszej wersji programu niż ta, która została uruchomiona.\n"
+"By otworzyć ten plik, potrzebna jest nowsza wersja programu KiCad.\n"
+"\n"
+"Wymagana wersja (lub nowsza) programu KiCad: %s\n"
+"\n"
+"Pełna treść błędu:\n"
+"%s"
 
 #: common/footprint_info.cpp:91 cvpcb/cvpcb_mainframe.cpp:801
 msgid "Load Error"
@@ -2683,7 +2730,7 @@ msgstr "Błąd wczytywania"
 
 #: common/footprint_info.cpp:93
 msgid "Errors were encountered loading footprints:"
-msgstr ""
+msgstr "Wystąpiły błędy podczas ładowania footprintów:"
 
 #: common/fp_lib_table.cpp:195
 #, c-format
@@ -2691,23 +2738,25 @@ msgid ""
 "Duplicate library nickname \"%s\" found in footprint library table file line "
 "%d"
 msgstr ""
+"Została znaleziona zduplikowana nazwa skrócona \"%s\" w tabeli bibliotek "
+"footprintów w linii %d"
 
 #: common/fp_lib_table.cpp:286
 #, c-format
 msgid "fp-lib-table files contain no library with nickname \"%s\""
-msgstr ""
+msgstr "pliki fp-lib-table nie zawierają biblioteki o nazwie skrótowej \"%s\""
 
 #: common/fp_lib_table.cpp:462
 #: eeschema/dialogs/dialog_global_sym_lib_table_config.cpp:138
 #: eeschema/symbol_lib_table.cpp:486
 #, c-format
 msgid "Cannot create global library table path \"%s\"."
-msgstr ""
+msgstr "Nie można utworzyć globalnej tabeli bibliotek w ścieżce \"%s\"."
 
 #: common/gestfich.cpp:233
 #, c-format
 msgid "Command \"%s\" could not found"
-msgstr ""
+msgstr "Polecenie \"%s\" nie zostało odnalezione"
 
 #: common/gestfich.cpp:377
 #, c-format
@@ -2715,11 +2764,13 @@ msgid ""
 "Problem while running the PDF viewer\n"
 "Command is \"%s\""
 msgstr ""
+"Wystąpił problem przy uruchomieniu przeglądarki PDF\n"
+"Polecenie: \"%s\""
 
 #: common/gestfich.cpp:384
 #, c-format
 msgid "Unable to find a PDF viewer for \"%s\""
-msgstr ""
+msgstr "Nie można odnaleźć przeglądarki PDF dla \"%s\""
 
 #: common/grid_tricks.cpp:176
 msgid "Cut\tCTRL+X"
@@ -2767,27 +2818,28 @@ msgstr "Zapisz plik konfiguracji klawiszy skrótów:"
 
 #: common/hotkeys_basic.cpp:816
 msgid "&Edit Hotkeys..."
-msgstr "&Edytuj skróty klawiszowe..."
+msgstr "&Edytuj plik konfiguracji klawiszy skrótów..."
 
 #: common/hotkeys_basic.cpp:817
 msgid "Edit hotkeys list"
-msgstr "Edytuj listę skrótów klawiszowych"
+msgstr "Edycja listy skrótów klawiszowych"
 
 #: common/hotkeys_basic.cpp:824 eeschema/menubar.cpp:708
 msgid "E&xport Hotkeys..."
-msgstr "Eksportuj skróty klawiszowe..."
+msgstr "Eksportuj plik konfiguracji klawiszy skrótów..."
 
 #: common/hotkeys_basic.cpp:825 eeschema/menubar.cpp:709
 msgid "Export current hotkeys into configuration file"
-msgstr "Wyeksportuj bieżące skróty klawiszowe do pliku konfiguracyjnego"
+msgstr ""
+"Eksportuje bieżący zestaw skrótów klawiszowych do pliku konfiguracyjnego"
 
 #: common/hotkeys_basic.cpp:830 eeschema/menubar.cpp:714
 msgid "&Import Hotkeys..."
-msgstr "&Importuj skróty klawiszowe..."
+msgstr "&Importuj konfigurację skrótów klawiszowych..."
 
 #: common/hotkeys_basic.cpp:831 eeschema/menubar.cpp:715
 msgid "Load existing hotkey configuration file"
-msgstr "Wczytaj istniejący plik konfiguracyjny skrótów klawiszowych"
+msgstr "Wczytuje istniejący plik konfiguracji skrótów klawiszowych"
 
 #: common/hotkeys_basic.cpp:836 eeschema/menubar.cpp:719
 msgid "&Hotkeys Options"
@@ -2795,18 +2847,19 @@ msgstr "Opcje skrótów klawiszowych"
 
 #: common/hotkeys_basic.cpp:837 eeschema/menubar.cpp:720
 msgid "Edit hotkeys configuration and preferences"
-msgstr "Edytuj konfigurację skrótów klawiszowych i preferencji"
+msgstr "Modyfikuje konfigurację skrótów klawiszowych oraz preferencje"
 
 #: common/kiway.cpp:184
 #, c-format
 msgid "Failed to load kiface library \"%s\"."
-msgstr "Nie udało się załadować kiface biblioteki \"%s\"."
+msgstr "Nie można załadować biblioteki KIFACE \"%s\"."
 
 #: common/kiway.cpp:193
 #, c-format
 msgid ""
 "Could not read instance name and version symbol form kiface library \"%s\"."
 msgstr ""
+"Nie można odczytać instancji oraz wersji symbolu z biblioteki KIFACE \"%s\"."
 
 #: common/kiway.cpp:227
 #, c-format
@@ -2815,24 +2868,29 @@ msgid ""
 "\"%s\"\n"
 "could not be loaded\n"
 msgstr ""
+"Fatalny błąd instalacji. Plik\n"
+"\"%s\"\n"
+"nie mógł być załadowany\n"
 
 #: common/kiway.cpp:231
 msgid "It is missing.\n"
-msgstr "Brakujące.\n"
+msgstr "Brakuje.\n"
 
 #: common/kiway.cpp:233
 msgid "Perhaps a shared library (.dll or .so) file is missing.\n"
-msgstr "Być może brakuje pliku następującej biblioteki (*.dll lub *.so).\n"
+msgstr "Prawdopodobnie brakuje biblioteki (.dll lub .so).\n"
 
 #: common/kiway.cpp:235
 msgid ""
 "From command line: argv[0]:\n"
 "'"
 msgstr ""
+"Z linii poleceń: argv[0]:\n"
+"'"
 
 #: common/lib_id.cpp:184 common/lib_id.cpp:201
 msgid "Illegal character found in LIB_ID string"
-msgstr ""
+msgstr "Znaleziono niewłaściwy znak w ciągu LIB_ID"
 
 #: common/lib_id.cpp:310
 msgid "Illegal character found in logical library name"
@@ -2945,11 +3003,11 @@ msgstr "Litewski"
 
 #: common/pgm_base.cpp:359
 msgid "No default editor found, you must choose it"
-msgstr "Nie znaleziono domyślnego edytora. Musisz go wybrać."
+msgstr "Nie znaleziono domyślnego edytora. Musisz go wybrać"
 
 #: common/pgm_base.cpp:379
 msgid "Executable file (*.exe)|*.exe"
-msgstr "Plik wykonywalny (*.exe) |*.exe"
+msgstr "Plik wykonywalny (*.exe)|*.exe"
 
 #: common/pgm_base.cpp:381
 msgid "Executable file (*)|*"
@@ -2962,15 +3020,15 @@ msgstr "Wybierz preferowany edytor"
 #: common/pgm_base.cpp:412
 #, c-format
 msgid "%s is already running. Continue?"
-msgstr "%s jest uruchomiony. Kontynuować?"
+msgstr "%s jest już uruchomiony. Kontynuować?"
 
 #: common/pgm_base.cpp:923
 msgid "Set Language"
-msgstr "Wybór języka "
+msgstr "Ustaw język"
 
 #: common/pgm_base.cpp:924
 msgid "Select application language (only for testing)"
-msgstr "Wybierz język aplikacji (tylko do testowania)"
+msgstr "Wybiera język aplikacji (tylko dla testów)"
 
 #: common/pgm_base.cpp:999
 msgid ""
@@ -2990,7 +3048,7 @@ msgid ""
 msgstr ""
 "Przy następnym uruchomieniu programu KiCad, wszelkie ścieżki,\n"
 "które będą już zdefiniowane są honorowane i ich ustawienia w oknie\n"
-"dialogowym ustawień ścieżek są ignorowane.\n"
+" dialogowym ustawień ścieżek są ignorowane.\n"
 "Jeśli nowe ustawienia mają zastąpić ustawienia pochodzące z zewnątrz,\n"
 "należy zmienić nazwy zmiennych systemowych będących w konflikcie\n"
 "lub usunąć je z systemu."
@@ -3002,25 +3060,26 @@ msgstr "Nie pokazuj tej wiadomości ponownie."
 #: common/project.cpp:258
 #, c-format
 msgid "Unable to find \"%s\" template config file."
-msgstr ""
+msgstr "Nie można znaleźć pliku konfiguracji \"%s\" szablonu."
 
 #: common/project.cpp:261
 msgid "Error copying project file template"
-msgstr ""
+msgstr "Błąd podczas kopiowania pliku projektu szablonu"
 
 #: common/project.cpp:282
 #, c-format
 msgid "Cannot create prj file \"%s\" (Directory not writable)"
 msgstr ""
+"Nie można utworzyć pliku prj \"%s\" (Folder zabezpieczony przed zapisem)"
 
 #: common/project.cpp:428
 msgid "Error loading project footprint library table"
-msgstr ""
+msgstr "Błąd podczas wczytywania tabeli bibliotek projektu"
 
-#: common/richio.cpp:167 tools/io_benchmark/stdstream_line_reader.cpp:76
+#: common/richio.cpp:167
 #, c-format
 msgid "Unable to open filename \"%s\" for reading"
-msgstr ""
+msgstr "Nie można otworzyć nazwy \"%s\" dla odczytu"
 
 #: common/richio.cpp:201 common/richio.cpp:296
 msgid "Maximum line length exceeded"
@@ -3033,12 +3092,12 @@ msgstr "Przekroczona długość linii"
 #: common/richio.cpp:527
 #, c-format
 msgid "cannot open or save file \"%s\""
-msgstr "nie mogę otworzyć lub zapisać pliku \"%s\""
+msgstr "nie można otworzyć lub zapisać pliku \"%s\""
 
 #: common/richio.cpp:546
 #, c-format
 msgid "error writing to file \"%s\""
-msgstr ""
+msgstr "błąd zapisu pliku \"%s\""
 
 #: common/richio.cpp:567
 msgid "OUTPUTSTREAM_OUTPUTFORMATTER write error"
@@ -3093,15 +3152,17 @@ msgstr "Dopasuj powiększenie"
 #: pagelayout_editor/menubar.cpp:134 pcbnew/hotkeys.cpp:225
 #: pcbnew/menubar_footprint_editor.cpp:231 pcbnew/menubar_pcb_editor.cpp:626
 msgid "Zoom to Selection"
-msgstr ""
+msgstr "Przybliż zaznaczenie"
 
 #: common/tool/common_tools.cpp:39
 msgid "Toggle Always Show Cursor"
-msgstr ""
+msgstr "Przełącza tryb widoczności kursora"
 
 #: common/tool/common_tools.cpp:40
 msgid "Toggle display of the cursor, even when not in an interactive tool"
 msgstr ""
+"Przełącza wyświetlanie kursora, nawet jeśli nie jest on w trybie narzędzia "
+"interaktywnego"
 
 #: common/tool/grid_menu.cpp:40 common/zoom.cpp:315
 #: eeschema/widgets/widget_eeschema_color_config.cpp:93
@@ -3111,7 +3172,7 @@ msgstr "Siatka"
 
 #: common/tool/zoom_menu.cpp:39 common/zoom.cpp:291
 msgid "Zoom"
-msgstr "Powiększenie "
+msgstr "Powiększenie"
 
 #: common/tool/zoom_menu.cpp:49
 #, c-format
@@ -3120,16 +3181,16 @@ msgstr "Powiększenie: %.2f"
 
 #: common/view/view.cpp:553
 msgid "Mirroring for Y axis is not supported yet"
-msgstr "Odbicie lustrzane dla osi Y nie jest jeszcze obsługiwane"
+msgstr "Obrót wokół osi Y nie jest obecnie wspierany"
 
 #: common/widgets/footprint_preview_widget.cpp:96
 msgid "Footprint not found"
-msgstr "Nie znaleziono footprintu"
+msgstr "Footprint nie został znaleziony"
 
 #: common/widgets/footprint_select_widget.cpp:78 cvpcb/cvpcb_mainframe.cpp:750
 #: pcbnew/load_select_footprint.cpp:213
 msgid "Loading Footprint Libraries"
-msgstr "Wczytywanie bibliotek footprintów"
+msgstr "Ładowanie bibliotek footprintów"
 
 #: common/widgets/footprint_select_widget.cpp:230
 msgid "No default footprint"
@@ -3138,35 +3199,35 @@ msgstr "Brak domyślnego footprintu"
 #: common/widgets/footprint_select_widget.cpp:235
 #: common/widgets/footprint_select_widget.cpp:236
 msgid "Other..."
-msgstr "Pozostałe..."
+msgstr "Inne..."
 
 #: common/widgets/gal_options_panel.cpp:75
 msgid " (not supported in Legacy Toolset)"
-msgstr "(nieobsługiwane w starszym zestawie narzędzi)"
+msgstr " (nie wspierane w zestawie narzędzi Legacy)"
 
 #: common/widgets/gal_options_panel.cpp:83
 msgid "Accelerated Graphics:"
-msgstr "Akceleracja grafiki:"
+msgstr "Przyśpieszana Grafika:"
 
 #: common/widgets/gal_options_panel.cpp:86
 msgid "No Antialiasing"
-msgstr "Bez Antylasingu"
+msgstr "Bez anty-aliasingu"
 
 #: common/widgets/gal_options_panel.cpp:87
 msgid "Subpixel Antialiasing (High Quality)"
-msgstr "Subpixel Antialiasing (Wysoka jakość)"
+msgstr "Anty-aliasing sub-pikseli (Wysoka jakość)"
 
 #: common/widgets/gal_options_panel.cpp:88
 msgid "Subpixel Antialiasing (Ultra Quality)"
-msgstr "Subpixel Antialiasing (Ultra jakość)"
+msgstr "Anty-aliasing sub-pikseli (Bardzo wysoka jakość)"
 
 #: common/widgets/gal_options_panel.cpp:89
 msgid "Supersampling (2x)"
-msgstr "Supersampling (2x)"
+msgstr "Nadpróbkowywanie (2x)"
 
 #: common/widgets/gal_options_panel.cpp:90
 msgid "Supersampling (4x)"
-msgstr "Supersampling (4x)"
+msgstr "Nadpróbkowywanie (4x)"
 
 #: common/widgets/gal_options_panel.cpp:107
 msgid "Grid Options"
@@ -3174,7 +3235,7 @@ msgstr "Opcje siatki"
 
 #: common/widgets/gal_options_panel.cpp:110
 msgid "Dots"
-msgstr "Punkty"
+msgstr "Kropki"
 
 #: common/widgets/gal_options_panel.cpp:111
 #: pcbnew/autorouter/auto_place_footprints.cpp:476
@@ -3183,7 +3244,7 @@ msgstr "Linie"
 
 #: common/widgets/gal_options_panel.cpp:112
 msgid "Small crosses"
-msgstr "Mały krzyż"
+msgstr "Krzyżyki"
 
 #: common/widgets/gal_options_panel.cpp:116
 msgid "Grid style:"
@@ -3191,16 +3252,16 @@ msgstr "Styl siatki:"
 
 #: common/widgets/gal_options_panel.cpp:128
 msgid "Grid thickness:"
-msgstr "Grubość linii siatki:"
+msgstr "Grubość siatki:"
 
 #: common/widgets/gal_options_panel.cpp:140
 #: common/widgets/gal_options_panel.cpp:157
 msgid "px"
-msgstr "pixeli"
+msgstr "px"
 
 #: common/widgets/gal_options_panel.cpp:145
 msgid "Min grid spacing:"
-msgstr "Minimalny rozmiar siatki:"
+msgstr "Minimalny odstęp siatki:"
 
 #: common/widgets/gal_options_panel.cpp:182
 msgid "Cursor Options"
@@ -3208,11 +3269,11 @@ msgstr "Opcje kursora"
 
 #: common/widgets/gal_options_panel.cpp:196
 msgid "Small crosshair"
-msgstr "Mały krzyż"
+msgstr "Mały krzyżyk"
 
 #: common/widgets/gal_options_panel.cpp:197
 msgid "Full window crosshair"
-msgstr "Pełnoekranowy krzyż"
+msgstr "Kursor pełnoekranowy"
 
 #: common/widgets/gal_options_panel.cpp:200
 msgid "Cursor shape:"
@@ -3220,19 +3281,19 @@ msgstr "Kształt kursora:"
 
 #: common/widgets/gal_options_panel.cpp:208
 msgid "Cursor shape for drawing, placement and movement tools"
-msgstr ""
+msgstr "Kształt kursora przy narzędziach rysowania, wstawiania i przesuwania"
 
 #: common/widgets/gal_options_panel.cpp:214
 msgid "Always display crosshairs"
-msgstr "Zawsze wyświetlaj krzyżyk przy kursorze"
+msgstr "Zawsze pokazuj nitki celownicze"
 
 #: common/widgets/gal_options_panel.cpp:219
 msgid "Always display crosshairs (not in Legacy)"
-msgstr "Wyświetla krzyżyk przy kursorze (niedostępne w starszej wersji)"
+msgstr "Zawsze pokazuj nitki celownicze (nie w trybie Legacy)"
 
 #: common/widgets/mathplot.cpp:1765
 msgid "Center plot view to this position"
-msgstr ""
+msgstr "Wycentruj widok wykresu na tej pozycji"
 
 #: common/widgets/mathplot.cpp:1766 eeschema/hotkeys.cpp:87
 #: eeschema/sim/sim_plot_frame_base.cpp:85
@@ -3241,19 +3302,19 @@ msgstr "Dopasuj do ekranu"
 
 #: common/widgets/mathplot.cpp:1766
 msgid "Set plot view to show all items"
-msgstr ""
+msgstr "Dopasowuje wykres by pokazać wszystkie elementy"
 
 #: common/widgets/mathplot.cpp:1767
 msgid "Zoom in plot view."
-msgstr ""
+msgstr "Powiększ wykres."
 
 #: common/widgets/mathplot.cpp:1768
 msgid "Zoom out plot view."
-msgstr ""
+msgstr "Pomniejsz wykres."
 
 #: common/widgets/widget_hotkey_list.cpp:104
 msgid "Press a new hotkey, or press Esc to cancel..."
-msgstr "Naciśnij nowy klawisz skrótu lub Esc, aby anulować ..."
+msgstr "Naciśnij nowy klawisz, lub wciśnij Esc by anulować..."
 
 #: common/widgets/widget_hotkey_list.cpp:111
 msgid "Command:"
@@ -3261,11 +3322,11 @@ msgstr "Polecenie:"
 
 #: common/widgets/widget_hotkey_list.cpp:119
 msgid "Current key:"
-msgstr "Bieżący klawisz:"
+msgstr "Bieżący skrót:"
 
 #: common/widgets/widget_hotkey_list.cpp:213
 msgid "Set Hotkey"
-msgstr "Ustaw skrót klawiszowy"
+msgstr "Ustaw skrót"
 
 #: common/widgets/widget_hotkey_list.cpp:379
 #: eeschema/libedit_onrightclick.cpp:202 eeschema/libedit_onrightclick.cpp:266
@@ -3282,7 +3343,7 @@ msgstr "Edytuj..."
 #: common/widgets/widget_hotkey_list.cpp:380
 #: eeschema/dialogs/dialog_edit_components_libid_base.cpp:93
 msgid "Undo Changes"
-msgstr "Cofnij zmiany"
+msgstr "Anuluj zmiany"
 
 #: common/widgets/widget_hotkey_list.cpp:381
 msgid "Restore Default"
@@ -3290,11 +3351,11 @@ msgstr "Przywróć domyślne"
 
 #: common/widgets/widget_hotkey_list.cpp:383
 msgid "Undo All Changes"
-msgstr "Cofnij wszystkie zmiany"
+msgstr "Anuluj wszystkie zmiany"
 
 #: common/widgets/widget_hotkey_list.cpp:384
 msgid "Restore All to Default"
-msgstr "Przywróć wszystko domyślnie"
+msgstr "Przywróć wszystkie do domyślnych"
 
 #: common/widgets/widget_hotkey_list.cpp:484
 #, c-format
@@ -3302,6 +3363,8 @@ msgid ""
 "\"%s\" is already assigned to \"%s\" in section \"%s\". Are you sure you "
 "want to change its assignment?"
 msgstr ""
+"\"%s\" jest obecnie przypisany do \"%s\" w sekcji \"%s\". Czy chcesz zmienić "
+"to przypisanie?"
 
 #: common/widgets/widget_hotkey_list.cpp:489
 msgid "Confirm change"
@@ -3317,83 +3380,83 @@ msgstr "Skróty klawiszowe"
 
 #: common/wildcards_and_files_ext.cpp:107
 msgid "All files (*)|*"
-msgstr "Wszystkie pliki (*.*)|*.*"
+msgstr "Wszystkie pliki (*)|*"
 
 #: common/wildcards_and_files_ext.cpp:112
 msgid "KiCad drawing symbol files (*.sym)|*."
-msgstr "Plik rysunków symboli programu KiCad (*.sym)|*.sym"
+msgstr "Pliki rysunków symboli (*.sym)|*."
 
 #: common/wildcards_and_files_ext.cpp:118
 msgid "KiCad symbol library files (*.lib)|*."
-msgstr "Plik bibliotek symboli programu KiCad (*.lib)|*.lib"
+msgstr "Pliki bibliotek symboli (*.lib)|*."
 
 #: common/wildcards_and_files_ext.cpp:124
 msgid "KiCad project files (*.pro)|*."
-msgstr "Pliki projektu programu KiCad (*.pro)|*.pro"
+msgstr "Pliki projektu programu KiCad (*.pro)|*."
 
 #: common/wildcards_and_files_ext.cpp:130
 msgid "KiCad schematic files (*.sch)|*."
-msgstr "Pliki schematów programu KiCad (*.sch)|*.sch"
+msgstr "Pliki schematu programu KiCad (*.sch)|*."
 
 #: common/wildcards_and_files_ext.cpp:136
 msgid "Eagle XML schematic files (*.sch)|*."
-msgstr "Pliki schematów XML Eagle (*.sch)|*.sch"
+msgstr "Pliki schematów programu EAGLE XML (*.sch)|*."
 
 #: common/wildcards_and_files_ext.cpp:142
 msgid "Eagle XML files (*.sch *.brd)|*."
-msgstr "Pliki schematów XML Eagle (*.sch)|*.sch"
+msgstr "Pliki Eagle XML (*.sch *.brd)|*."
 
 #: common/wildcards_and_files_ext.cpp:149
 msgid "KiCad netlist files (*.net)|*."
-msgstr "Pliki listy sieci programu KiCad (*.net)|*.net"
+msgstr "Pliki listy sieci (*.net)|*."
 
 #: common/wildcards_and_files_ext.cpp:155
 msgid "Gerber files (*.pho)|*."
-msgstr "Pliki Gerber (*.pho)|*.pho"
+msgstr "Pliki Gerber (*.pho)|*."
 
 #: common/wildcards_and_files_ext.cpp:161
 msgid "KiCad printed circuit board files (*.brd)|*."
-msgstr "Pliki PCB programu KiCad (*.brd)|*.brd"
+msgstr "Pliki obwodu drukowanego programu KiCad (*.brd)|*."
 
 #: common/wildcards_and_files_ext.cpp:167
 msgid "Eagle ver. 6.x XML PCB files (*.brd)|*."
-msgstr "Pliki płytek XML Eagle ver. 6.x (*.brd)|*.brd"
+msgstr "Pliki obwodu drukowanego programu EAGLE wer. 6.x XML (*.brd)|*."
 
 #: common/wildcards_and_files_ext.cpp:173
 msgid "P-Cad 200x ASCII PCB files (*.pcb)|*."
-msgstr "Pliki ASCII PCB programu P-Cad 200x (*.pcb)|*.pcb"
+msgstr "Pliki PCB programu P-Cad 200x formatu ASCII (*.pcb)|*."
 
 #: common/wildcards_and_files_ext.cpp:179
 msgid "KiCad printed circuit board files (*.kicad_pcb)|*."
-msgstr "Pliki płytek programu KiCad (*.kicad_pcb)|*."
+msgstr "Pliki obwodu drukowanego programu KiCad (*.kicad_pcb)|*."
 
 #: common/wildcards_and_files_ext.cpp:186
 msgid "KiCad footprint files (*.kicad_mod)|*."
-msgstr "Pliki footprintów KiCad (*.kicad_mod)|*."
+msgstr "Footrpritny programu KiCad (*.kicad_mod)|*."
 
 #: common/wildcards_and_files_ext.cpp:192
 msgid "KiCad footprint library paths (*.pretty)|*."
-msgstr "Ścieżki biblioteki footprintów KiCad (* .pretty)|*."
+msgstr "Foldery bibliotek footprintów programu KiCad (*.pretty)|*."
 
 #: common/wildcards_and_files_ext.cpp:198
 msgid "Legacy footprint library files (*.mod)|*."
-msgstr "Starsze biblioteki footprintów (*.mod)|*."
+msgstr "Pliki bibliotek starszego typu (*.mod)|*."
 
 #: common/wildcards_and_files_ext.cpp:204
 msgid "Eagle ver. 6.x XML library files (*.lbr)|*."
-msgstr "Pliki bibliotek XML Eagle ver. 6.x (*.lbr)|*."
+msgstr "Biblioteki programu Eagle wer. 6.x XML (*.lbr)|*."
 
 #: common/wildcards_and_files_ext.cpp:210
 msgid "Geda PCB footprint library files (*.fp)|*."
-msgstr ""
+msgstr "Biblioteki footprintów programu Geda PCB (*.fp)|*."
 
 #: common/wildcards_and_files_ext.cpp:216
 msgid "Page layout design files (*.kicad_wks)|*."
-msgstr ""
+msgstr "Pliki z układem strony (*.kicad_wks)|*."
 
 #: common/wildcards_and_files_ext.cpp:223
 msgid "KiCad symbol footprint link files (*.cmp)|*."
-msgstr ""
+msgstr "Pliki z łączami symboli z footprintami (*.cmp)|*."
 
 #: common/wildcards_and_files_ext.cpp:230
 msgid "Drill files (*.drl)|*."
@@ -3413,7 +3476,7 @@ msgstr "Pliki CSV (*.csv)|*."
 
 #: common/wildcards_and_files_ext.cpp:255
 msgid "Portable document format files (*.pdf)|*."
-msgstr ""
+msgstr "Pliki PDF (*.pdf)|*."
 
 #: common/wildcards_and_files_ext.cpp:261
 msgid "PostScript files (.ps)|*."
@@ -3425,7 +3488,7 @@ msgstr "Pliki raportów (*.rpt)|*."
 
 #: common/wildcards_and_files_ext.cpp:273
 msgid "Footprint place files (*.pos)|*."
-msgstr ""
+msgstr "Pliki położeń footprintów (*.pos)|*."
 
 #: common/wildcards_and_files_ext.cpp:279
 msgid "VRML and X3D files (*.wrl *.x3d)|*."
@@ -3433,43 +3496,43 @@ msgstr "Pliki VRML i X3D (*.wrl *.x3d)|*."
 
 #: common/wildcards_and_files_ext.cpp:286
 msgid "IDFv3 footprint files (*.idf)|*."
-msgstr "Pliki IDFv3 footprintów (*.idf)|*."
+msgstr "Pliki footprintów IDFv3 (*.idf)|*."
 
 #: common/wildcards_and_files_ext.cpp:292
 msgid "Text files (*.txt)|*."
-msgstr "Pliki tekstowe (*.txt)|*."
+msgstr "Pliki textowe (*.txt)|*."
 
 #: common/wildcards_and_files_ext.cpp:298
 msgid "Legacy footprint export files (*.emp)|*."
-msgstr ""
+msgstr "Pliki eksportu starszych typów bibliotek (*.emp)|*."
 
 #: common/wildcards_and_files_ext.cpp:304
 msgid "Electronic rule check file (.erc)|*."
-msgstr ""
+msgstr "Pliki raportów ERC (.erc)|*."
 
 #: common/wildcards_and_files_ext.cpp:310
 msgid "Spice library file (*.lib)|*."
-msgstr "Pliki bibliotek SPICE (*.lib)|*."
+msgstr "Pliki bibliotek Spice (*.lib)|*."
 
 #: common/wildcards_and_files_ext.cpp:316
 msgid "SPICE netlist file (.cir)|*."
-msgstr "Pliki listy połączeń SPICE (.cir)|*."
+msgstr "Pliki list sieci SPICE (.cir)|*."
 
 #: common/wildcards_and_files_ext.cpp:322
 msgid "CadStar netlist file (.frp)|*."
-msgstr "Plik listy połączeń CadStar (.frp)*."
+msgstr "Pliki listy sieci programu CadStar (.frp)|*."
 
 #: common/wildcards_and_files_ext.cpp:328
 msgid "Symbol footprint association files (*.equ)|*."
-msgstr ""
+msgstr "Pliki automatycznego przypisywania footprintów (*.equ)|*."
 
 #: common/wildcards_and_files_ext.cpp:334
 msgid "Zip file (*.zip)|*."
-msgstr "Pliki ZIP (*.zip)|*."
+msgstr "Pliki Zip (*.zip)|*."
 
 #: common/wildcards_and_files_ext.cpp:340
 msgid "GenCAD 1.4 board files (.cad)|*."
-msgstr "Pliki płytek GenCAD 1.4 (.cad)|*."
+msgstr "Pliki obwodów programu GenCAD 1.4 (.cad)|*."
 
 #: common/wildcards_and_files_ext.cpp:346
 msgid "DXF Files (*.dxf)|*."
@@ -3477,11 +3540,11 @@ msgstr "Pliki DXF (*.dxf)|*."
 
 #: common/wildcards_and_files_ext.cpp:352
 msgid "Gerber job file (*.gbrjob)|*."
-msgstr ""
+msgstr "Plik zadań Gerber (*.gbrjob)|*."
 
 #: common/wildcards_and_files_ext.cpp:359
 msgid "Specctra DSN file (*.dsn)|*."
-msgstr "Plik Spectra DSN (*.dsn)|*."
+msgstr "Pliki Specctra DSN (*.dsn)|*."
 
 #: common/wildcards_and_files_ext.cpp:365
 msgid "IPC-D-356 Test Files (.d356)|*."
@@ -3489,20 +3552,19 @@ msgstr "Pliki testowe IPC-D-356 (.d356)|*."
 
 #: common/wildcards_and_files_ext.cpp:371
 msgid "Workbook file (*.wbk)|*."
-msgstr "Plik Workbook (*.wbk)|*."
+msgstr "Pliki zestawu arkuszy (*.wbk)|*."
 
 #: common/wildcards_and_files_ext.cpp:377
 msgid "PNG file (*.png)|*."
-msgstr "Plik PNG (*.png)|*."
+msgstr "Pliki PNG (*.png)|*."
 
 #: common/zoom.cpp:283 pagelayout_editor/menubar.cpp:139
 msgid "Redraw View"
 msgstr "Odśwież widok"
 
 #: common/zoom.cpp:285 pagelayout_editor/menubar.cpp:131
-#, fuzzy
 msgid "Zoom to Fit"
-msgstr "Pomniejsz"
+msgstr "Dopasuj powiększenie"
 
 #: common/zoom.cpp:304
 msgid "Zoom: "
@@ -3537,11 +3599,14 @@ msgstr "Zamknij"
 #, c-format
 msgid "Equivalence file \"%s\" could not be found in the default search paths."
 msgstr ""
+"Nie można odnaleźć pliku automatycznego przypisywania \"%s\" w żadnej z "
+"domyślnych ścieżek."
 
 #: cvpcb/auto_associate.cpp:128
 #, c-format
 msgid "Error opening equivalence file \"%s\"."
 msgstr ""
+"Wystąpił błąd podczas otwierania pliku automatycznych przypisani \"%s\"."
 
 #: cvpcb/auto_associate.cpp:179
 msgid "Equivalence File Load Error"
@@ -3567,11 +3632,13 @@ msgstr "Ostrzeżenie CvPcb"
 #: cvpcb/cfg.cpp:77
 #, c-format
 msgid "Project file \"%s\" is not writable"
-msgstr ""
+msgstr "Plik projektu \"%s\" nie jest zapisywalny"
 
 #: cvpcb/common_help_msg.h:28
 msgid "Save footprint associations in schematic symbol footprint fields"
-msgstr "Zapisuje skojarzenia symboli schematu z footprintami"
+msgstr ""
+"Zapisuje przypisania footprintów w polach nazwy footprintu symboli na "
+"schemacie"
 
 #: cvpcb/cvpcb.cpp:159
 msgid ""
@@ -3584,29 +3651,34 @@ msgid ""
 "See the \"Footprint Library Table\" section of the CvPcb documentation for "
 "more information."
 msgstr ""
+"CvPcb został uruchomiony pierwszy raz z użyciem nowej metody wyszukiwania "
+"fooptrintów w Tabeli Bibliotek.\n"
+"CvPcb skopiuje teraz domyślną tabelę bądź utworzy pustą tabele w katalogu "
+"domowym użytkownika.\n"
+"Konfigurację tabeli bibliotek należy uzupełnić o pozostałe biblioteki "
+"footprintów nie będące składnikami programu.\n"
+"Zobacz rozdział \"Tabele bibliotek\" w dokumentacji programu CvPcb lub "
+"Pcbnew by uzyskać więcej informacji."
 
 #: cvpcb/cvpcb.cpp:174
 msgid "An error occurred attempting to load the global footprint library table"
-msgstr ""
+msgstr "Wystąpił błąd przy próbie załadowania globalnej biblioteki footprintów"
 
 #: cvpcb/cvpcb_mainframe.cpp:109
-#, fuzzy
 msgid "Assign Footprints"
-msgstr "Kojarzenie elementów"
+msgstr "Przypisz footprinty"
 
 #: cvpcb/cvpcb_mainframe.cpp:192
 #: eeschema/dialogs/dialog_fields_editor_global_base.cpp:100
-#, fuzzy
 msgid "Apply, Save Schematic && Continue"
-msgstr "Zapisz projekt schematu"
+msgstr "Zastosuj, zapisz schemat && Kontynuuj"
 
 #: cvpcb/cvpcb_mainframe.cpp:259
-#, fuzzy
 msgid ""
 "Component to Footprint links modified.\n"
 "Save before exit?"
 msgstr ""
-"Linki pomiędzy komponentami a footprintami zostały zmienione.\n"
+"Linki pomiędzy komponentami a footprintami zostały zmodyfikowane.\n"
 "Zapisać przed zakończeniem?"
 
 #: cvpcb/cvpcb_mainframe.cpp:407
@@ -3620,6 +3692,9 @@ msgid ""
 "\"%s\"\n"
 "%s"
 msgstr ""
+"Wystąpił błąd podczas zapisu globalnej tabeli bibliotek:\n"
+"\"%s\"\n"
+"%s"
 
 #: cvpcb/cvpcb_mainframe.cpp:468 cvpcb/cvpcb_mainframe.cpp:488
 #: eeschema/sch_base_frame.cpp:335 eeschema/sch_base_frame.cpp:353
@@ -3636,6 +3711,9 @@ msgid ""
 "\"%s\"\n"
 "%s"
 msgstr ""
+"Wystąpił błąd podczas zapisu tabeli bibliotek projektu:\n"
+"\"%s\"\n"
+"%s"
 
 #: cvpcb/cvpcb_mainframe.cpp:678
 msgid "key words"
@@ -3650,9 +3728,8 @@ msgid "library"
 msgstr "bibliotek"
 
 #: cvpcb/cvpcb_mainframe.cpp:709
-#, fuzzy
 msgid "search text"
-msgstr "Dodaj tekst (grafika)"
+msgstr "wyszukiwany tekst"
 
 #: cvpcb/cvpcb_mainframe.cpp:713
 msgid "No filtering"
@@ -3666,7 +3743,7 @@ msgstr "Filtrowane według %s"
 #: cvpcb/cvpcb_mainframe.cpp:729
 #, c-format
 msgid "Description: %s;  Key words: %s"
-msgstr ""
+msgstr "Oznaczenie: %s;  Słowa kluczowe: %s"
 
 #: cvpcb/cvpcb_mainframe.cpp:745
 msgid ""
@@ -3680,12 +3757,12 @@ msgid "Configuration Error"
 msgstr "Błąd Konfiguracji"
 
 #: cvpcb/cvpcb_mainframe.cpp:800
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "Error loading schematic.\n"
 "%s"
 msgstr ""
-"Błąd podczas odczytywania listy sieci.\n"
+"Błąd podczas ładowania pliku schematu.\n"
 "%s"
 
 #: cvpcb/dialogs/dialog_config_equfiles.cpp:52
@@ -3695,24 +3772,24 @@ msgstr "Plik projektu: \"%s\""
 
 #: cvpcb/dialogs/dialog_config_equfiles.cpp:104
 msgid "No editor defined in KiCad. Please choose it."
-msgstr ""
+msgstr "Nie wybrano żadnego edytora dla programu KiCad. Proszę go wybrać."
 
 #: cvpcb/dialogs/dialog_config_equfiles.cpp:249
 msgid "Footprint Association File"
-msgstr "Pliki skojarzeń footprintów"
+msgstr "Plik z przypisaniami footprintów"
 
 #: cvpcb/dialogs/dialog_config_equfiles.cpp:294
 #, c-format
 msgid "File \"%s\" already exists in list"
-msgstr "Plik \"% s\" już istnieje na liście"
+msgstr "Plik \"%s\" już istnieje na liście"
 
 #: cvpcb/dialogs/dialog_config_equfiles_base.cpp:20
 msgid "Symbol Footprint Association Files (.equ)"
-msgstr "Pliki skojarzeń footprintów (*.equ)"
+msgstr "Pliki automatycznego przypisywania footprintów (.equ)"
 
 #: cvpcb/dialogs/dialog_config_equfiles_base.cpp:48
 msgid "Edit File"
-msgstr "Edytuj plik"
+msgstr "Edycja pliku"
 
 #: cvpcb/dialogs/dialog_config_equfiles_base.cpp:63
 msgid "Available environment variables for relative paths:"
@@ -3736,7 +3813,7 @@ msgstr "Wartość"
 #: cvpcb/dialogs/dialog_config_equfiles_base.cpp:99
 #: pcbnew/dialogs/dialog_gendrill_base.cpp:115
 msgid "Absolute"
-msgstr "Bezwzględna"
+msgstr "Bezwzględny"
 
 #: cvpcb/dialogs/dialog_config_equfiles_base.cpp:99
 msgid "Relative"
@@ -3744,12 +3821,11 @@ msgstr "Względna"
 
 #: cvpcb/dialogs/dialog_config_equfiles_base.cpp:101
 msgid "Path Type:"
-msgstr "Ścieżka typu:"
+msgstr "Typ ścieżki:"
 
 #: cvpcb/dialogs/dialog_display_options_base.cpp:23
-#, fuzzy
 msgid "Draw Options:"
-msgstr "Opcje rysowania"
+msgstr "Opcje rysowania:"
 
 #: cvpcb/dialogs/dialog_display_options_base.cpp:25
 msgid "Graphic items sketch mode"
@@ -3770,24 +3846,23 @@ msgstr "Pokaż &numery pól"
 #: cvpcb/dialogs/dialog_display_options_base.cpp:41
 #: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:71
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:82
-#, fuzzy
 msgid "Pan and Zoom:"
-msgstr "Panoramowanie i przybliżanie"
+msgstr "Panoramowanie i przybliżanie:"
 
 #: cvpcb/dialogs/dialog_display_options_base.cpp:43
 msgid "Center and warp cursor on zoom"
-msgstr "Wyśrodkuj i przesuń kursor przy powiększeniu"
+msgstr "Centruj i przesuwaj kursor przy powiększaniu"
 
 #: cvpcb/dialogs/dialog_display_options_base.cpp:44
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:85
 msgid "Center the cursor on screen when zooming."
-msgstr ""
+msgstr "Centruj pozycję kursora podczas powiększania."
 
 #: cvpcb/dialogs/dialog_display_options_base.cpp:48
 #: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:78
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:89
 msgid "Use touchpad to pan"
-msgstr ""
+msgstr "Użyj płytki dotykowej by panoramować"
 
 #: cvpcb/dialogs/dialog_display_options_base.cpp:49
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:90
@@ -3795,10 +3870,12 @@ msgid ""
 "Enable touchpad-friendly controls (pan with scroll action, zoom with Ctrl"
 "+scroll)."
 msgstr ""
+"Włącza sterowanie przyjazne dla gładzika (panoramowanie wraz z przesuwaniem, "
+"powiększanie przy wciśniętym klawiszu CTRL)."
 
 #: cvpcb/dialogs/dialog_display_options_base.cpp:53
 msgid "Pan while moving object"
-msgstr ""
+msgstr "Panoramuj podczas przesuwania obiektów"
 
 #: cvpcb/dialogs/dialog_display_options_base.cpp:54
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:95
@@ -3806,6 +3883,8 @@ msgid ""
 "When drawing a track or moving an item, pan when approaching the edge of the "
 "display."
 msgstr ""
+"Gdy rysowana jest ścieżka lub przesuwany jest element, widok będzie "
+"panoramowany przy zbliżaniu się do krawędzi widoku."
 
 #: cvpcb/dialogs/fp_conflict_assignment_selector.cpp:37
 msgid "Ref"
@@ -3826,11 +3905,14 @@ msgid ""
 "\n"
 "Please choose the assignment."
 msgstr ""
+"Przypisania footprintów w liście sieci i w pliku z przypisaniami footprintów "
+"(.cmp) są niejednorodne.\n"
+"\n"
+"Proszę wybrać źródło przypisań."
 
 #: cvpcb/dialogs/fp_conflict_assignment_selector_base.h:53
-#, fuzzy
 msgid "Footprint Assignment Conflicts"
-msgstr "Pliki skojarzeń footprintów"
+msgstr "Konflikty przy przypisywaniu footprintów"
 
 #: cvpcb/display_footprints_frame.cpp:76
 msgid "Footprint Viewer"
@@ -3866,8 +3948,7 @@ msgstr "Zmień kształt kursora"
 #: pcbnew/menubar_footprint_editor.cpp:276 pcbnew/menubar_pcb_editor.cpp:672
 #: pcbnew/tool_footprint_editor.cpp:236 pcbnew/tool_pcb_editor.cpp:372
 msgid "Change cursor shape (not supported in Legacy Toolset)"
-msgstr ""
-"Zmienia kształt kursora (nie jest obsługiwane w starszym zestawie narzędzi)"
+msgstr "Zmień kształt kursora (nie wspierane w zestawie narzędzi Legacy)"
 
 #: cvpcb/display_footprints_frame.cpp:202
 #: pcbnew/menubar_footprint_editor.cpp:286 pcbnew/menubar_pcb_editor.cpp:703
@@ -3900,7 +3981,6 @@ msgid "Redraw view (F3)"
 msgstr "Odśwież widok (F3)"
 
 #: cvpcb/display_footprints_frame.cpp:239
-#, fuzzy
 msgid "Zoom to fit footprint (Home)"
 msgstr "Dopasuj powiększenie (Home)"
 
@@ -3925,14 +4005,14 @@ msgid "Show outlines in sketch mode"
 msgstr "Pokaż tylko zarys szkicu"
 
 #: cvpcb/display_footprints_frame.cpp:435
-#, fuzzy, c-format
+#, c-format
 msgid "Footprint ID \"%s\" is not valid."
-msgstr "Nazwa pliku '%s' jest niepoprawna."
+msgstr "ID footprintu \"%s\" nie jest prawidłowy."
 
 #: cvpcb/display_footprints_frame.cpp:462
 #, c-format
 msgid "Footprint \"%s\" not found"
-msgstr "Footprintu \"%s\" nie znaleziono"
+msgstr "Footprint \"%s\" nie został znaleziony"
 
 #: cvpcb/display_footprints_frame.cpp:478
 #, c-format
@@ -3945,13 +4025,12 @@ msgid "Lib: %s"
 msgstr "Biblioteka: %s"
 
 #: cvpcb/menubar.cpp:57
-#, fuzzy
 msgid "&Save Schematic\tCtrl+S"
-msgstr "Zapisz schemat"
+msgstr "Zapisz schemat\tCtrl+S"
 
 #: cvpcb/menubar.cpp:67
 msgid "Configure &Paths..."
-msgstr "Konfiguracja ścieżek..."
+msgstr "Konfiguracja ścieżek dostępu..."
 
 #: cvpcb/menubar.cpp:68 eeschema/menubar.cpp:674
 #: eeschema/menubar_libedit.cpp:292 kicad/menubar.cpp:338
@@ -3961,21 +4040,24 @@ msgstr "Edycja ścieżek dostępu w zmiennych środowiskowych"
 
 #: cvpcb/menubar.cpp:72
 msgid "Manage Footprint &Libraries..."
-msgstr "Menadżer footprintów i bibliotek..."
+msgstr "Zarządzanie bibliotekami footprintów..."
 
 #: cvpcb/menubar.cpp:72
 msgid "Manage footprint libraries"
-msgstr "Menadżer bibliotek footprintów"
+msgstr "Zarządza bibliotekami footprintów"
 
 #: cvpcb/menubar.cpp:77
 msgid "Footprint &Association Files..."
-msgstr "Pliki skojarzeń footprintów..."
+msgstr "Pliki przypisywania footprintów..."
 
 #: cvpcb/menubar.cpp:78
 msgid ""
 "Configure footprint association file (.equ) list.These files are used to "
 "automatically assign the footprint name from the symbol value"
 msgstr ""
+"Konfiguruje listę wstępnych przypisani footprintów (plik .equ). Pliki te są "
+"używane do automatycznego przypisywania footprintów na postawie wartości "
+"symbolów"
 
 #: cvpcb/menubar.cpp:91
 msgid "CvPcb &Manual"
@@ -3993,9 +4075,9 @@ msgid "About KiCad"
 msgstr "O programie KiCad"
 
 #: cvpcb/readwrite_dlgs.cpp:103
-#, fuzzy, c-format
+#, c-format
 msgid "\"%s\" is not a valid LIB_ID."
-msgstr "\"%s\" nie jest prawidłową wartością SPICE"
+msgstr "\"%s\" to nie jest poprawna wartość LIB_ID."
 
 #: cvpcb/readwrite_dlgs.cpp:207
 msgid ""
@@ -4004,18 +4086,26 @@ msgid ""
 "required LIB_ID format? (If you answer no, then these assignments will be "
 "cleared out and you will have to re-assign these footprints yourself.)"
 msgstr ""
+"Niektóre z przypisanych footpritów to pozycje starszego typu (nie posiadają "
+"nazw skrótowych). Czy chcesz by CvPcb spróbował skonwertować je do nowego "
+"formatu LIB_ID? (Jeśli odpowiesz nie, wtedy te przypisania zostaną skasowane "
+"i będzie trzeba ponownie przyporządkować te footprinty ręcznie.)"
 
 #: cvpcb/readwrite_dlgs.cpp:240
 #, c-format
 msgid ""
 "Component \"%s\" footprint \"%s\" was <b>not found</b> in any library.\n"
 msgstr ""
+"Komponent \"%s\" footprint \"%s\" <b>nie został znaleziony</b> w żadnej z "
+"bibliotek.\n"
 
 #: cvpcb/readwrite_dlgs.cpp:248
 #, c-format
 msgid ""
 "Component \"%s\" footprint \"%s\" was found in <b>multiple</b> libraries.\n"
 msgstr ""
+"Komponent \"%s\" footprint \"%s\" <b>został znaleziony w kilku</b> "
+"bibliotekach.\n"
 
 #: cvpcb/readwrite_dlgs.cpp:261
 msgid "First check your footprint library table entries."
@@ -4054,11 +4144,11 @@ msgstr "Pokaż zaznaczony footprint"
 
 #: cvpcb/tool_cvpcb.cpp:55
 msgid "Select previous unlinked symbol"
-msgstr "Wybierz poprzedni nieskojarzony symbol"
+msgstr "Wybiera poprzedni nieprzydzielony symbol"
 
 #: cvpcb/tool_cvpcb.cpp:59
 msgid "Select next unlinked symbol"
-msgstr "Wybierz następny nieskojarzony symbol"
+msgstr "Wybiera następny nieprzydzielony symbol"
 
 #: cvpcb/tool_cvpcb.cpp:64
 msgid "Perform automatic footprint association"
@@ -4066,11 +4156,12 @@ msgstr "Automatyczne kojarzenie footprintów"
 
 #: cvpcb/tool_cvpcb.cpp:68
 msgid "Delete all footprint associations"
-msgstr "Usuń wszystkie skojarzenia footprintów"
+msgstr "Usuń wszystkie przypisania footprintów"
 
 #: cvpcb/tool_cvpcb.cpp:75
 msgid "Filter footprint list by schematic symbol keywords"
-msgstr "Filtruj listę footprintów według słów kluczowych w schemacie"
+msgstr ""
+"Filtruje listę footprintów za pomocą słów kluczowych z symboli schematowych"
 
 #: cvpcb/tool_cvpcb.cpp:82
 msgid "Filter footprint list by pin count"
@@ -4083,7 +4174,7 @@ msgstr "Filtruj listę footprintów według wybranej bibioteki"
 
 #: cvpcb/tool_cvpcb.cpp:95
 msgid "Filter footprint list using a partial name or a pattern"
-msgstr "Filtruj listę footprintów, używając częściowej nazwy lub wzorca"
+msgstr "Filtruj listę footprintów według częściowej nazwy lub wzorca"
 
 #: eeschema/annotate.cpp:112
 #, c-format
@@ -4091,32 +4182,32 @@ msgid "%d duplicate time stamps were found and replaced."
 msgstr "Zostało znalezionych i zamienionych %d powielonych odcisków czasowych."
 
 #: eeschema/annotate.cpp:202
-#, fuzzy, c-format
+#, c-format
 msgid "Updated %s (unit %s) from %s to %s"
-msgstr "Zaktualizowano %s z %s na %s"
+msgstr "Uaktualniono %s (część %s) z %s do %s"
 
 #: eeschema/annotate.cpp:208
 #, c-format
 msgid "Updated %s from %s to %s"
-msgstr "Zaktualizowano %s z %s na %s"
+msgstr "Uaktualnione %s z %s do %s"
 
 #: eeschema/annotate.cpp:216
-#, fuzzy, c-format
+#, c-format
 msgid "Annotated %s (unit %s) as %s"
-msgstr "Element nie ma numeracji: %s%s (część %d)\n"
+msgstr "Ponumerowano %s (część %s) jako %s"
 
 #: eeschema/annotate.cpp:221
 #, c-format
 msgid "Annotated %s as %s"
-msgstr ""
+msgstr "Ponumerowane %s jako %s"
 
 #: eeschema/annotate.cpp:231
 msgid "Annotation complete."
-msgstr "Numeracja kompletna."
+msgstr "Numerowanie wykonane."
 
 #: eeschema/backanno.cpp:221
 msgid "Load Symbol Footprint Link File"
-msgstr ""
+msgstr "Ładowanie pliku łączy symboli z footprintami"
 
 #: eeschema/backanno.cpp:232
 msgid "Keep existing footprint field visibility"
@@ -4142,6 +4233,8 @@ msgstr "Zmiana widoczności"
 #, c-format
 msgid "Failed to open component-footprint link file \"%s\""
 msgstr ""
+"Nie udało się otworzyć pliku \"%s\" zawierającego łącza pomiędzy symbolami a "
+"footprintami"
 
 #: eeschema/block.cpp:471
 msgid "No item to paste."
@@ -4154,6 +4247,9 @@ msgid ""
 "the sheet \"%s\" or one of it's subsheets as a parent somewhere in the "
 "schematic hierarchy."
 msgstr ""
+"Zmiany w arkuszu nie mogą zostać wykonane, ponieważ docelowy arkusz posiada "
+"arkusz \"%s\" lub jeden z jego podrzędnych arkuszy stanowi arkusz nadrzędny "
+"w innym miejscu hierarchii."
 
 #: eeschema/class_libentry.cpp:104 eeschema/class_libentry.cpp:236
 msgid "none"
@@ -4172,11 +4268,14 @@ msgid ""
 "This may cause some unexpected behavior when loading components into a "
 "schematic."
 msgstr ""
+"Bibliotek \"%s\" posiada zdublowaną nazwę \"%s\".\n"
+"Może to doprowadzić do nieprzewidywalnego zachowania podczas ładowania "
+"komponentów do schematu."
 
 #: eeschema/class_library.cpp:537
 #, c-format
 msgid "Unable to load project's \"%s\" file"
-msgstr ""
+msgstr "Nie można załadować pliku \"%s\" należącego do"
 
 #: eeschema/class_library.cpp:577 eeschema/cmp_tree_model_adapter_base.cpp:120
 #: eeschema/lib_edit_frame.cpp:1669
@@ -4185,7 +4284,7 @@ msgstr "Wczytywanie bibliotek symboli"
 
 #: eeschema/class_library.cpp:594
 msgid "Loading "
-msgstr "Wczytywanie"
+msgstr "Wczytywanie "
 
 #: eeschema/class_library.cpp:637
 #, c-format
@@ -4193,6 +4292,8 @@ msgid ""
 "Symbol library \"%s\" failed to load. Error:\n"
 " %s"
 msgstr ""
+"Nie można załadować biblioteki \"%s\". Błąd:\n"
+" %s"
 
 #: eeschema/class_library.cpp:661
 #, c-format
@@ -4200,6 +4301,8 @@ msgid ""
 "Symbol library \"%s\" failed to load.\n"
 "Error: %s"
 msgstr ""
+"Nie można załadować biblioteki \"%s\".\n"
+"Błąd: %s"
 
 #: eeschema/cmp_tree_model.cpp:126 eeschema/lib_draw_item.cpp:70
 #: eeschema/libedit.cpp:685 eeschema/onrightclick.cpp:490
@@ -4230,6 +4333,9 @@ msgid ""
 "\n"
 "%s"
 msgstr ""
+"Wystąpił błąd podczas ładowania biblioteki symboli %s.\n"
+"\n"
+"%s"
 
 #: eeschema/cmp_tree_model_adapter.cpp:87
 #: eeschema/dialogs/dialog_choose_component.cpp:270
@@ -4242,6 +4348,9 @@ msgid ""
 "\n"
 "%s"
 msgstr ""
+"Wystąpił błąd podczas ładowania symbolu %s z biblioteki %s.\n"
+"\n"
+"%s"
 
 #: eeschema/cmp_tree_model_adapter_base.cpp:131
 #: eeschema/lib_edit_frame.cpp:1673
@@ -4255,7 +4364,7 @@ msgstr "Nazwa symbolu"
 
 #: eeschema/cmp_tree_model_adapter_base.cpp:221
 msgid "Desc"
-msgstr "Opis"
+msgstr "Malejąco"
 
 #: eeschema/component_references_lister.cpp:554
 #, c-format
@@ -4270,7 +4379,7 @@ msgstr "Element nie ma numeracji: %s%s\n"
 #: eeschema/component_references_lister.cpp:582
 #, c-format
 msgid "Error: symbol %s%s unit %d and symbol has only %d units defined\n"
-msgstr ""
+msgstr "Błąd: symbol %s%s część %d oraz symbol posiada tylko %d elementów\n"
 
 #: eeschema/component_references_lister.cpp:620
 #: eeschema/component_references_lister.cpp:650
@@ -4302,24 +4411,24 @@ msgstr "Sprecyzuj Wybór"
 
 #: eeschema/cross-probing.cpp:82
 msgid "Selected net: "
-msgstr "Wybrana sieć:"
+msgstr "Zaznaczona sieć: "
 
 #: eeschema/cross-probing.cpp:287
-#, fuzzy
 msgid "Schematic saved"
-msgstr "Rozmiar schematu"
+msgstr "Schemat został zapisany"
 
 #: eeschema/dialogs/dialog_annotate.cpp:117
 msgid "Annotation Messages:"
-msgstr "Komunikaty numeracji elementów"
+msgstr "Raport z numeracji:"
 
 #: eeschema/dialogs/dialog_annotate.cpp:206
 msgid "Clear and annotate all of the symbols on the entire schematic?"
-msgstr ""
+msgstr "Skasować oraz ponumerować na nowo wszystkie symbole w całym schemacie?"
 
 #: eeschema/dialogs/dialog_annotate.cpp:208
 msgid "Clear and annotate all of the symbols on the current sheet?"
 msgstr ""
+"Skasować oraz ponumerować na nowo wszystkie symbole w bieżącym arkuszu?"
 
 #: eeschema/dialogs/dialog_annotate.cpp:210
 msgid ""
@@ -4358,14 +4467,12 @@ msgid "Use the current page only"
 msgstr "Użyj tylko bieżącej strony"
 
 #: eeschema/dialogs/dialog_annotate_base.cpp:40
-#, fuzzy
 msgid "Scope:"
-msgstr "Zakres"
+msgstr "Zakres:"
 
 #: eeschema/dialogs/dialog_annotate_base.cpp:45
-#, fuzzy
 msgid "Order:"
-msgstr "Kolejność"
+msgstr "Ułożenie:"
 
 #: eeschema/dialogs/dialog_annotate_base.cpp:50
 msgid "Sort components by &X position"
@@ -4377,17 +4484,17 @@ msgstr "Sortuj symbole wg pozycji w osi &Y"
 
 #: eeschema/dialogs/dialog_annotate_base.cpp:80
 msgid "Keep existing annotations"
-msgstr "Zachowaj istniejące adnotacje"
+msgstr "Pozostaw bieżącą numerację"
 
 #: eeschema/dialogs/dialog_annotate_base.cpp:80
 msgid "Reset existing annotations"
-msgstr "Zresetuj istniejące adnotacje"
+msgstr "Resetuj bieżącą numerację"
 
 #: eeschema/dialogs/dialog_annotate_base.cpp:80
 msgid "Reset, but keep order of multi-unit parts"
 msgstr ""
-"Zresetuj, ale zachowaj porządek elementów\n"
-"składających się z wielu części"
+"Zresetuj, ale nie zamieniaj żadnej z ponumerowanych części elementów "
+"wieloczęściowych"
 
 #: eeschema/dialogs/dialog_annotate_base.cpp:82
 #: eeschema/dialogs/dialog_lib_edit_text_base.cpp:75
@@ -4401,9 +4508,8 @@ msgid "Options:"
 msgstr "Opcje:"
 
 #: eeschema/dialogs/dialog_annotate_base.cpp:87
-#, fuzzy
 msgid "Numbering:"
-msgstr "Numeracja"
+msgstr "Numerowanie:"
 
 #: eeschema/dialogs/dialog_annotate_base.cpp:94
 msgid "Use first free number after:"
@@ -4411,11 +4517,11 @@ msgstr "Użyj pierwszego wolnego numeru po:"
 
 #: eeschema/dialogs/dialog_annotate_base.cpp:100
 msgid "First free after sheet number X 100"
-msgstr "Pierwszy wolny arkusz po numerze X 100"
+msgstr "Pierwszy wolny według numeru arkusza razy 100"
 
 #: eeschema/dialogs/dialog_annotate_base.cpp:103
 msgid "First free after sheet number X 1000"
-msgstr "Pierwszy wolny arkusz po numerze X 1000"
+msgstr "Pierwszy wolny według numeru arkusza razy 1000"
 
 #: eeschema/dialogs/dialog_annotate_base.cpp:124
 msgid "Keep this dialog open"
@@ -4440,7 +4546,7 @@ msgstr "Numeruj schemat"
 #: eeschema/dialogs/dialog_bom.cpp:356
 #, c-format
 msgid "Failed to open file \"%s\""
-msgstr "Nie można otworzyć pliku \"%s\""
+msgstr "Niepowodzenie przy otwarciu pliku \"%s\""
 
 #: eeschema/dialogs/dialog_bom.cpp:489
 msgid "Plugin name in plugin list"
@@ -4452,7 +4558,7 @@ msgstr "Nazwa wtyczki"
 
 #: eeschema/dialogs/dialog_bom.cpp:500
 msgid "This name already exists. Abort"
-msgstr "Ta nazwa już istnieje. Przerwano."
+msgstr "Ta nazwa już istnieje. Przerwano"
 
 #: eeschema/dialogs/dialog_bom.cpp:529 eeschema/dialogs/dialog_netlist.cpp:846
 msgid "Plugin files:"
@@ -4461,11 +4567,11 @@ msgstr "Pliki wtyczek:"
 #: eeschema/dialogs/dialog_bom.cpp:646
 msgid "Plugin file name not found. Cannot edit plugin file"
 msgstr ""
-"Nazwa pliku wtyczki nie została znaleziona. Nie można edytować pliku wtyczki."
+"Nazwa pliku wtyczki nie została znaleziona. Nie można edytować pliku wtyczki"
 
 #: eeschema/dialogs/dialog_bom.cpp:656
 msgid "No text editor selected in KiCad. Please choose it"
-msgstr "Edytor tekstu nie został zdefiniowany. Proszę wybrać."
+msgstr "Edytor tekstu nie został zdefiniowany. Proszę wybrać"
 
 #: eeschema/dialogs/dialog_bom.cpp:661
 msgid "Bom Generation Help"
@@ -4505,10 +4611,13 @@ msgid ""
 "redirected to \"Plugin info\" field.\n"
 "Set this option to show the window of the running command."
 msgstr ""
+"Domyślnie, konsola uruchamiana jest w tle i jej wyjście jest kierowane do "
+"pola \"Informacja o wtyczce\".\n"
+"Ustaw tą opcję by okno konsoli było widoczne podczas jej uruchomienia."
 
 #: eeschema/dialogs/dialog_bom_base.cpp:107
 msgid "Plugin Information:"
-msgstr "Informacja o wtyczce"
+msgstr "Informacje o wtyczce:"
 
 #: eeschema/dialogs/dialog_bom_base.h:95
 msgid "Bill of Material"
@@ -4516,15 +4625,15 @@ msgstr "Lista materiałowa"
 
 #: eeschema/dialogs/dialog_choose_component.cpp:298
 msgid "No footprint specified"
-msgstr ""
+msgstr "Nie określono footprintu"
 
 #: eeschema/dialogs/dialog_choose_component.cpp:312
 msgid "Invalid footprint specified"
-msgstr ""
+msgstr "Określono niepoprawny footprint"
 
 #: eeschema/dialogs/dialog_choose_component.cpp:494
 msgid "Double-click here to select a symbol from the library browser"
-msgstr ""
+msgstr "Kliknij dwukrotnie by wybrać symbol z przeglądarki bibliotek"
 
 #: eeschema/dialogs/dialog_edit_component_in_lib.cpp:74
 msgid "Library Component Properties"
@@ -4538,7 +4647,7 @@ msgstr "Właściwości %s (inaczej zwany %s)"
 #: eeschema/dialogs/dialog_edit_component_in_lib.cpp:87
 #, c-format
 msgid "Alias List of %s"
-msgstr ""
+msgstr "Lista aliasów %s"
 
 #: eeschema/dialogs/dialog_edit_component_in_lib.cpp:91
 #, c-format
@@ -4553,6 +4662,7 @@ msgstr "Liczba części składowych (maks. dostępne %d)"
 #: eeschema/dialogs/dialog_edit_component_in_lib.cpp:304
 msgid "Delete All can be done only when editing the main symbol."
 msgstr ""
+"\"Usuń wszystkie\" może być wykonane tylko podczas edycji głównego symbolu."
 
 #: eeschema/dialogs/dialog_edit_component_in_lib.cpp:308
 msgid "Remove all aliases from list?"
@@ -4561,7 +4671,7 @@ msgstr "Usunąć wszystkie aliasy z listy ?"
 #: eeschema/dialogs/dialog_edit_component_in_lib.cpp:325
 #, c-format
 msgid "Current alias \"%s\" cannot be edited."
-msgstr ""
+msgstr "Bieżący alias \"%s\" nie może zostać zmieniony."
 
 #: eeschema/dialogs/dialog_edit_component_in_lib.cpp:330
 #: eeschema/dialogs/dialog_edit_component_in_lib.cpp:346
@@ -4571,22 +4681,22 @@ msgstr "Nowy alias:"
 #: eeschema/dialogs/dialog_edit_component_in_lib.cpp:330
 #: eeschema/dialogs/dialog_edit_component_in_lib.cpp:346
 msgid "Symbol alias:"
-msgstr ""
+msgstr "Alias symbolu:"
 
 #: eeschema/dialogs/dialog_edit_component_in_lib.cpp:366
 #, c-format
 msgid "Alias \"%s\" already exists."
-msgstr ""
+msgstr "Alias \"%s\" już istnieje."
 
 #: eeschema/dialogs/dialog_edit_component_in_lib.cpp:376
 #, c-format
 msgid "Symbol name \"%s\" already exists in library \"%s\"."
-msgstr ""
+msgstr "Nazwa symbolu \"%s\" już występuje w bibliotece \"%s\"."
 
 #: eeschema/dialogs/dialog_edit_component_in_lib.cpp:397
 #, c-format
 msgid "Current alias \"%s\" cannot be removed."
-msgstr ""
+msgstr "Bieżący alias \"%s\" nie może być usunięty."
 
 #: eeschema/dialogs/dialog_edit_component_in_lib.cpp:417
 msgid "Delete extra parts from component?"
@@ -4616,9 +4726,9 @@ msgid "Footprint Filter"
 msgstr "Filtr footprintów"
 
 #: eeschema/dialogs/dialog_edit_component_in_lib.cpp:541
-#, fuzzy, c-format
+#, c-format
 msgid "Footprint filter \"%s\" is already defined."
-msgstr "Filtr footprintów <%s> jest obecnie zdefiniowany."
+msgstr "Filtr footprintów \"%s\" jest już zdefiniowany."
 
 #: eeschema/dialogs/dialog_edit_component_in_lib.cpp:582
 msgid "Edit footprint filter"
@@ -4638,6 +4748,7 @@ msgstr "Posiada alternatywny styl symbolu (DeMorgan)."
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:31
 msgid "Check this option if the symbol has an alternate body style (De Morgan)"
 msgstr ""
+"Zaznacz tą opcję jeśli symbol posiada alternatywny styl rysowania (De Morgan)"
 
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:35
 msgid "Show pin number"
@@ -4669,18 +4780,18 @@ msgstr ""
 "Jeśli opcja nie jest zaznaczona to oba są umieszczone na zewnątrz."
 
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:65
-#, fuzzy
 msgid "Number of Units:"
-msgstr "Liczba części składowych"
+msgstr "Liczba części składowych:"
 
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:67
 msgid "Enter the number of units for a symbol that contains more than one unit"
 msgstr ""
+"Wpisz liczbę elementów składowych dla symbolu, który posiada więcej niż "
+"jeden element składowy"
 
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:80
-#, fuzzy
 msgid "Pin Name Position Offset:"
-msgstr "Przesunięcie pozycji tekstu w opisie pinu"
+msgstr "Przesunięcie pozycji tekstu w opisie pinu:"
 
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:82
 msgid ""
@@ -4697,7 +4808,7 @@ msgstr "Utwórz symbol jako symbol zasilania"
 
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:99
 msgid "Check this option when the symbol is a power symbol"
-msgstr ""
+msgstr "Zaznacz tą opcję gdy symbol jest portem zasilania"
 
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:103
 msgid "All units are not interchangeable"
@@ -4708,9 +4819,11 @@ msgid ""
 "Check this option when creating multiple unit symbols and all units are not "
 "interchangeable"
 msgstr ""
+"Zaznacz tą opcję gdy tworzysz symbole z wieloma elementami składowymi ale są "
+"one niewymienne"
 
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:112
-#: eeschema/dialogs/dialog_erc_base.cpp:154 include/lib_table_grid.h:195
+#: eeschema/dialogs/dialog_erc_base.cpp:154
 msgid "Options"
 msgstr "Opcje"
 
@@ -4738,16 +4851,19 @@ msgid ""
 "Enter key words that can be used to select this symbol.\n"
 "Key words cannot have spaces and are separated by a space."
 msgstr ""
+"Wpisz słowa kluczowe, które można wykorzystać przy wyszukiwaniu symboli.\n"
+"Słowa kluczowe nie mogą zwierać spacji i są oddzielane spacjami."
 
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:135
-#, fuzzy
 msgid "Documentation File Name:"
-msgstr "Nazwa pliku z dokumentacją"
+msgstr "Nazwa pliku z dokumentacją:"
 
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:137
 msgid ""
 "Enter the documentation file (a .pdf document) associated with the symbol."
 msgstr ""
+"Wprowadź nazwę pliku z dokumentacją (dokument .pdf) przypisaną do tego "
+"symbolu."
 
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:147
 msgid "Copy Document from Parent"
@@ -4758,9 +4874,8 @@ msgid "Browse Files"
 msgstr "Przeglądaj pliki"
 
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:168
-#, fuzzy
 msgid "Alias List:"
-msgstr "Lista aliasów"
+msgstr "Lista aliasów:"
 
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:170
 msgid ""
@@ -4768,6 +4883,11 @@ msgid ""
 "It has its own documentation and keywords.\n"
 "A fast way to extend a library with similar symbols."
 msgstr ""
+"Alias to symbol, który używa rysunku innego symbolu jako swój własny.\n"
+"Posiada on własne słowa kluczowe oraz dokumentację, ale współdzieli również "
+"footprint.\n"
+"Jest to szybki sposób na powiększenie zasobu bibliotek za pomocą podobnych "
+"symboli."
 
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:189
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:231
@@ -4816,20 +4936,23 @@ msgid ""
 "Footprints names can used wildcards like sm* to allow all footprints names "
 "starting by sm."
 msgstr ""
+"Lista nazw footprintów, które mogą być użyte dla tego symbolu.\n"
+"Nazwy footprintów mogą posiadać symbole wieloznaczne, np. SM* by umożliwić "
+"przypasowanie różnych wariantów."
 
 #: eeschema/dialogs/dialog_edit_component_in_lib_base.h:115
 msgid "Library Symbol Properties"
-msgstr ""
+msgstr "Właściwości biblioteki symboli"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:263
 #, c-format
 msgid "\"%s\" is not a valid library symbol identifier."
-msgstr ""
+msgstr "\"%s\" nie jest prawidłowym identyfikatorem symbolu w bibliotece."
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:280
 #, c-format
 msgid "Symbol \"%s\" not found in library \"%s\""
-msgstr "Symbol \"%s\" nie został znaleziony w bibliotece \"%s\""
+msgstr "Symbol \"%s\" nie został odnaleziony w bibliotece \"%s\""
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:286
 #, c-format
@@ -4839,16 +4962,16 @@ msgstr "Symbol \"%s\" został znaleziony w bibliotece \"%s\""
 #: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:373
 #, c-format
 msgid "Symbol library identifier \"%s\" is not valid!"
-msgstr ""
+msgstr "Identyfikator symbolu \"%s\" nie jest prawidłowy!"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:390
 #, c-format
 msgid "Symbol \"%s\" not found in library \"%s\"!"
-msgstr "Symbolu \"%s\" nie znaleziono w bibliotece \"%s\"!"
+msgstr "Symbol \"%s\" nie został odnaleziony w bibliotece \"%s\"!"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:465
 msgid "Illegal reference. References must start with a letter"
-msgstr ""
+msgstr "Niepoprawne oznaczenie. Oznaczenie musi rozpoczynać się od litery"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:491
 #, c-format
@@ -4857,6 +4980,10 @@ msgid ""
 "template list.  Empty field values are invalid an will be removed from the "
 "component.  Do you wish to remove this and all remaining undefined fields?"
 msgstr ""
+"Pole o nazwie \"%s\" nie posiada wartości i nie zostało zdefiniowane na "
+"liście wzorców pól.  Puste pola nie są prawidłowe i będą usunięte z "
+"komponentu.  Czy chcesz usunąć te pole i inne nie posiadające żadnej "
+"wartości?"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:498
 msgid "Remove Fields"
@@ -4885,12 +5012,12 @@ msgstr "Przeglądaj footprinty"
 #: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:998
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib.cpp:807
 msgid "Open the footprint browser to choose a footprint and assign it."
-msgstr ""
+msgstr "Otwiera przeglądarkę footprintów by wybrać żadany footprint."
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:1004
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib.cpp:813
 msgid "Used only for fields Footprint and Datasheet."
-msgstr ""
+msgstr "Używane tylko dla pól Footprint oraz Dokumentacja."
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:1143
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:41
@@ -4913,7 +5040,7 @@ msgstr "Jednostka:"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:37
 msgid "Interchangeable units:"
-msgstr "Jednostki zamienne:"
+msgstr "Wymienne elementy składowe:"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:48
 #: pcbnew/dialogs/dialog_create_array_base.cpp:71
@@ -4965,29 +5092,31 @@ msgstr "-90"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:50
 msgid "Orientation (degrees):"
-msgstr "Orientacja (stopnie):"
+msgstr "Orientacja (w stopniach):"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:52
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:73
 msgid "Select if the symbol is to be rotated when drawn"
-msgstr ""
+msgstr "Wybierz czy symbol może być obracany podczas rysowania"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:56
 msgid "Mirror around X axis"
-msgstr "Odbicie wokół osi X"
+msgstr "Odbij w osi X"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:56
 msgid "Mirror around Y axis"
-msgstr "Odbicie wokół osi Y"
+msgstr "Odbij w osi Y"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:58
 msgid "Aspect:"
-msgstr ""
+msgstr "Aspekt:"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:60
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:81
 msgid "Pick the graphical transformation to be used when displaying the symbol"
 msgstr ""
+"Zaznacz jakie transformacje graficzne mogą być używane przy wyświetlaniu "
+"symbolu"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:64
 msgid "Convert shape"
@@ -4998,15 +5127,17 @@ msgid ""
 "Use the alternate shape of this symbol.\n"
 "For gates, this is the \"De Morgan\" conversion"
 msgstr ""
+"Użyj alternatywnego kształtu tego symbolu.\n"
+"Dla bramek logicznych jest to konwersja \"De Morgan\"-a"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:70
 #: eeschema/dialogs/dialog_rescue_each_base.cpp:63
 msgid "Library Symbol:"
-msgstr "Symbol biblioteki:"
+msgstr "Symbole w bibliotece:"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:73
 msgid "Name of the symbol in the library to which this symbol is linked"
-msgstr ""
+msgstr "Nazwa symbolu w bibliotece z którym obecny symbol jest połączony"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:80
 #: kicad/dialogs/dialog_template_selector_base.cpp:39
@@ -5021,15 +5152,15 @@ msgstr "Zmień (jeśli trzeba)"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:92
 msgid "Symbol ID:"
-msgstr ""
+msgstr "ID symbolu:"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:97
 msgid "Unique ID that identifies the symbol"
-msgstr ""
+msgstr "Unikalny ID, który identyfikuje symbol"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:104
 msgid "Edit Spice Model"
-msgstr "Edytuj model SPICE"
+msgstr "Edycja modelu Spice"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:107
 msgid "Reset Field Properties"
@@ -5041,37 +5172,39 @@ msgid ""
 "value.\n"
 "Field values are not modified."
 msgstr ""
+"Ustala pozycję oraz styl pól, a także orientację symbolu do wartości "
+"domyślnych w bibliotece.\n"
+"Zawartość pól nie jest modyfikowana."
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:112
 msgid "Update Field Values"
-msgstr "Aktualizuj wartości pól"
+msgstr "Uaktualnij pola z wartościami"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:113
 msgid "Sets fields to the original library values"
-msgstr ""
+msgstr "Ustaw pola zgodnie z wartościami z biblioteki"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:121
-#, fuzzy
 msgid "Fields:"
-msgstr "Pola"
+msgstr "Pola:"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:135
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:32
 msgid "Move the selected optional field up one position"
-msgstr ""
+msgstr "Przesuwa wybrane pole w górę o jedną pozycję"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:140
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:37
 msgid "Move the selected optional field down one position"
-msgstr ""
+msgstr "Przesuń wybrane pole opcjonalne w dół o jedną pozycję"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:148
 msgid "Delete optional field"
-msgstr "Usuń jedno z pól dodatkowych"
+msgstr "Usuń dodatkowe pole"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:153
 msgid "Create new custom field"
-msgstr "Utwórz własne pole"
+msgstr "Tworzy nowe pole użytkownika"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:169
 #: eeschema/dialogs/dialog_lib_edit_text_base.cpp:101
@@ -5097,12 +5230,12 @@ msgstr "Pozycja poziomo:"
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:175
 #: eeschema/dialogs/dialog_lib_edit_text_base.cpp:107
 msgid "Align top"
-msgstr "Wyrównaj do góry"
+msgstr "Wyrównaj do górnej krawędzi"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:175
 #: eeschema/dialogs/dialog_lib_edit_text_base.cpp:107
 msgid "Align bottom"
-msgstr "Wyrównaj do dołu"
+msgstr "Wyrównaj do dolnej krawędzi"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:177
 msgid "Vertical Position:"
@@ -5121,17 +5254,17 @@ msgstr "Pokaż"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:191
 msgid "Make selected field visible"
-msgstr ""
+msgstr "Uwidacznia wybrane pole"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:196
 msgid "Rotated 90 degrees the selected field"
-msgstr ""
+msgstr "Obrót wybranego pola o 90 st"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:203
 #: eeschema/dialogs/dialog_edit_label_base.cpp:75
 #: eeschema/dialogs/dialog_lib_edit_text_base.cpp:95
 msgid "Bold and italic"
-msgstr "Pogrubiona kursywa"
+msgstr "Pogrubienie i kursywa"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:205
 msgid "Font Style:"
@@ -5140,21 +5273,21 @@ msgstr "Styl czcionki:"
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:215
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:119
 msgid "Field Name:"
-msgstr "Pole nazwy:"
+msgstr "Nazwa pola:"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:220
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:229
 msgid "Name of the selected field. Fixed field names are not editable"
-msgstr ""
+msgstr "Nazwa wybranego pola. Stałe nazwy pól nie mogą być modyfikowane"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:224
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:128
 msgid "Field Value:"
-msgstr "Pole wartości:"
+msgstr "Wartość pola:"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:233
 msgid "Open in Browser"
-msgstr "Otwówiera w przeglądarce"
+msgstr "Otwórz w przeglądarce"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:234
 msgid ""
@@ -5167,11 +5300,11 @@ msgstr ""
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:247
 msgid "Font size:"
-msgstr "Rozmiar czcionki:"
+msgstr "Rozmiar tekstu:"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:252
 msgid "Font Size of the selected field"
-msgstr ""
+msgstr "Rozmiar czcionki wybranego pola"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:256
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:269
@@ -5225,7 +5358,7 @@ msgstr "Pozycja X:"
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:265
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:278
 msgid "X coordinate of the selected field"
-msgstr ""
+msgstr "Współrzędna X wybranego pola"
 
 #: eeschema/dialogs/dialog_edit_component_in_schematic_base.cpp:273
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:97
@@ -5242,52 +5375,50 @@ msgstr "Właściwości symbolu"
 #: eeschema/dialogs/dialog_edit_components_libid.cpp:366
 #, c-format
 msgid "Symbol library identifier \"%s\" is not valid at row %d!"
-msgstr ""
+msgstr "Identyfikator symbolu \"%s\" w rzędzie %d nie jest prawidłowy!"
 
 #: eeschema/dialogs/dialog_edit_components_libid.cpp:486
 #, c-format
 msgid "Available Candidates for %s "
-msgstr ""
+msgstr "Dostępni kandydaci dla %s "
 
 #: eeschema/dialogs/dialog_edit_components_libid.cpp:490
 #, c-format
 msgid "Candidates count %d "
-msgstr ""
+msgstr "Liczba kandydatów %d "
 
 #: eeschema/dialogs/dialog_edit_components_libid.cpp:500
 #, c-format
 msgid "%u link(s) mapped, %d not found"
-msgstr ""
+msgstr "%u łącz zmapowano, nie odnaleziono %d"
 
 #: eeschema/dialogs/dialog_edit_components_libid.cpp:504
 #, c-format
 msgid "All %u link(s) resolved"
-msgstr ""
+msgstr "Wszystkie %u łącza zostały rozpoznane"
 
 #: eeschema/dialogs/dialog_edit_components_libid.cpp:527
 msgid "Invalid symbol library identifier"
-msgstr ""
+msgstr "Niepoprawny identyfikator symbolu w bibliotece"
 
 #: eeschema/dialogs/dialog_edit_components_libid_base.cpp:39
 msgid "Symbols"
-msgstr "Symbol"
+msgstr "Symboli"
 
 #: eeschema/dialogs/dialog_edit_components_libid_base.cpp:40
-#, fuzzy
 msgid "Current Library Reference"
-msgstr "Bieżą&ca biblioteka"
+msgstr "Bieżący odnośnik w bibliotece"
 
 #: eeschema/dialogs/dialog_edit_components_libid_base.cpp:41
-#, fuzzy
 msgid "New Library Reference"
-msgstr "Nowa biblioteka"
+msgstr "Nowy odnośnik w bibliotece"
 
 #: eeschema/dialogs/dialog_edit_components_libid_base.cpp:70
 msgid ""
 "Warning: Changes made from this dialog cannot be undone, after closing it."
 msgstr ""
-"Ostrzeżenie: Zmian dokonanych w tym oknie dialogowym nie można cofnąć, po "
-"jego zamknięciu."
+"Ostrzeżenie: Zmiany wykonane w tym oknie nie mogą zostać cofnięte po jego "
+"zamknięciu."
 
 #: eeschema/dialogs/dialog_edit_components_libid_base.cpp:96
 msgid "Browse Libraries"
@@ -5295,7 +5426,7 @@ msgstr "Przeglądaj biblioteki"
 
 #: eeschema/dialogs/dialog_edit_components_libid_base.cpp:99
 msgid "Map Orphans"
-msgstr ""
+msgstr "Mapuj osierocone symbole"
 
 #: eeschema/dialogs/dialog_edit_components_libid_base.cpp:100
 msgid ""
@@ -5303,11 +5434,14 @@ msgid ""
 "try to find a candidate having the same name in one of loaded symbol "
 "libraries"
 msgstr ""
+"Jeśli pewne komponenty są osierocone (połączone symbole nie zostały "
+"odnalezione),\n"
+"spróbuj odnaleźć podobne symbole posiadające tą samą nazwę w jednej z "
+"bibliotek symboli"
 
 #: eeschema/dialogs/dialog_edit_components_libid_base.h:64
-#, fuzzy
 msgid "Symbol Library References"
-msgstr "Edytor bibliotek symboli"
+msgstr "Odnośniki w bibliotece symboli"
 
 #: eeschema/dialogs/dialog_edit_label.cpp:197
 msgid "Global Label Properties"
@@ -5323,7 +5457,7 @@ msgstr "Właściwości etykiety"
 
 #: eeschema/dialogs/dialog_edit_label.cpp:209
 msgid "Hierarchical Sheet Pin Properties."
-msgstr "Właściwości hierarchicznego arkusza pinów"
+msgstr "Właściwości hierarchicznego arkusza pinów."
 
 #: eeschema/dialogs/dialog_edit_label.cpp:213
 #: pcbnew/dialogs/dialog_pcb_text_properties_base.h:77
@@ -5377,14 +5511,12 @@ msgid "Down"
 msgstr "Dół"
 
 #: eeschema/dialogs/dialog_edit_label_base.cpp:71
-#, fuzzy
 msgid "O&rientation:"
-msgstr "Orientacja"
+msgstr "Orientacja:"
 
 #: eeschema/dialogs/dialog_edit_label_base.cpp:77
-#, fuzzy
 msgid "St&yle:"
-msgstr "Styl"
+msgstr "Styl:"
 
 #: eeschema/dialogs/dialog_edit_label_base.cpp:81
 #: eeschema/dialogs/dialog_sch_edit_sheet_pin.cpp:30 eeschema/pin_type.cpp:38
@@ -5416,9 +5548,8 @@ msgid "Passive"
 msgstr "Pasywny"
 
 #: eeschema/dialogs/dialog_edit_label_base.cpp:83
-#, fuzzy
 msgid "S&hape:"
-msgstr "Kształt"
+msgstr "Kształt:"
 
 #: eeschema/dialogs/dialog_edit_label_base.h:68
 msgid "Text Editor"
@@ -5426,7 +5557,7 @@ msgstr "Edytor tekstu"
 
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib.cpp:280
 msgid "Illegal reference.  References must start with a letter."
-msgstr ""
+msgstr "Niepoprawne oznaczenie. Oznaczenie musi rozpoczynać się od litery."
 
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib.cpp:296
 #, c-format
@@ -5437,7 +5568,7 @@ msgid ""
 msgstr ""
 "Została wpisana nowa nazwa dla tego symbolu\n"
 "Alias %s już istnieje!\n"
-"Nie można uaktualnić tego symbolu."
+"Nie można uaktualnić tego symbolu"
 
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib.cpp:768
 msgid "Chip Name"
@@ -5454,13 +5585,12 @@ msgstr "Dodaj nowe pole użytkownika"
 
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:57
 msgid "Edit Spice model"
-msgstr "Edycja modelu Spice"
+msgstr "Edytuj model Spice"
 
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:71
 #: eeschema/dialogs/dialog_lib_edit_text_base.cpp:103
-#, fuzzy
 msgid "Horizontal Align:"
-msgstr "Odstęp poziomo:"
+msgstr "Wyrównanie poziomo:"
 
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:77
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:99
@@ -5474,9 +5604,8 @@ msgstr "Górna"
 
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:79
 #: eeschema/dialogs/dialog_lib_edit_text_base.cpp:109
-#, fuzzy
 msgid "Vertical Align:"
-msgstr "Odstęp pionowo:"
+msgstr "Wyrównanie pionowo:"
 
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:95
 msgid "Check if you want this field visible"
@@ -5524,7 +5653,7 @@ msgstr "Pozycja Y:"
 
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:180
 msgid "The Y coordinate of the text relative to the symbol anchor position"
-msgstr "Współrzędna Y tekstu względem pozycji zakotwiczenia symbolu"
+msgstr "Współrzędna Y tekstu względem pozycji zaczepienia symbolu"
 
 #: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.h:96
 msgid "Field Properties"
@@ -5545,20 +5674,19 @@ msgstr "Pełny"
 
 #: eeschema/dialogs/dialog_edit_line_style_base.cpp:62
 msgid "Dashed"
-msgstr "linia przerywana"
+msgstr "Kreskowana"
 
 #: eeschema/dialogs/dialog_edit_line_style_base.cpp:62
 msgid "Dotted"
-msgstr "linia kropkowana"
+msgstr "Kropkowana"
 
 #: eeschema/dialogs/dialog_edit_line_style_base.cpp:62
 msgid "Dash-Dot"
-msgstr "lina - kropka"
+msgstr "Kreska-kropka"
 
 #: eeschema/dialogs/dialog_edit_line_style_base.cpp:64
-#, fuzzy
 msgid "Line Style:"
-msgstr "Styl linii"
+msgstr "Styl linii:"
 
 #: eeschema/dialogs/dialog_edit_line_style_base.h:74
 msgid "Line Style"
@@ -5566,7 +5694,7 @@ msgstr "Styl linii"
 
 #: eeschema/dialogs/dialog_edit_one_field.cpp:223
 msgid "Illegal reference field value!"
-msgstr "Nieprawidłowa wartość pola referencyjnego!"
+msgstr "Pole oznaczenie nie jest poprawne!"
 
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:44
 #: eeschema/dialogs/dialog_libedit_options_base.cpp:41
@@ -5575,15 +5703,15 @@ msgstr "Rozmiar siatki:"
 
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:57
 msgid "&Bus thickness:"
-msgstr "Gru&bość magistrali:"
+msgstr "Grubość magistral:"
 
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:68
 msgid "&Line thickness:"
-msgstr "Grubość &linii:"
+msgstr "Grubość linii:"
 
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:79
 msgid "&Part ID notation:"
-msgstr "Notacja ID części:"
+msgstr "Notacja części składowych elementów:"
 
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:83
 #: eeschema/dialogs/dialog_plot_schematic_base.cpp:49
@@ -5621,7 +5749,7 @@ msgstr "_1"
 #: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:95
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:52
 msgid "Icon scale:"
-msgstr "Skalowanie ikon:"
+msgstr "Skala ikon:"
 
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:99
 #: eeschema/dialogs/dialog_libedit_options_base.cpp:151
@@ -5656,7 +5784,7 @@ msgstr ""
 
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:127
 msgid "S&how hidden pins"
-msgstr "Pokaż ukryte wyprowadzenia"
+msgstr "Pokaż ukryte piny"
 
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:130
 msgid "Show page limi&ts"
@@ -5664,12 +5792,12 @@ msgstr "Pokaż granice strony"
 
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:134
 msgid "Footprint previews in symbol chooser (experimental)"
-msgstr "Podgląd footprintów w oknie wyboru symboli (eksperymentalnie)"
+msgstr "Podgląd footprintu przy wyborze symbolu (eksperymentalny)"
 
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:144
 #: pcbnew/class_text_mod.cpp:391
 msgid "Display"
-msgstr "Pokazuj"
+msgstr "Widok"
 
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:157
 msgid "&Measurement units:"
@@ -5695,18 +5823,16 @@ msgid "Def&ault text size:"
 msgstr "Domyślny rozmiar tekstu:"
 
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:212
-#, fuzzy
 msgid "&Auto-save time interval:"
-msgstr "Auto zapis tworzony co"
+msgstr "Auto zapis tworzony co:"
 
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:217
 msgid ""
 "Delay after the first change to create a backup file of the board on disk.\n"
 "If set to 0, auto backup is disabled"
 msgstr ""
-"Czas opóźnienia po pierwszej zmianie w projekcie, po której tworzony\n"
-"jest plik kopii zapasowej na dysku. Jeśli ustawienie wynosi 0 tworzenie\n"
-"kopii zapasowej pliku jest wyłączone."
+"Czas opóźnienia utworzenia kopii zapasowej na dysku po pierwszej zmianie.\n"
+"Ustawienie 0 spowoduje wyłączenie automatycznej kopii zapasowej"
 
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:221
 msgid "minutes"
@@ -5714,15 +5840,15 @@ msgstr "minut"
 
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:234
 msgid "A&utomatically place symbol fields"
-msgstr "A&utomatycznie umieszczaj pola symboli"
+msgstr "Automatyczne rozmieszczanie pól symboli"
 
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:237
 msgid "A&llow field autoplace to change justification"
-msgstr "Pozwó&l automatycznie rozmieszczać i wyrównywać pola "
+msgstr "Zezwól na zmianę wyrównania przy rozkładzie automatycznym"
 
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:240
 msgid "Al&ways align autoplaced fields to the 50 mil grid"
-msgstr "Za&wsze wyrównaj automatycznie rozmieszczone pola do siatki 50 milsów"
+msgstr "Zawsze wyrównuj automatycznie rozmieszczane pola do siatki 50 mils"
 
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:250
 msgid "Editing"
@@ -5734,7 +5860,7 @@ msgstr "Skróty klawiszowe:"
 
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:285
 msgid "Cen&ter and warp cursor on zoom"
-msgstr "Przesuń kursor i wyśrodkuj na planszy przy powiększaniu"
+msgstr "Centruj i przesuwaj kursor przy powiększaniu"
 
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:286
 #: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:74
@@ -5743,12 +5869,12 @@ msgstr "Zachowaj bieżącą pozycję kursora podczas powiększania"
 
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:290
 msgid "Use touchpa&d to pan"
-msgstr "Użyj touchpada do przesuwania"
+msgstr "Użyj płytki &dotykowej by panoramować"
 
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:291
 #: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:79
 msgid "Use touchpad to pan canvas"
-msgstr "Użyj touchpada aby przesuwać planszę"
+msgstr "Użyj płytki dotykowej do panoramowania widoku"
 
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:295
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:94
@@ -5757,11 +5883,11 @@ msgstr "Panoramuj podczas przesuwania obiektów"
 
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:305
 msgid "Controls"
-msgstr "Sterowanie"
+msgstr "Zachowanie"
 
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:319
 msgid "User defined field names for schematic components. "
-msgstr "Nazwy pól użytkownika dla symboli schematowych."
+msgstr "Nazwy pól użytkownika dla symboli schematowych. "
 
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:343
 #: eeschema/lib_pin.cpp:1724
@@ -5780,9 +5906,8 @@ msgid "De&lete"
 msgstr "Usuń"
 
 #: eeschema/dialogs/dialog_eeschema_options_base.cpp:379
-#, fuzzy
 msgid "Field Name Templates"
-msgstr "Nazwa pola"
+msgstr "Wzorce nazw pól"
 
 #: eeschema/dialogs/dialog_eeschema_options_base.h:138
 msgid "Schematic Editor Options"
@@ -5809,9 +5934,9 @@ msgid "Annotation required!"
 msgstr "Wymagana numeracja elementów!"
 
 #: eeschema/dialogs/dialog_erc.cpp:593
-#, fuzzy, c-format
+#, c-format
 msgid "Pin %s on %s is connected to both %s and %s"
-msgstr "Pin %s (%s) symbolu %s jest połączony z "
+msgstr "Pin %s w %s jest połączony zarówno do %s jak i %s"
 
 #: eeschema/dialogs/dialog_erc.cpp:627 pcbnew/drc.cpp:533
 msgid "Finished"
@@ -5858,39 +5983,42 @@ msgid "ERC"
 msgstr "ERC"
 
 #: eeschema/dialogs/dialog_erc_base.cpp:123
-#, fuzzy
 msgid "Label to Label Connections:"
-msgstr "Połączenia etykieta do etykiety"
+msgstr "Połączenia pomiędzy etykietami:"
 
 #: eeschema/dialogs/dialog_erc_base.cpp:125
 msgid "Test similar labels"
-msgstr "Sprawdź podobne etykiety"
+msgstr "Testuj na podobność etykiet"
 
 #: eeschema/dialogs/dialog_erc_base.cpp:126
 msgid ""
 "Similar labels are labels (inside a sheet) which differs only by upper/lower "
 "case"
 msgstr ""
+"Etykiety podobne do siebie (wewnątrz arkusza) różnią się tylko wielkością "
+"liter w nazwie"
 
 #: eeschema/dialogs/dialog_erc_base.cpp:130
-#, fuzzy
 msgid "Test single instances of global labels"
-msgstr "Sprawdź unikalne etykiety globalne"
+msgstr "Testuj czy występują osamotnione etykiety globalne"
 
 #: eeschema/dialogs/dialog_erc_base.cpp:131
 msgid ""
 "Global labels are used to connect signals across the full hierarchy.\n"
 "They are expected to be at least two labels with the same name."
 msgstr ""
+"Etykiety globalne są używane do łączenia sygnałów pomiędzy arkuszami w "
+"hierarchii.\n"
+"W kompletnym schemacie powinny występować przynajmniej dwie takie same "
+"etykiety."
 
 #: eeschema/dialogs/dialog_erc_base.cpp:139
-#, fuzzy
 msgid "Pin to Pin Connections:"
-msgstr "Połączenia pin do pinu"
+msgstr "Połączenia pomiędzy wyprowadzeniami:"
 
 #: eeschema/dialogs/dialog_erc_base.cpp:144
 msgid "Initialize to Default"
-msgstr "Zresetuj do ustawień domyślnych"
+msgstr "Zainicjalizuj do domyślnych"
 
 #: eeschema/dialogs/dialog_erc_base.h:86 eeschema/menubar_libedit.cpp:236
 msgid "Electrical Rules Checker"
@@ -5903,9 +6031,8 @@ msgid "Field"
 msgstr "Pole"
 
 #: eeschema/dialogs/dialog_fields_editor_global.cpp:544
-#, fuzzy
 msgid "Group By"
-msgstr "Grupuj symbole"
+msgstr "Grupuj według"
 
 #: eeschema/dialogs/dialog_fields_editor_global.cpp:694
 #: eeschema/dialogs/dialog_rescue_each.cpp:113 eeschema/lib_field.cpp:440
@@ -5938,12 +6065,11 @@ msgstr "Grupuj symbole"
 
 #: eeschema/dialogs/dialog_fields_editor_global_base.cpp:31
 msgid "Group components together based on common properties"
-msgstr ""
+msgstr "Grupuje komponenty razem na postawie wspólnych właściwości"
 
 #: eeschema/dialogs/dialog_fields_editor_global_base.h:72
-#, fuzzy
 msgid "Symbol Fields"
-msgstr "Symbol"
+msgstr "Pola symbolu"
 
 #: eeschema/dialogs/dialog_global_sym_lib_table_config.cpp:89
 #, c-format
@@ -5952,15 +6078,18 @@ msgid ""
 "\n"
 "%s"
 msgstr ""
+"Wystąpił błąd podczas zapisu pustej tabeli bibliotek symboli.\n"
+"\n"
+"%s"
 
 #: eeschema/dialogs/dialog_global_sym_lib_table_config.cpp:103
 msgid "Please select a symbol library table file."
-msgstr ""
+msgstr "Proszę wybrać plik z tabelą bibliotek symboli."
 
 #: eeschema/dialogs/dialog_global_sym_lib_table_config.cpp:113
 #, c-format
 msgid "File \"%s\" not found."
-msgstr "Pliku \"%s\" nie znaleziono."
+msgstr "Plik \"%s\" nie został znaleziony."
 
 #: eeschema/dialogs/dialog_global_sym_lib_table_config.cpp:127
 #, c-format
@@ -5969,6 +6098,9 @@ msgid ""
 "\n"
 "%s"
 msgstr ""
+"Plil \"%s\" nie jest poprawnym plikiem tabeli symboli.\n"
+"\n"
+"%s"
 
 #: eeschema/dialogs/dialog_global_sym_lib_table_config.cpp:147
 #, c-format
@@ -5981,6 +6113,13 @@ msgid ""
 "\n"
 "\"%s\"."
 msgstr ""
+"Nie można skopiować pliku globalnej tabeli symboli:\n"
+"\n"
+" \"%s\"\n"
+"\n"
+":do:\n"
+"\n"
+"\"%s\"."
 
 #: eeschema/dialogs/dialog_global_sym_lib_table_config.cpp:164
 #, c-format
@@ -5989,6 +6128,9 @@ msgid ""
 "\n"
 "%s"
 msgstr ""
+"Wystąpił błąd podczas wczytywania globalnej tabeli bibliotek:\n"
+"\n"
+"%s"
 
 #: eeschema/dialogs/dialog_global_sym_lib_table_config_base.cpp:22
 msgid ""
@@ -5998,39 +6140,50 @@ msgid ""
 "of the options below.  If you are not sure which option to select, please "
 "use the default selection."
 msgstr ""
+"KiCad został uruchomiony po raz pierwszy z użyciem nowego systemu dostępu do "
+"bibliotek przez tabele bibliotek symboli. By program KiCad miał dostęp do "
+"bibliotek symboli, należy skonfigurować globalną tabelę bibliotek symboli. "
+"Proszę wybrać jedną z opcji pokazanych poniżej. Jeśli nie jest pewne, którą "
+"opcję wybrać, prosimy wybrać zalecaną opcję domyślną."
 
 #: eeschema/dialogs/dialog_global_sym_lib_table_config_base.cpp:29
 msgid "Copy default global symbol library table (recommended)"
-msgstr ""
+msgstr "Kopiuj domyślną globalną tabelę bibliotek symboli (Zalecane)"
 
 #: eeschema/dialogs/dialog_global_sym_lib_table_config_base.cpp:31
 msgid ""
 "Select this option if you not sure about configuring the global symbol "
 "library table"
 msgstr ""
+"Wybierz tę opcję jeśli nie jesteś pewien jak skonfigurować globalną tabelę "
+"bibliotek"
 
 #: eeschema/dialogs/dialog_global_sym_lib_table_config_base.cpp:35
 msgid "Copy custom global symbol library table"
-msgstr ""
+msgstr "Kopiuj własną globalną tabelę bibliotek symboli"
 
 #: eeschema/dialogs/dialog_global_sym_lib_table_config_base.cpp:36
 msgid ""
 "Select this option to copy a symbol library table file other than the default"
 msgstr ""
+"Wybierz tę opcję by jako domyślną tabelę skopiować inną gotową tabelę "
+"bibliotek"
 
 #: eeschema/dialogs/dialog_global_sym_lib_table_config_base.cpp:40
 msgid "Create an empty global symbol library table"
-msgstr ""
+msgstr "Utwórz nową globalną tabelę bibliotek symboli"
 
 #: eeschema/dialogs/dialog_global_sym_lib_table_config_base.cpp:41
 msgid ""
 "Select this option to define symbol libraries in project specific library "
 "tables"
 msgstr ""
+"Wybierz tą opcję by wybrać możliwość użycia bibliotek symboli z lokalnej "
+"tabeli bibliotek symboli projektu"
 
 #: eeschema/dialogs/dialog_global_sym_lib_table_config_base.cpp:48
 msgid "Select global symbol library table file:"
-msgstr ""
+msgstr "Wybierz plik zawierający globalną tabelę bibliotek symboli:"
 
 #: eeschema/dialogs/dialog_global_sym_lib_table_config_base.cpp:52
 msgid "Select a file"
@@ -6038,7 +6191,7 @@ msgstr "Wybierz plik"
 
 #: eeschema/dialogs/dialog_global_sym_lib_table_config_base.h:58
 msgid "Configure Global Symbol Library Table"
-msgstr ""
+msgstr "Konfiguruje globalną tabelę bibliotek symboli"
 
 #: eeschema/dialogs/dialog_lib_edit_draw_item_base.cpp:34
 msgid "&Width:"
@@ -6046,9 +6199,8 @@ msgstr "Szerokość:"
 
 #: eeschema/dialogs/dialog_lib_edit_draw_item_base.cpp:51
 #: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:81
-#, fuzzy
 msgid "Sharing:"
-msgstr "Współdzielenie"
+msgstr "Współdzielenie:"
 
 #: eeschema/dialogs/dialog_lib_edit_draw_item_base.cpp:63
 msgid "Common to all &units in component"
@@ -6060,9 +6212,8 @@ msgid "Common to all body &styles (DeMorgan)"
 msgstr "Wspólne dla wszystkich stylów (DeMorgan)"
 
 #: eeschema/dialogs/dialog_lib_edit_draw_item_base.cpp:84
-#, fuzzy
 msgid "Fill Style:"
-msgstr "Styl wypełnienia"
+msgstr "Styl wypełnienia:"
 
 #: eeschema/dialogs/dialog_lib_edit_draw_item_base.cpp:99
 msgid "Do &not fill"
@@ -6110,12 +6261,11 @@ msgstr "&Styl grafiki:"
 
 #: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:83
 msgid "Common to all &units in symbol"
-msgstr ""
+msgstr "Wspólne dla wszystkich elementów składowych symbolu"
 
 #: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:93
-#, fuzzy
 msgid "Schematic Properties:"
-msgstr "Właściwości"
+msgstr "Właściwości schematu:"
 
 #: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:95
 msgid "&Visible"
@@ -6135,11 +6285,11 @@ msgstr "Długość:"
 
 #: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:150
 msgid "Pin Pos X:"
-msgstr ""
+msgstr "Pozycja pinu X:"
 
 #: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:161
 msgid "Pin Pos Y:"
-msgstr ""
+msgstr "Pozycja pinu Y:"
 
 #: eeschema/dialogs/dialog_lib_edit_pin_base.h:106
 msgid "Pin Properties"
@@ -6183,7 +6333,7 @@ msgstr "Wybierz"
 
 #: eeschema/dialogs/dialog_lib_edit_text_base.cpp:65
 msgid "Power symbol value text cannot be modified!"
-msgstr ""
+msgstr "Wartość portu zasilania nie może być modyfikowana!"
 
 #: eeschema/dialogs/dialog_lib_edit_text_base.cpp:77
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:213
@@ -6210,19 +6360,21 @@ msgid "Library Text Properties"
 msgstr "Właściwości tekstów biblioteki"
 
 #: eeschema/dialogs/dialog_lib_new_component_base.cpp:22
-#, fuzzy
 msgid "General Settings:"
-msgstr "Ustawienia główne"
+msgstr "Ustawienia główne:"
 
 #: eeschema/dialogs/dialog_lib_new_component_base.cpp:34
 msgid "Symbol &name:"
-msgstr "&Nazwa symbolu:"
+msgstr "Nazwa symbolu:"
 
 #: eeschema/dialogs/dialog_lib_new_component_base.cpp:36
 msgid ""
 "This is the symbol name in library,\n"
 "and also the default component value when loaded in the schematic."
 msgstr ""
+"Jest to nazwa symbolu w bibliotece,\n"
+"a jest to też domyślna wartość komponentu podczas umieszczania go na "
+"schemacie."
 
 #: eeschema/dialogs/dialog_lib_new_component_base.cpp:43
 msgid "Default reference designator:"
@@ -6238,20 +6390,19 @@ msgstr "Liczba części składowych w paczce:"
 
 #: eeschema/dialogs/dialog_lib_new_component_base.cpp:63
 msgid "Create symbol with alternate body style (DeMorgan)"
-msgstr ""
+msgstr "Twórz symbol z alternatywnym stylem graficznym (DeMorgan)"
 
 #: eeschema/dialogs/dialog_lib_new_component_base.cpp:66
 msgid "Create symbol as power symbol"
-msgstr ""
+msgstr "Twórz symbol jako port zasilania"
 
 #: eeschema/dialogs/dialog_lib_new_component_base.cpp:69
 msgid "Units are not interchangeable"
 msgstr "Części składowe nie są zamienne"
 
 #: eeschema/dialogs/dialog_lib_new_component_base.cpp:81
-#, fuzzy
 msgid "Pin Settings:"
-msgstr "Ustawienia strony"
+msgstr "Właściwości pinu:"
 
 #: eeschema/dialogs/dialog_lib_new_component_base.cpp:92
 msgid "Pin text position offset:"
@@ -6299,7 +6450,7 @@ msgstr "50"
 
 #: eeschema/dialogs/dialog_libedit_options_base.cpp:176
 msgid "Show pin &electrical type"
-msgstr "Pokaż pin i jego typ &elektryczny"
+msgstr "Pokaż typ elektryczny pinu"
 
 #: eeschema/dialogs/dialog_libedit_options_base.h:93
 msgid "Library Editor Options"
@@ -6311,11 +6462,12 @@ msgstr "Format domyślny"
 
 #: eeschema/dialogs/dialog_netlist.cpp:397
 msgid "Reformat passive symbol values"
-msgstr ""
+msgstr "Reformatuj wartości pasywnych symboli"
 
 #: eeschema/dialogs/dialog_netlist.cpp:399
 msgid "Reformat passive symbol values e.g. 1M -> 1Meg"
 msgstr ""
+"Wykonuje proces reformatowania wartości elementów pasywnych, np. 1M -> 1Meg"
 
 #: eeschema/dialogs/dialog_netlist.cpp:404
 msgid "Simulator command:"
@@ -6345,19 +6497,19 @@ msgstr "%s Eksportuj"
 
 #: eeschema/dialogs/dialog_netlist.cpp:795
 msgid "This plugin already exists. Abort"
-msgstr "Ta wtyczka już istnieje. Przerwano."
+msgstr "Ta wtyczka już istnieje. Przerwano"
 
 #: eeschema/dialogs/dialog_netlist.cpp:822
 msgid "Error. You must provide a command String"
-msgstr "Błąd. Musisz wypełnić pole \"Polecenie netlisty\""
+msgstr "Błąd. Musisz wypełnić pole Polecenie netlisty"
 
 #: eeschema/dialogs/dialog_netlist.cpp:828
 msgid "Error. You must provide a Title"
-msgstr "Błąd. Musisz wypełnić pole \"Tytuł\""
+msgstr "Błąd. Musisz wypełnić pole Tytuł"
 
 #: eeschema/dialogs/dialog_netlist.cpp:880
 msgid "Do not forget to choose a title for this netlist control page"
-msgstr "Nie zapomnij wypełnić pola \"Tytuł\""
+msgstr "Nie zapomnij wybrać i wypełnić pola Tytuł dla tej zakładki"
 
 #: eeschema/dialogs/dialog_netlist_base.cpp:46
 msgid "Generate Netlist"
@@ -6407,6 +6559,8 @@ msgid ""
 "Do you want to use a path relative to\n"
 "\"%s\""
 msgstr ""
+"Czy chcesz użyć ścieżki względnej do\n"
+"\"%s\""
 
 #: eeschema/dialogs/dialog_plot_schematic.cpp:185
 #: eeschema/dialogs/dialog_plot_schematic.cpp:193
@@ -6479,14 +6633,12 @@ msgid "HPGL"
 msgstr "HPGL"
 
 #: eeschema/dialogs/dialog_plot_schematic_base.cpp:43
-#, fuzzy
 msgid "Output Format:"
-msgstr "Format wyjściowy"
+msgstr "Format wyjściowy:"
 
 #: eeschema/dialogs/dialog_plot_schematic_base.cpp:47
-#, fuzzy
 msgid "Paper Options:"
-msgstr "Ustawienia papieru"
+msgstr "Ustawienia papieru:"
 
 #: eeschema/dialogs/dialog_plot_schematic_base.cpp:49
 #: eeschema/dialogs/dialog_plot_schematic_base.cpp:61
@@ -6504,9 +6656,8 @@ msgstr "Rozmiar strony:"
 
 #: eeschema/dialogs/dialog_plot_schematic_base.cpp:55
 #: pcbnew/dialogs/dialog_plot_base.cpp:269
-#, fuzzy
 msgid "HPGL Options:"
-msgstr "Opcje HPGL"
+msgstr "Opcje HPGL:"
 
 #: eeschema/dialogs/dialog_plot_schematic_base.cpp:57
 msgid "Page size:"
@@ -6546,30 +6697,28 @@ msgstr "E"
 
 #: eeschema/dialogs/dialog_plot_schematic_base.cpp:67
 msgid "Bottom left"
-msgstr ""
+msgstr "Dolny lewy róg"
 
 #: eeschema/dialogs/dialog_plot_schematic_base.cpp:67
 msgid "Center on page"
-msgstr "Wyśrodkuj na stronie"
+msgstr "Wycentruj na stronie"
 
 #: eeschema/dialogs/dialog_plot_schematic_base.cpp:69
-#, fuzzy
 msgid "Align:"
-msgstr "Wyrównaj"
+msgstr "Ułożenie:"
 
 #: eeschema/dialogs/dialog_plot_schematic_base.cpp:73
 msgid "Pen width:"
-msgstr "Szerokość pisaka:"
+msgstr "Grubość pisaka:"
 
 #: eeschema/dialogs/dialog_plot_schematic_base.cpp:87
 #: pcbnew/dialogs/dialog_plot_base.cpp:83
-#, fuzzy
 msgid "General Options:"
-msgstr "Opcje główne"
+msgstr "Opcje główne:"
 
 #: eeschema/dialogs/dialog_plot_schematic_base.cpp:89
 msgid "Default line thickness:"
-msgstr ""
+msgstr "Domyślna grubość linii:"
 
 #: eeschema/dialogs/dialog_plot_schematic_base.cpp:94
 msgid ""
@@ -6596,9 +6745,8 @@ msgid "Black and white"
 msgstr "Czarno-biały"
 
 #: eeschema/dialogs/dialog_plot_schematic_base.cpp:100
-#, fuzzy
 msgid "Output Mode:"
-msgstr "Wyjście, aktywny niski"
+msgstr "Tryb wyjściowy:"
 
 #: eeschema/dialogs/dialog_plot_schematic_base.cpp:102
 #: pcbnew/dialogs/dialog_SVG_print_base.cpp:93
@@ -6618,7 +6766,7 @@ msgstr "Rysuj opis arkusza i tabliczkę tytułową"
 
 #: eeschema/dialogs/dialog_plot_schematic_base.cpp:108
 msgid "Print the frame references."
-msgstr ""
+msgstr "Drukuje referencyjną ramkę."
 
 #: eeschema/dialogs/dialog_plot_schematic_base.cpp:120
 msgid "Plot Current Page"
@@ -6706,6 +6854,12 @@ msgid ""
 "\n"
 "The following changes are recommended to update the project."
 msgstr ""
+"Ten schemat został utworzony z użyciem starszych bibliotek symboli, które "
+"mogą uszkodzić schemat.  Dla niektórych symboli może być wymagane połączenie "
+"z inną nazwą symbolu.  Niektóre z nich mogą wymagać \"odzyskania\" (zostaną "
+"skopiowane i nazwa ich zostanie zmieniona) w nowej bibliotece projektu.\n"
+"\n"
+"Zalecane są następujące zmiany by uaktualnić projekt."
 
 #: eeschema/dialogs/dialog_rescue_each.cpp:90
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:199
@@ -6719,12 +6873,12 @@ msgstr "Nazwa symbolu"
 
 #: eeschema/dialogs/dialog_rescue_each.cpp:109
 msgid "Action Taken"
-msgstr "Podjęte działania"
+msgstr "Zastosowana akcja"
 
 #: eeschema/dialogs/dialog_rescue_each.cpp:211
 #, c-format
 msgid "Instances of this symbol (%d items):"
-msgstr ""
+msgstr "Ilość wystąpień symbolu (%d części):"
 
 #: eeschema/dialogs/dialog_rescue_each.cpp:320
 msgid ""
@@ -6734,10 +6888,15 @@ msgid ""
 "This setting can be changed from the \"Symbol Libraries\" dialog,\n"
 "and the tool can be activated manually from the \"Tools\" menu."
 msgstr ""
+"Nie wyświetlać tego narzędzia?\n"
+"Nie zostaną wprowadzone żadne zmiany.\n"
+"\n"
+"To ustawienie może zostać zmienione w oknie \"Biblioteki symboli\",\n"
+"a narzędzie można aktywować ręcznie z menu \"Narzędzia\"."
 
 #: eeschema/dialogs/dialog_rescue_each.cpp:324
 msgid "Rescue Symbols"
-msgstr "Odzyskiwanie symboli..."
+msgstr "Odzyskaj symbole"
 
 #: eeschema/dialogs/dialog_rescue_each_base.cpp:22
 msgid "Symbols to update:"
@@ -6749,7 +6908,7 @@ msgstr "Instancje tego symbolu:"
 
 #: eeschema/dialogs/dialog_rescue_each_base.cpp:46
 msgid "Cached Symbol:"
-msgstr ""
+msgstr "Symbole pamięci podręcznej:"
 
 #: eeschema/dialogs/dialog_rescue_each_base.cpp:83
 msgid "Never Show Again"
@@ -6834,7 +6993,7 @@ msgstr "Zamień przez:"
 
 #: eeschema/dialogs/dialog_schematic_find_base.cpp:49
 msgid "Direction:"
-msgstr "Kierunek"
+msgstr "Kierunek:"
 
 #: eeschema/dialogs/dialog_schematic_find_base.cpp:58
 msgid "F&orward"
@@ -6870,7 +7029,7 @@ msgstr "Szukaj wszystkich &nazw i numerów pinów"
 
 #: eeschema/dialogs/dialog_schematic_find_base.cpp:94
 msgid "Search the current &sheet only"
-msgstr ""
+msgstr "Prze&szukaj wyłącznie bieżący arkusz"
 
 #: eeschema/dialogs/dialog_schematic_find_base.cpp:97
 msgid "Replace componen&t reference designators"
@@ -6894,30 +7053,30 @@ msgstr "Z&amień wszystkie"
 
 #: eeschema/dialogs/dialog_sim_settings.cpp:99
 msgid "You need to enable at least one source"
-msgstr ""
+msgstr "Należy włączyć przynajmniej jedno źródło"
 
 #: eeschema/dialogs/dialog_sim_settings.cpp:109
 msgid "You need to select DC source (sweep 1)"
-msgstr ""
+msgstr "Należy wybrać źródło DC (sweep 1)"
 
 #: eeschema/dialogs/dialog_sim_settings.cpp:148
 msgid "You need to select DC source (sweep 2)"
-msgstr ""
+msgstr "Należy wybrać źródło DC (sweep 2)"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:29
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:273
 msgid "Decade"
-msgstr ""
+msgstr "Dekada"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:29
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:273
 msgid "Octave"
-msgstr ""
+msgstr "Oktawa"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:29
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:273
 msgid "Linear"
-msgstr "Liniowy"
+msgstr "Liniowo"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:31
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:275
@@ -6925,33 +7084,29 @@ msgid "Frequency scale"
 msgstr "Skala częstotliwości"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:45
-#, fuzzy
 msgid "Number of points:"
-msgstr "Liczba punktów"
+msgstr "Liczba punktów:"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:55
-#, fuzzy
 msgid "Start frequency:"
-msgstr "Częstotliwość początkowa [Hz]"
+msgstr "Częstotliwość początkowa:"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:62
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:73
 msgid "Hertz"
-msgstr ""
+msgstr "Herców"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:66
-#, fuzzy
 msgid "Stop frequency:"
-msgstr "Częstotliwość końcowa [Hz]"
+msgstr "Częstotliwość końcowa:"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:87
 msgid "AC"
 msgstr "AC"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:93
-#, fuzzy
 msgid "DC sweep source 1:"
-msgstr "DC zasięg źródła 1"
+msgstr "Przemiatane źródło DC 1:"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:95
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:156
@@ -6960,15 +7115,13 @@ msgstr "Włącz"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:104
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:164
-#, fuzzy
 msgid "DC source:"
-msgstr "Źródło DC"
+msgstr "Źródło DC:"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:114
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:174
-#, fuzzy
 msgid "Starting voltage:"
-msgstr "Napięcie początkowe [V]"
+msgstr "Napięcie początkowe:"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:121
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:132
@@ -6976,38 +7129,34 @@ msgstr "Napięcie początkowe [V]"
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:181
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:192
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:203
-#, fuzzy
 msgid "Volts"
 msgstr "V"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:125
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:185
-#, fuzzy
 msgid "Final voltage:"
-msgstr "Napięcie końcowe [V]"
+msgstr "Napięcie końcowe:"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:136
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:196
-#, fuzzy
 msgid "Increment step:"
-msgstr "Krok zwiększenia [V]"
+msgstr "Krok:"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:154
-#, fuzzy
 msgid "DC sweep source 2:"
-msgstr "DC zasięg źródła 2"
+msgstr "Przemiatane źródło DC 2:"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:217
 msgid "DC Transfer"
-msgstr ""
+msgstr "Przenoszenie DC"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:221
 msgid "Distortion"
-msgstr "Zniekształcenia"
+msgstr "Zniekształcenie"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:236
 msgid "Measured node"
-msgstr "Węzeł mierzony"
+msgstr "Węzeł pomiarowy"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:246
 msgid "Reference node"
@@ -7015,7 +7164,7 @@ msgstr "Węzeł odniesienia"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:253
 msgid "(optional; default GND)"
-msgstr "(opcjonalnie, domyślnie GND)"
+msgstr "(opcjonalne; domyślnie GND)"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:257
 msgid "Noise source"
@@ -7027,7 +7176,7 @@ msgstr "Liczba punktów"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:294
 msgid "Start frequency [Hz]"
-msgstr "Częstotliwość początkowa [Hz]"
+msgstr "Częstotliwość początkowa [Hz]"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:301
 msgid "Stop frequency [Hz]"
@@ -7039,15 +7188,15 @@ msgstr "Szum"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:328
 msgid "This tab has no settings"
-msgstr ""
+msgstr "Ta zakładka nie posiada żadnych opcji"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:339
 msgid "Operating Point"
-msgstr ""
+msgstr "Punkt pracy"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:343
 msgid "Pole-Zero"
-msgstr ""
+msgstr "Pole-Zero"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:347
 msgid "Sensitivity"
@@ -7055,12 +7204,11 @@ msgstr "Czułość"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:351
 msgid "Transfer Function"
-msgstr ""
+msgstr "Funkcja przenoszenia"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:364
-#, fuzzy
 msgid "Time step:"
-msgstr "Krok czasu [s]"
+msgstr "Krok czasu:"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:371
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:385
@@ -7076,33 +7224,31 @@ msgstr "Krok czasu [s]"
 #: eeschema/dialogs/dialog_spice_model_base.cpp:551
 #: eeschema/dialogs/dialog_spice_model_base.cpp:562
 msgid "seconds"
-msgstr ""
+msgstr "sekund"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:378
-#, fuzzy
 msgid "Final time:"
-msgstr "Czas końcowy [s]"
+msgstr "Czas końcowy:"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:392
-#, fuzzy
 msgid "Initial time:"
-msgstr "Czas początkowy [s]"
+msgstr "Czas początkowy:"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:403
 msgid "(optional; default 0)"
-msgstr "(opcjonalnie, domyślnie 0)"
+msgstr "(opcionalny; domyślnie 0)"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:417
 msgid "Transient"
-msgstr ""
+msgstr "Czasowa"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:422
 msgid "Spice directives:"
-msgstr ""
+msgstr "Dyrektywy Spice:"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:431
 msgid "Load directives from schematic"
-msgstr ""
+msgstr "Załaduj dyrektywy ze schematu"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:438
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:29
@@ -7112,11 +7258,12 @@ msgstr "Własny"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:442
 msgid "Adjust passive symbol values (e.g. M -> Meg; 100 nF -> 100n)"
-msgstr ""
+msgstr "Dostrajaj wartości elementów pasywnych (np. M -> Meg; 100nF -> 100n)"
 
 #: eeschema/dialogs/dialog_sim_settings_base.cpp:445
 msgid "Add full path for .include library directives"
 msgstr ""
+"Dodaj pełną ścieżkę do dyrektyw .include wprowadzających dodatkowe biblioteki"
 
 #: eeschema/dialogs/dialog_sim_settings_base.h:132
 #: eeschema/sim/sim_plot_frame.cpp:179
@@ -7125,16 +7272,15 @@ msgstr "Ustawienia symulacji"
 
 #: eeschema/dialogs/dialog_spice_model.cpp:738
 msgid "Select library"
-msgstr "Wybór biblioteki"
+msgstr "Wybierz bibliotekę"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:30
 #: eeschema/dialogs/dialog_spice_model_base.cpp:233
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:29
 #: pcb_calculator/dialogs/dialog_regulator_data_base.cpp:47
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:163
-#, fuzzy
 msgid "Type:"
-msgstr "Typ"
+msgstr "Typ:"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:34
 #: eeschema/dialogs/dialog_spice_model_base.cpp:35
@@ -7147,7 +7293,7 @@ msgstr "Kondensator"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:37
 msgid "Inductor"
-msgstr "Indykcyjność"
+msgstr "Cewka"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:41
 msgid "Passive type"
@@ -7155,17 +7301,20 @@ msgstr "Typ pasywny"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:54
 msgid "Spice value in simulation"
-msgstr "Wartość SPICE w symulacji"
+msgstr "Wartość Spice w symulacji"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:67
 msgid ""
 "In Spice values,the decimal separator is the point.\n"
 "Values can use Spice unit symbols."
 msgstr ""
+"W wartościach Spice, separatorem dziesiętnym jest kropka.\n"
+"Wartości mogą używać symboli jednostek Spice."
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:71
 msgid "Spice unit symbols in values (case insensitive):"
 msgstr ""
+"Jednostki Spice w wartościach symboli (wielkość liter nie ma znaczenia):"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:81
 msgid "f"
@@ -7181,11 +7330,11 @@ msgstr "1e-15"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:93
 msgid "p"
-msgstr "f"
+msgstr "p"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:97
 msgid "pico"
-msgstr "piko"
+msgstr "pico"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:101
 msgid "1e-12"
@@ -7212,7 +7361,7 @@ msgstr "u"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:121
 msgid "micro"
-msgstr "mikro"
+msgstr "micro"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:125
 msgid "1e-6"
@@ -7224,7 +7373,7 @@ msgstr "m"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:133
 msgid "milli"
-msgstr "mili"
+msgstr "milli"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:137
 msgid "1e-3"
@@ -7279,18 +7428,16 @@ msgid "1e12"
 msgstr "1e12"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:210
-#, fuzzy
 msgid "Library:"
-msgstr "Biblioteka"
+msgstr "Biblioteka:"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:220
 msgid "Select file..."
 msgstr "Wybierz plik..."
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:226
-#, fuzzy
 msgid "Model:"
-msgstr "Model"
+msgstr "Model:"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:238
 msgid "Subcircuit"
@@ -7313,13 +7460,12 @@ msgid "Model"
 msgstr "Model"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:264
-#, fuzzy
 msgid "DC/AC analysis:"
-msgstr "Analiza DC/AC"
+msgstr "Analiza DC/AC:"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:273
 msgid "DC:"
-msgstr ""
+msgstr "DC:"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:282
 #: eeschema/dialogs/dialog_spice_model_base.cpp:304
@@ -7331,85 +7477,71 @@ msgstr ""
 #: eeschema/dialogs/dialog_spice_model_base.cpp:518
 #: eeschema/dialogs/dialog_spice_model_base.cpp:607
 msgid "Volts/Amps"
-msgstr ""
+msgstr "V/A"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:295
-#, fuzzy
 msgid "AC magnitude:"
-msgstr "Wielkość AC [V/A]"
+msgstr "Magnituda AC:"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:308
-#, fuzzy
 msgid "AC phase:"
-msgstr "Faza AC [radiany]"
+msgstr "Faza AC:"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:317
-#, fuzzy
 msgid "radians"
-msgstr "Radiany"
+msgstr "radianów"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:328
-#, fuzzy
 msgid "Transient analysis:"
-msgstr "Analiza przejściowa"
+msgstr "Analiza czasowa:"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:338
 #: eeschema/dialogs/dialog_spice_model_base.cpp:498
-#, fuzzy
 msgid "Initial value:"
-msgstr "Wartość początkowa [V/A]"
+msgstr "Wartość początkowa:"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:351
 #: eeschema/dialogs/dialog_spice_model_base.cpp:511
-#, fuzzy
 msgid "Pulsed value:"
-msgstr "Wartość impulsu [V/A]"
+msgstr "Wartość impulsowa:"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:362
-#, fuzzy
 msgid "Delay time:"
-msgstr "Czas opóźnienia [s]"
+msgstr "Czas opóźnienia:"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:373
-#, fuzzy
 msgid "Rise time:"
-msgstr "Czas narastania [s]"
+msgstr "Czas narastania:"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:384
-#, fuzzy
 msgid "Fall time:"
-msgstr "Czas opadania [s]"
+msgstr "Czas opadania:"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:395
-#, fuzzy
 msgid "Pulse width:"
-msgstr "Szerokość pisaka:"
+msgstr "Szerokość impulsu:"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:406
-#, fuzzy
 msgid "Period:"
-msgstr "Okres [s]"
+msgstr "Okres:"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:421
 msgid "Pulse"
-msgstr "Impuls"
+msgstr "Impulsowa"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:429
-#, fuzzy
 msgid "DC offset:"
-msgstr "Przesunięcie DC [V/A]"
+msgstr "DC offset:"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:442
-#, fuzzy
 msgid "Amplitude:"
-msgstr "Amplituda [V/A]"
+msgstr "Amplituda:"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:453
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:768
 #: pcb_calculator/transline_ident.cpp:156
-#, fuzzy
 msgid "Frequency:"
-msgstr "Częstotliwość"
+msgstr "Częstotliwość:"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:460
 #: pcb_calculator/UnitSelector.cpp:107
@@ -7417,59 +7549,52 @@ msgid "Hz"
 msgstr "Hz"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:464
-#, fuzzy
 msgid "Delay:"
-msgstr "Pokazuj:"
+msgstr "Opóźnienie:"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:475
-#, fuzzy
 msgid "Damping factor:"
-msgstr "Współczynnik tłumienia [1/s]"
+msgstr "Współczynnik tłumienia:"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:482
 msgid "1/seconds"
-msgstr ""
+msgstr "1/sekund"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:490
 msgid "Sinusoidal"
-msgstr "Sinusoidalny"
+msgstr "Sinusoidana"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:522
-#, fuzzy
 msgid "Rise delay time:"
-msgstr "Stały czas opadania [s]"
+msgstr "Czas opóźnienia narastania:"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:533
-#, fuzzy
 msgid "Rise time constant:"
-msgstr "Stała czasowa narastania [s]"
+msgstr "Stała czasowa narastania:"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:544
-#, fuzzy
 msgid "Fall delay time:"
-msgstr "Czas opadania [s]"
+msgstr "Czas opóźnienia opadania:"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:555
-#, fuzzy
 msgid "Fall time constant:"
-msgstr "Stała czasowa [s]"
+msgstr "Stała czasowa opadania:"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:570
 msgid "Exponential"
-msgstr "Wykładniczy"
+msgstr "Wykładniczo"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:572
 msgid "Piece-wise linear"
 msgstr "Odcinkowo liniowy"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:587
-#, fuzzy
 msgid "Time:"
-msgstr "Czas [s]"
+msgstr "Czas:"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:596
 msgid "second"
-msgstr ""
+msgstr "sekunda"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:629
 msgid "Piece-wise Linear"
@@ -7506,9 +7631,8 @@ msgid "Current"
 msgstr "Prąd"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:658
-#, fuzzy
 msgid "Source type:"
-msgstr "Źródło typu"
+msgstr "Typ źródła:"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:666
 msgid "Source"
@@ -7520,17 +7644,18 @@ msgstr "Wyłącz symbol z symulacji"
 
 #: eeschema/dialogs/dialog_spice_model_base.cpp:679
 msgid "Alternate node sequence:"
-msgstr ""
+msgstr "Sekwencja zmienna węzła:"
 
 #: eeschema/dialogs/dialog_spice_model_base.h:198
 msgid "Spice Model Editor"
-msgstr "Edytor modelu SIPCE"
+msgstr "Edytor modelu Spice"
 
 #: eeschema/dialogs/dialog_sym_lib_table.cpp:274
 #: pcbnew/dialogs/dialog_fp_lib_table.cpp:359
-#, fuzzy, c-format
+#, c-format
 msgid "Illegal character \"%c\" found in Nickname: \"%s\" in row %d"
-msgstr "Znaleziono niepoprawny znak '%s' w nazwie '%s' w rzędzie %d"
+msgstr ""
+"Znaleziono nieprawidłowy znak \"%c\" w nazwie skrótowej: \"%s\" w rzędzie %d"
 
 #: eeschema/dialogs/dialog_sym_lib_table.cpp:288
 #: pcbnew/dialogs/dialog_fp_lib_table.cpp:373
@@ -7541,7 +7666,7 @@ msgstr "Nie można stosować przecinków w nazwach"
 #: pcbnew/dialogs/dialog_fp_lib_table.cpp:403
 #, c-format
 msgid "Duplicate Nickname: \"%s\" in rows %d and %d"
-msgstr ""
+msgstr "Zduplikowana nazwa skrótowa: \"%s\" w rzędzie %d oraz %d"
 
 #: eeschema/dialogs/dialog_sym_lib_table.cpp:333
 #: pcbnew/dialogs/dialog_fp_lib_table.cpp:418
@@ -7557,33 +7682,31 @@ msgstr "Wybór biblioteki"
 #: eeschema/dialogs/dialog_sym_lib_table.cpp:383
 #: pcbnew/dialogs/dialog_fp_lib_table.cpp:656
 msgid "Warning: Duplicate Nickname"
-msgstr ""
+msgstr "Ostrzeżenie: Zduplikowana nazwa skrótowa"
 
 #: eeschema/dialogs/dialog_sym_lib_table.cpp:384
 #: pcbnew/dialogs/dialog_fp_lib_table.cpp:657
-#, fuzzy, c-format
+#, c-format
 msgid "A library nicknamed \"%s\" already exists."
-msgstr "Plik o nazwie \"%s\" już istnieje."
+msgstr "Biblioteka o nazwie skrótowej \"%s\" już istnieje."
 
 #: eeschema/dialogs/dialog_sym_lib_table.cpp:385
 #: pcbnew/dialogs/dialog_fp_lib_table.cpp:658
 msgid "Skip"
-msgstr ""
+msgstr "Pomiń"
 
 #: eeschema/dialogs/dialog_sym_lib_table.cpp:386
 #: pcbnew/dialogs/dialog_fp_lib_table.cpp:659
 msgid "Skip All Remaining Duplicates"
-msgstr ""
+msgstr "Pomiń wszystkie pozostałe duplikaty"
 
 #: eeschema/dialogs/dialog_sym_lib_table.cpp:387
 #: pcbnew/dialogs/dialog_fp_lib_table.cpp:660
-#, fuzzy
 msgid "Add Anyway"
-msgstr "Dodaj alias"
+msgstr "Dodaj mimo to"
 
 #: eeschema/dialogs/dialog_sym_lib_table_base.cpp:20
 #: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:20
-#, fuzzy
 msgid "Libraries by Scope"
 msgstr "Tabele bibliotek według zasięgu"
 
@@ -7624,7 +7747,7 @@ msgstr "Dołącz bibliotekę"
 
 #: eeschema/dialogs/dialog_sym_lib_table_base.cpp:138
 msgid "Add a symbol library row to this table"
-msgstr "Dodaj bibliotekę symboli do wiersza tej tabeli"
+msgstr "Dodaje wpis o bibliotece symboli do tej tabeli"
 
 #: eeschema/dialogs/dialog_sym_lib_table_base.cpp:142
 #: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:141
@@ -7633,7 +7756,7 @@ msgstr "Usuń bibliotekę"
 
 #: eeschema/dialogs/dialog_sym_lib_table_base.cpp:143
 msgid "Remove a symbol library from this library table"
-msgstr ""
+msgstr "Usuwa bibliotekę symboli z tej tabeli bibliotek"
 
 #: eeschema/dialogs/dialog_sym_lib_table_base.cpp:148
 #: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:147
@@ -7647,9 +7770,8 @@ msgstr "Przesuń zaznaczony wpis o jedną pozycję w górę"
 
 #: eeschema/dialogs/dialog_sym_lib_table_base.cpp:164
 #: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:168
-#, fuzzy
 msgid "Path Substitutions:"
-msgstr "Odpowiedniki ścieżek"
+msgstr "Odpowiedniki ścieżek:"
 
 #: eeschema/dialogs/dialog_sym_lib_table_base.cpp:182
 #: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:186
@@ -7669,9 +7791,8 @@ msgstr ""
 "środowiskowymi."
 
 #: eeschema/dialogs/dialog_sym_lib_table_base.h:73
-#, fuzzy
 msgid "Symbol Libraries"
-msgstr "Wczytywanie bibliotek symboli"
+msgstr "Biblioteki symboli"
 
 #: eeschema/dialogs/dialog_symbol_remap.cpp:53
 #, c-format
@@ -7679,8 +7800,8 @@ msgid ""
 "Remapping is not possible because you do not have write privileges to the "
 "project folder \"%s\"."
 msgstr ""
-"Ponowne mapowanie nie jest możliwe, ponieważ nie masz uprawnień do zapisu do "
-"folderu projektu \"% s\"."
+"Remapowanie nie jest możliwe, ponieważ nie masz wystarczających uprawnień w "
+"folderze projektu \"%s\"."
 
 #: eeschema/dialogs/dialog_symbol_remap.cpp:62
 msgid ""
@@ -7693,24 +7814,24 @@ msgid ""
 "to skip this step, you will be responsible for manually remapping the "
 "symbols."
 msgstr ""
-"Ten schemat obecnie wykorzystuje metodę wyszukiwania listy bibliotek symboli "
-"projektu do wczytywania symboli bibliotecznych. KiCad spróbuje zmapować "
-"istniejące symbole, aby użyć nowej tabeli bibliotek symboli. Remapowanie "
-"zmieni niektóre pliki projektu, a schematy mogą nie być kompatybilne ze "
-"starszymi wersjami KiCada. Wszystkie zmienione pliki zostaną zapisane w "
-"folderze \"remap_backup\" w folderze projektu, jeśli zajdzie potrzeba "
-"cofnięcia zmian. Jeśli zdecydujesz się pominąć ten krok, będziesz "
-"odpowiedzialny za ręczne ponowne mapowanie symboli."
+"Ten schemat obecnie używa poprzedniej metody dostępu do bibliotek opartej na "
+"liście ładowanych bibliotek.  KiCad dokona teraz mapowania obecnych symboli "
+"by użyć nowej metody dostępu do bibliotek poprzez tabele bibliotek.  "
+"Remapowanie zmieni zawartość pliku schematu, co spowoduje, że stanie się on "
+"nieczytelny dla poprzednich wersji programu KiCad.  Kopia wszystkich plików, "
+"które zostaną zmienione zostanie zapisana w folderze \"remap_backup\", by "
+"móc w razie czego je odzyskać.  Jeśli ten krok zostanie pominięty, będzie "
+"trzeba samodzielnie dokonać pełnego remapowania symboli."
 
 #: eeschema/dialogs/dialog_symbol_remap.cpp:189
 #, c-format
 msgid "Adding library \"%s\", file \"%s\" to project symbol library table."
-msgstr ""
+msgstr "Dodaję bibliotekę \"%s\", plik \"%s\" do tabeli bibliotek projektu."
 
 #: eeschema/dialogs/dialog_symbol_remap.cpp:198
 #, c-format
 msgid "Library \"%s\" not found."
-msgstr "Biblioteki \"%s\" nie znaleziono."
+msgstr "Biblioteka \"%s\" nie została znaleziona."
 
 #: eeschema/dialogs/dialog_symbol_remap.cpp:215
 #, c-format
@@ -7718,29 +7839,31 @@ msgid ""
 "Failed to write project symbol library table. Error:\n"
 "  %s"
 msgstr ""
+"Zapis tabeli bibliotek symboli projektu nie powiódł się. Błąd:\n"
+"  %s"
 
 #: eeschema/dialogs/dialog_symbol_remap.cpp:220
 msgid "Created project symbol library table.\n"
-msgstr ""
+msgstr "Utworzono tabelę bibliotek symboli projektów.\n"
 
 #: eeschema/dialogs/dialog_symbol_remap.cpp:248
 #, c-format
 msgid "No symbol \"%s\" found in symbol library table."
-msgstr ""
+msgstr "Nie znaleziono symbolu \"%s\" w tabeli bibliotek symboli."
 
 #: eeschema/dialogs/dialog_symbol_remap.cpp:254
 #, c-format
 msgid "Symbol \"%s\" mapped to symbol library \"%s\"."
-msgstr ""
+msgstr "Symbol \"%s\" zmapowany do biblioteki symboli \"%s\"."
 
 #: eeschema/dialogs/dialog_symbol_remap.cpp:263
 msgid "Symbol library table mapping complete!"
-msgstr ""
+msgstr "Mapowanie symboli według tabeli bibliotek zakończone!"
 
 #: eeschema/dialogs/dialog_symbol_remap.cpp:333
 #, c-format
 msgid "Cannot create project remap back up folder \"%s\"."
-msgstr ""
+msgstr "Nie można utworzyć folderu kopii zapasowych \"%s\"."
 
 #: eeschema/dialogs/dialog_symbol_remap.cpp:336
 #: eeschema/dialogs/dialog_symbol_remap.cpp:477
@@ -7750,7 +7873,7 @@ msgstr "Błąd kopii zapasowej"
 #: eeschema/dialogs/dialog_symbol_remap.cpp:338
 #: eeschema/dialogs/dialog_symbol_remap.cpp:481
 msgid "Continue with Rescue"
-msgstr ""
+msgstr "Kontynuuj odzyskiwanie"
 
 #: eeschema/dialogs/dialog_symbol_remap.cpp:339
 #: eeschema/dialogs/dialog_symbol_remap.cpp:482
@@ -7765,7 +7888,7 @@ msgstr "Przerwij odzyskiwanie"
 #: eeschema/dialogs/dialog_symbol_remap.cpp:463
 #, c-format
 msgid "Backing up file \"%s\" to file \"%s\"."
-msgstr ""
+msgstr "Tworznie kopii zapasowej \"%s\" w pliku \"%s\"."
 
 #: eeschema/dialogs/dialog_symbol_remap.cpp:363
 #: eeschema/dialogs/dialog_symbol_remap.cpp:403
@@ -7775,29 +7898,29 @@ msgstr ""
 #: eeschema/dialogs/dialog_symbol_remap.cpp:470
 #, c-format
 msgid "Failed to back up file \"%s\".\n"
-msgstr ""
+msgstr "Nie można utworzyć kopii zapasowej pliku \"%s\".\n"
 
 #: eeschema/dialogs/dialog_symbol_remap.cpp:395
 #, c-format
 msgid "Failed to create backup folder \"%s\"\n"
-msgstr ""
+msgstr "Nie można utworzyć folderu kopii \"%s\"\n"
 
 #: eeschema/dialogs/dialog_symbol_remap.cpp:476
 msgid "Some of the project files could not be backed up."
-msgstr ""
+msgstr "Pewne pliki projektu nie mogły zostać zapisane jako kopie zapasowe."
 
 #: eeschema/dialogs/dialog_symbol_remap_base.cpp:30
 #: eeschema/dialogs/dialog_symbol_remap_base.h:51
 msgid "Remap Symbols"
-msgstr "Odzyskaj symbole"
+msgstr "Remapowanie symboli"
 
 #: eeschema/dialogs/dialog_update_fields_base.cpp:19
 msgid "Select fields to update:"
-msgstr "Zaznacz pola do aktualizacji:"
+msgstr "Wybierz pola do aktualizacji:"
 
 #: eeschema/dialogs/dialog_update_fields_base.cpp:33
 msgid "Select None"
-msgstr "Odznacz"
+msgstr "Odznacz wszystkie"
 
 #: eeschema/dialogs/dialog_update_fields_base.cpp:39
 msgid "Remove extra fields"
@@ -7805,7 +7928,7 @@ msgstr "Usuń dodatkowe pola"
 
 #: eeschema/dialogs/dialog_update_fields_base.cpp:40
 msgid "Removes fields that do not occur in the original library symbols"
-msgstr ""
+msgstr "Usuwa pola, które nie występują w oryginalnych symbolach z biblioteki"
 
 #: eeschema/dialogs/dialog_update_fields_base.cpp:44
 msgid "Omit empty fields"
@@ -7813,11 +7936,11 @@ msgstr "Pomiń puste pola"
 
 #: eeschema/dialogs/dialog_update_fields_base.cpp:45
 msgid "Do not clear existing entries if library field is empty"
-msgstr ""
+msgstr "Nie czyść istniejących wpisów jeśli pole w bibliotece jest puste"
 
 #: eeschema/dialogs/dialog_update_fields_base.h:57
 msgid "Update Symbol Fields"
-msgstr ""
+msgstr "Uaktualnij pola symbolu"
 
 #: eeschema/drc_erc_item.cpp:40
 msgid "ERC err unspecified"
@@ -7838,11 +7961,11 @@ msgstr "Pin podłączony do innych pinów ale nie ma pinu sterującego"
 
 #: eeschema/drc_erc_item.cpp:48
 msgid "Conflict problem between pins. Severity: warning"
-msgstr "Ostrzeżenie: Konflikt pomiędzy pinami."
+msgstr "Ostrzeżenie: Konflikt pomiędzy pinami"
 
 #: eeschema/drc_erc_item.cpp:50
 msgid "Conflict problem between pins. Severity: error"
-msgstr "BŁĄD: Konflikt pomiędzy pinami."
+msgstr "BŁĄD: Konflikt pomiędzy pinami"
 
 #: eeschema/drc_erc_item.cpp:52
 msgid "Mismatch between hierarchical labels and pins sheets"
@@ -7858,27 +7981,31 @@ msgstr "Etykieta globalna nie połączona z inną etykietą globalną"
 
 #: eeschema/drc_erc_item.cpp:58
 msgid "Labels are similar (lower/upper case difference only)"
-msgstr ""
+msgstr "Etykiety są podobne (różnią się tylko wielkością liter)"
 
 #: eeschema/drc_erc_item.cpp:60
 msgid "Global labels are similar (lower/upper case difference only)"
-msgstr ""
+msgstr "Globalne etykiety są podobne (różnią się tylko wielkością liter)"
 
 #: eeschema/drc_erc_item.cpp:62
 msgid "Different footprint assigned in another unit of the same component"
 msgstr ""
+"Różne footprinty przypisane do tego samego komponentu w poszczególnych "
+"instancjach"
 
 #: eeschema/drc_erc_item.cpp:64
 msgid ""
 "Different net assigned to a shared pin in another unit of the same component"
 msgstr ""
+"Różne sieci przypisane do tego samego pinu w innej części komponentu "
+"wieloczęściowego"
 
 #: eeschema/edit_bitmap.cpp:115 eeschema/edit_bitmap.cpp:125
 #: pagelayout_editor/pl_editor_frame.cpp:635
 #: pagelayout_editor/pl_editor_frame.cpp:643
 #, c-format
 msgid "Couldn't load image from \"%s\""
-msgstr ""
+msgstr "Nie można załadować obrazu z \"%s\""
 
 #: eeschema/edit_component_in_schematic.cpp:65
 #, c-format
@@ -7890,11 +8017,12 @@ msgid ""
 "An error occurred attempting to load the global symbol library table.\n"
 "Please edit this global symbol library table in Preferences menu."
 msgstr ""
+"Wystąpił błąd podczas wczytywania globalnej tabeli bibliotek symboli.\n"
+"Proszę dokonać edycji globalnej tabeli w menu Ustawienia."
 
 #: eeschema/eeschema_config.cpp:176 pcbnew/pcbnew_config.cpp:189
-#, fuzzy
 msgid "Load Project File"
-msgstr "Odczytaj plik projektu"
+msgstr "Wczytywanie pliku projektu"
 
 #: eeschema/eeschema_config.cpp:413 pcbnew/pcbnew_config.cpp:265
 msgid "Save Project File"
@@ -7903,7 +8031,7 @@ msgstr "Zapisz plik projektu"
 #: eeschema/eeschema_config.cpp:793 eeschema/files-io.cpp:524
 #, c-format
 msgid "An error occurred loading the symbol library table \"%s\"."
-msgstr ""
+msgstr "Wystąpił błąd podczas ładowania tabeli bibliotek schematu \"%s\"."
 
 #: eeschema/erc.cpp:89 eeschema/erc.cpp:105
 msgid "Input Pin"
@@ -7957,6 +8085,7 @@ msgstr "Podwójna nazwa arkusza"
 #, c-format
 msgid "Unit %s has '%s' assigned, whereas unit %s has '%s' assigned"
 msgstr ""
+"Część %s posiada przypisany '%s', gdzie część %s posiada przypisanie '%s'"
 
 #: eeschema/erc.cpp:319
 #, c-format
@@ -8027,22 +8156,22 @@ msgstr ""
 #: eeschema/erc.cpp:883
 #, c-format
 msgid "Global label \"%s\" (sheet \"%s\") looks like:"
-msgstr ""
+msgstr "Globalna etykieta \"%s\" (arkusz \"%s\") wygląda podobnie do:"
 
 #: eeschema/erc.cpp:884
 #, c-format
 msgid "Local label \"%s\" (sheet \"%s\") looks like:"
-msgstr ""
+msgstr "Lokalna etykieta \"%s\" (arkusz \"%s\") wygląda podobnie do:"
 
 #: eeschema/erc.cpp:892
 #, c-format
 msgid "Global label \"%s\" (sheet \"%s\")"
-msgstr ""
+msgstr "Globalna etykieta \"%s\" (arkusz \"%s\")"
 
 #: eeschema/erc.cpp:893
 #, c-format
 msgid "Local label \"%s\" (sheet \"%s\")"
-msgstr ""
+msgstr "Lokalna etykieta \"%s\" (arkusz \"%s\")"
 
 #: eeschema/files-io.cpp:76
 msgid "Schematic Files"
@@ -8051,7 +8180,7 @@ msgstr "Pliki schematów"
 #: eeschema/files-io.cpp:106
 #, c-format
 msgid "Could not save backup of file \"%s\""
-msgstr ""
+msgstr "Nie można zapisać pliku kopii zapasowej \"%s\""
 
 #: eeschema/files-io.cpp:125
 #, c-format
@@ -8059,6 +8188,8 @@ msgid ""
 "Error saving schematic file \"%s\".\n"
 "%s"
 msgstr ""
+"Błąd podczas zapisywania pliku schematu \"%s\".\n"
+"%s"
 
 #: eeschema/files-io.cpp:129
 #, c-format
@@ -8077,12 +8208,12 @@ msgstr "Błąd operacji zapisu do pliku."
 #: eeschema/files-io.cpp:212 eeschema/files-io.cpp:779
 #, c-format
 msgid "Schematic file \"%s\" is already open."
-msgstr ""
+msgstr "Schemat \"%s\" jest już otwarty."
 
 #: eeschema/files-io.cpp:232
 #, c-format
 msgid "Schematic \"%s\" does not exist.  Do you wish to create it?"
-msgstr ""
+msgstr "Schemat \"%s\" nie istnieje.  Czy chcesz go utworzyć?"
 
 #: eeschema/files-io.cpp:302
 msgid ""
@@ -8090,6 +8221,8 @@ msgid ""
 "load \n"
 "hierarchical sheet schematics."
 msgstr ""
+"Pełen schemat nie mógł zostać wczytany.  Błędy wystąpiły podczas próby\n"
+"załadowania arkuszy hierarchicznych."
 
 #: eeschema/files-io.cpp:316 eeschema/files-io.cpp:882
 #, c-format
@@ -8097,11 +8230,13 @@ msgid ""
 "Error loading schematic file \"%s\".\n"
 "%s"
 msgstr ""
+"Błąd podczas ładowania pliku schematu \"%s\".\n"
+"%s"
 
 #: eeschema/files-io.cpp:320 eeschema/files-io.cpp:886
 #, c-format
 msgid "Failed to load \"%s\""
-msgstr "Nie można wczytać \"%s\""
+msgstr "Nie można załadować \"%s\""
 
 #: eeschema/files-io.cpp:335
 msgid ""
@@ -8109,6 +8244,9 @@ msgid ""
 "fixed.  Please save the schematic to repair the broken file or it may not be "
 "usable with other versions of KiCad."
 msgstr ""
+"Został znaleziony błąd podczas ładowania schematu, który zostanie naprawiony "
+"automatycznie. Proszę zapisać schemat by naprawić uszkodzony plik, inaczej "
+"może stać się nie do użytku dla innych wersji programu KiCad."
 
 #: eeschema/files-io.cpp:399
 msgid "Append Schematic"
@@ -8119,16 +8257,18 @@ msgid ""
 "The entire schematic could not be load.  Errors occurred attempting to load "
 "hierarchical sheet schematics."
 msgstr ""
+"Schemat nie mógł zostać odczytany.  Błędy wystąpiły podczas próby "
+"załadowania arkuszy hierarchicznych."
 
 #: eeschema/files-io.cpp:456 eeschema/sheet.cpp:284
 #, c-format
 msgid "Error occurred loading schematic file \"%s\"."
-msgstr ""
+msgstr "Wystąpił błąd przy ładowaniu schematu \"%s\"."
 
 #: eeschema/files-io.cpp:459 eeschema/sheet.cpp:287
 #, c-format
 msgid "Failed to load schematic \"%s\""
-msgstr "Nie można wczytać schematu \"%s\""
+msgstr "Nie można załadować schematu \"%s\""
 
 #: eeschema/files-io.cpp:652
 msgid ""
@@ -8136,6 +8276,9 @@ msgid ""
 "\n"
 "Do you want to save the current document before proceeding?"
 msgstr ""
+"Ta operacja nie może zostać cofnięta.\n"
+"\n"
+"Czy chcesz zapisać obecny dokument przed kontynuacją?"
 
 #: eeschema/files-io.cpp:672
 msgid "Import Schematic"
@@ -8144,7 +8287,7 @@ msgstr "Importuj Schemat"
 #: eeschema/files-io.cpp:703
 #, c-format
 msgid "Directory \"%s\" is not writable."
-msgstr ""
+msgstr "Zapis w folderze \"%s\" nie jest możliwy."
 
 #: eeschema/files-io.cpp:912
 msgid ""
@@ -8211,11 +8354,11 @@ msgstr "Symbol %s nie został znaleziony"
 #: eeschema/find.cpp:496
 #, c-format
 msgid "No item found matching %s."
-msgstr "Nie znaleziono elementu pasującego do %s"
+msgstr "Nie znaleziono elementu pasującego do %s."
 
 #: eeschema/generate_alias_info.cpp:37 eeschema/sch_component.cpp:1409
 msgid "Alias of"
-msgstr "Alias "
+msgstr "Alias"
 
 #: eeschema/generate_alias_info.cpp:39 eeschema/selpart.cpp:72
 msgid "Key words:"
@@ -8231,22 +8374,24 @@ msgstr "Ostatnio użyte"
 
 #: eeschema/getpart.cpp:152
 msgid "Recently used items"
-msgstr ""
+msgstr "Ostatnio użyte elementy"
 
 #: eeschema/getpart.cpp:167
 #, c-format
 msgid "Choose Power Symbol (%d items loaded)"
-msgstr "Wybierz symbol zasilania (%d wczytano elementów)"
+msgstr "Wybór portu zasilania (załadowano %d obiektów)"
 
 #: eeschema/getpart.cpp:169 eeschema/viewlibs.cpp:61
 #, c-format
 msgid "Choose Symbol (%d items loaded)"
-msgstr "Wybierz symbol (%d wczytano elementów)"
+msgstr "Wybór symboli (załadowano %d obiektów)"
 
 #: eeschema/getpart.cpp:408
 #, c-format
 msgid "No alternate body style found for symbol \"%s\" in library \"%s\"."
 msgstr ""
+"Nie znaleziono alternatywnej reprezentacji dla symbolu \"%s\" w bibliotece "
+"\"%s\"."
 
 #: eeschema/help_common_strings.h:40
 msgid "Undo last command"
@@ -8257,9 +8402,8 @@ msgid "Redo last command"
 msgstr "Ponów ostatnio cofniętą operację"
 
 #: eeschema/help_common_strings.h:45
-#, fuzzy
 msgid "Zoom to fit schematic page"
-msgstr "Powiększ, aby dopasować płytkę do ekranu"
+msgstr "Powiększa by widoczna była cała płytka"
 
 #: eeschema/help_common_strings.h:46
 msgid "Redraw schematic view"
@@ -8274,7 +8418,7 @@ msgstr "Usuń element"
 
 #: eeschema/help_common_strings.h:51
 msgid "Find symbols and text"
-msgstr ""
+msgstr "Znajdź symbole i tekst"
 
 #: eeschema/help_common_strings.h:52
 msgid "Find and replace text in schematic items"
@@ -8306,11 +8450,11 @@ msgstr "Dodaj wejście magistrali do magistrali"
 
 #: eeschema/help_common_strings.h:59
 msgid "Place no connection flag"
-msgstr ""
+msgstr "Umieść flagę niepodłączone"
 
 #: eeschema/help_common_strings.h:61
 msgid "Place net label"
-msgstr ""
+msgstr "Umieść etykietę sieci"
 
 #: eeschema/help_common_strings.h:64
 msgid ""
@@ -8327,6 +8471,8 @@ msgid ""
 "Place a hierarchical label. Label will be seen as a hierarchical pin in the "
 "sheet"
 msgstr ""
+"Umieszcza etykietę hierarchiczną. Etykieta będzie widoczna jako pin "
+"hierarchiczny w arkuszu"
 
 #: eeschema/help_common_strings.h:68
 msgid "Place junction"
@@ -8357,49 +8503,51 @@ msgstr "Dodaj tekst (grafika)"
 
 #: eeschema/help_common_strings.h:76
 msgid "Annotate schematic symbols"
-msgstr "Numeracja elementów na schemacie"
+msgstr "Numeruje symbole na schemacie"
 
 #: eeschema/help_common_strings.h:77
 msgid "Create, delete, and edit symbols"
-msgstr "Tworzenie, usuwanie i edycja symboli"
+msgstr "Tworzy, usuwa oraz dokonuje edycji symboli"
 
 #: eeschema/help_common_strings.h:78
 msgid "Browse symbol libraries"
-msgstr "Przeglądaj biblioteki symboli"
+msgstr "Przegląda biblioteki smboli"
 
 #: eeschema/help_common_strings.h:79
 msgid "Generate bill of materials"
-msgstr "Generuj listę materiałową"
+msgstr "Generuje listę materiałową"
 
 #: eeschema/help_common_strings.h:81
 msgid ""
 "Back-import symbol footprint association fields from the .cmp back import "
 "file created by Pcbnew"
 msgstr ""
+"Importuje dane o przypisanych footprintach z pliku .cmp utworzonego w "
+"programie Pcbnew"
 
 #: eeschema/help_common_strings.h:84
 msgid "Add pins to symbol"
-msgstr "Dodaj wyprowadzenia do symbolu"
+msgstr "Dodaje piny do symbolu"
 
 #: eeschema/help_common_strings.h:85
 msgid "Add text to symbol body"
-msgstr ""
+msgstr "Dodaje tekst do rysunku symbolu"
 
 #: eeschema/help_common_strings.h:86
 msgid "Add graphic rectangle to symbol body"
-msgstr ""
+msgstr "Dodaje prostokąt do rysunku symbolu"
 
 #: eeschema/help_common_strings.h:87
 msgid "Add circles to symbol body"
-msgstr ""
+msgstr "Dodaje okręgi do rysunku symbolu"
 
 #: eeschema/help_common_strings.h:88
 msgid "Add arcs to symbol body"
-msgstr ""
+msgstr "Dodaje łuki do rysunku symbolu"
 
 #: eeschema/help_common_strings.h:89
 msgid "Add lines and polygons to symbol body"
-msgstr ""
+msgstr "Dodaje linie do rysunku symbolu"
 
 #: eeschema/help_common_strings.h:90 eeschema/tool_sch.cpp:266
 msgid "Add bitmap image"
@@ -8416,6 +8564,8 @@ msgstr "Główny"
 #: eeschema/highlight_connection.cpp:51
 msgid "Error: duplicate sub-sheet names found in current sheet. Fix it"
 msgstr ""
+"BŁĄD: znaleziono zdublowane nazwy arkuszy podrzędnych w bieżącym arkuszu. "
+"Proszę poprawić"
 
 #: eeschema/hotkeys.cpp:93 gerbview/hotkeys.cpp:62
 #: pagelayout_editor/hotkeys.cpp:76 pcbnew/hotkeys.cpp:202
@@ -8479,7 +8629,7 @@ msgstr "Dodaj węzeł"
 
 #: eeschema/hotkeys.cpp:139
 msgid "Add Symbol"
-msgstr "Dodaj symbol"
+msgstr "Dodaj sybmbol"
 
 #: eeschema/hotkeys.cpp:141
 msgid "Add Power"
@@ -8487,7 +8637,7 @@ msgstr "Dodaj port zasilania"
 
 #: eeschema/hotkeys.cpp:143
 msgid "Add No Connect Flag"
-msgstr "Dodaj flagę \"Niepołączone\""
+msgstr "Dodaj flagę Niepołączone"
 
 #: eeschema/hotkeys.cpp:145
 msgid "Add Sheet"
@@ -8523,19 +8673,19 @@ msgstr "Edytuj element"
 
 #: eeschema/hotkeys.cpp:163
 msgid "Edit Symbol Value"
-msgstr "Edytuj wartość symbolu"
+msgstr "Edycja wartości symbolu"
 
 #: eeschema/hotkeys.cpp:166
 msgid "Edit Symbol Reference"
-msgstr ""
+msgstr "Edycja odnośnika symbolu"
 
 #: eeschema/hotkeys.cpp:169
 msgid "Edit Symbol Footprint"
-msgstr "Edytuj footprint symbolu"
+msgstr "Edycja footprintu symbolu"
 
 #: eeschema/hotkeys.cpp:172
 msgid "Edit with Symbol Editor"
-msgstr ""
+msgstr "Edycja za pomocą edytora symboli"
 
 #: eeschema/hotkeys.cpp:176
 msgid "Move Schematic Item"
@@ -8543,7 +8693,7 @@ msgstr "Przesuń element schematu"
 
 #: eeschema/hotkeys.cpp:180
 msgid "Duplicate Symbol or Label"
-msgstr ""
+msgstr "Duplikuje symbol lub etykietę"
 
 #: eeschema/hotkeys.cpp:184 pcbnew/hotkeys.cpp:144
 msgid "Drag Item"
@@ -8597,11 +8747,11 @@ msgstr "Zapisz wszystkie biblioteki"
 
 #: eeschema/hotkeys.cpp:212 eeschema/onrightclick.cpp:410
 msgid "Autoplace Fields"
-msgstr ""
+msgstr "Automatycznie rozłóż pola"
 
 #: eeschema/hotkeys.cpp:215 pcbnew/dialogs/dialog_update_pcb_base.h:53
 msgid "Update PCB from Schematic"
-msgstr "Uaktualnij płytkę ze schematu"
+msgstr "Uaktualnia PCB na podstawie schematu"
 
 #: eeschema/hotkeys.cpp:219
 msgid "Highlight Connection"
@@ -8610,7 +8760,7 @@ msgstr "Podświetl połączenie"
 #: eeschema/hotkeys.cpp:223 pagelayout_editor/hotkeys.cpp:96
 #: pcbnew/dialogs/wizard_3DShape_Libs_downloader.cpp:212 pcbnew/hotkeys.cpp:288
 msgid "New"
-msgstr "Nowy"
+msgstr "Nowa"
 
 #: eeschema/hotkeys.cpp:224 pagelayout_editor/files.cpp:135
 #: pagelayout_editor/hotkeys.cpp:97 pcbnew/hotkeys.cpp:289
@@ -8644,7 +8794,7 @@ msgstr "Ponów"
 #: eeschema/hotkeys.cpp:240 pcbnew/hotkeys.cpp:304
 #: pcbnew/tools/edit_tool.cpp:185
 msgid "Cut"
-msgstr "Wytnij"
+msgstr "Wytnik"
 
 #: eeschema/hotkeys.cpp:241 eeschema/onrightclick.cpp:555
 #: pcbnew/hotkeys.cpp:305 pcbnew/onrightclick.cpp:954
@@ -8735,7 +8885,7 @@ msgstr "tak"
 
 #: eeschema/lib_draw_item.cpp:81
 msgid "Converted"
-msgstr "Konwertuj"
+msgstr "Skonwertowany"
 
 #: eeschema/lib_edit_frame.cpp:428 eeschema/onrightclick.cpp:476
 #, c-format
@@ -8744,30 +8894,29 @@ msgstr "Część składowa %s"
 
 #: eeschema/lib_edit_frame.cpp:521
 msgid "&Save Symbol [Read Only]"
-msgstr "Zapi&sz symbol [Tylko do odczytu]"
+msgstr "Zapisz symbol [Tylko do odczytu]"
 
 #: eeschema/lib_edit_frame.cpp:521 eeschema/menubar_libedit.cpp:194
 #: eeschema/widgets/cmp_tree_pane.cpp:78
 msgid "&Save Symbol"
-msgstr "Zapi&sz symbol"
+msgstr "Zapisz symbol"
 
 #: eeschema/lib_edit_frame.cpp:571
 msgid "&Save Library [Read Only]"
-msgstr "Zapi&sz bibliotekę [Tylko do odczytu]"
+msgstr "Zapisz bibliotekę [Tylko do odczytu]"
 
 #: eeschema/lib_edit_frame.cpp:571 eeschema/menubar_libedit.cpp:76
 #: eeschema/widgets/cmp_tree_pane.cpp:56
 msgid "&Save Library"
-msgstr "Zapi&sz bibliotekę"
+msgstr "Zapisz bibliotekę"
 
 #: eeschema/lib_edit_frame.cpp:597
-#, fuzzy
 msgid "Save All &Libraries..."
-msgstr "Zapisz wszystkie bib&lioteki"
+msgstr "Zapisz wszystkie biblioteki..."
 
 #: eeschema/lib_edit_frame.cpp:597 eeschema/menubar_libedit.cpp:86
 msgid "Save All &Libraries"
-msgstr "Zapisz wszystkie bib&lioteki"
+msgstr "Zapisz wszystkie biblioteki"
 
 #: eeschema/lib_edit_frame.cpp:1208
 msgid "Add pin"
@@ -8810,15 +8959,15 @@ msgstr "Importuj"
 #: eeschema/lib_edit_frame.cpp:1569
 #, c-format
 msgid "Library \"%s\" already exists"
-msgstr ""
+msgstr "Biblioteka \"%s\" już istnieje"
 
 #: eeschema/lib_edit_frame.cpp:1584
 msgid "Could not create the library file. Check write permission."
-msgstr ""
+msgstr "Nie można zapisać biblioteki. Sprawdź swoje uprawnienia."
 
 #: eeschema/lib_edit_frame.cpp:1591
 msgid "Could not open the library file."
-msgstr ""
+msgstr "Nie można otworzyć pliku biblioteki."
 
 #: eeschema/lib_edit_frame.cpp:1607
 msgid "New Library"
@@ -8834,15 +8983,15 @@ msgstr "Projekt"
 
 #: eeschema/lib_edit_frame.cpp:1716
 msgid "Select Symbol Library Table"
-msgstr ""
+msgstr "Wybierz Tabelę bibliotek symboli"
 
 #: eeschema/lib_edit_frame.cpp:1717
 msgid "Choose the Library Table to add the library:"
-msgstr ""
+msgstr "Wybierz docelową Tabelę bibliotek, do której dodać bibliotekę:"
 
 #: eeschema/lib_edit_frame.cpp:1739
 msgid "Failed to save backup document to file "
-msgstr ""
+msgstr "Nie udało się zapisać kopii zapasowej do pliku "
 
 #: eeschema/lib_export.cpp:60 eeschema/symbedit.cpp:64
 msgid "Import Symbol"
@@ -8851,12 +9000,12 @@ msgstr "Importuj symbol"
 #: eeschema/lib_export.cpp:80 eeschema/symbedit.cpp:90
 #, c-format
 msgid "Cannot import symbol library \"%s\"."
-msgstr ""
+msgstr "Nie można zaimportować biblioteki symboli \"%s\"."
 
 #: eeschema/lib_export.cpp:87 eeschema/symbedit.cpp:97
 #, c-format
 msgid "Symbol library file \"%s\" is empty."
-msgstr ""
+msgstr "Plik biblioteki symboli \"%s\" jest pusty."
 
 #: eeschema/lib_export.cpp:97
 #, c-format
@@ -8865,7 +9014,7 @@ msgstr "Symbol \"%s\" już istnieje w bibliotece \"%s\"."
 
 #: eeschema/lib_export.cpp:114
 msgid "There is no symbol selected to save."
-msgstr ""
+msgstr "Nie ma zaznaczonych symboli do zapisu."
 
 #: eeschema/lib_export.cpp:123 eeschema/symbedit.cpp:171
 msgid "Export Symbol"
@@ -8874,31 +9023,31 @@ msgstr "Eksportuj symbol"
 #: eeschema/lib_export.cpp:147
 #, c-format
 msgid "Error occurred attempting to load symbol library file \"%s\""
-msgstr ""
+msgstr "Wystąpił błąd podczas próby załadowania pliku biblioteki \"%s\""
 
 #: eeschema/lib_export.cpp:155
 #, c-format
 msgid "Symbol \"%s\" already exists. Overwrite it?"
-msgstr "Symbol \"%s\" już istnieje. Nadpisać?"
+msgstr "Symbol \"%s\" już istnieje. Chcesz go zastąpić?"
 
 #: eeschema/lib_export.cpp:164
 #, c-format
 msgid "Write permissions are required to save library \"%s\"."
-msgstr ""
+msgstr "Wymagane są prawa zapisu by zapisać w bibliotece \"%s\"."
 
 #: eeschema/lib_export.cpp:178
 msgid "Failed to create symbol library file "
-msgstr ""
+msgstr "Nie można utworzyć pliku bibliotek symboli "
 
 #: eeschema/lib_export.cpp:180
 #, c-format
 msgid "Error creating symbol library \"%s\""
-msgstr ""
+msgstr "Błąd podczas tworzenia biblioteki symboli \"%s\""
 
 #: eeschema/lib_export.cpp:189
 #, c-format
 msgid "Symbol \"%s\" saved in library \"%s\""
-msgstr ""
+msgstr "Symbol \"%s\" zapisany w bibliotece \"%s\""
 
 #: eeschema/lib_field.cpp:470
 #, c-format
@@ -8930,27 +9079,27 @@ msgstr "Wysokość"
 #: eeschema/lib_manager.cpp:104
 #, c-format
 msgid "Cannot find library \"%s\" in the Symbol Library Table"
-msgstr ""
+msgstr "Nie można odnaleźć biblioteki \"%s\" w tabeli bibliotek symboli"
 
 #: eeschema/lib_manager.cpp:143
 #, c-format
 msgid "Cannot flush library changes (\"%s\")"
-msgstr ""
+msgstr "Nie można opróżnić bufora zmian w bibliotece (\"%s\")"
 
 #: eeschema/lib_manager.cpp:299 eeschema/lib_manager.cpp:670
 #, c-format
 msgid "Cannot enumerate library \"%s\""
-msgstr ""
+msgstr "Nie można wyliczyć elementów biblioteki \"%s\""
 
 #: eeschema/lib_manager.cpp:337
 #, c-format
 msgid "Cannot load aliases from library \"%s\""
-msgstr ""
+msgstr "Nie można załadować aliasów z biblioteki \"%s\""
 
 #: eeschema/lib_manager.cpp:368 eeschema/lib_manager.cpp:533
 #, c-format
 msgid "Cannot load symbol \"%s\" from library \"%s\""
-msgstr ""
+msgstr "Nie można załadować symbolu \"%s\" z biblioteki \"%s\""
 
 #: eeschema/lib_pin.cpp:1728 pcbnew/class_drawsegment.cpp:436
 #: pcbnew/class_track.cpp:1095
@@ -9012,32 +9161,33 @@ msgid "Text"
 msgstr "Tekst"
 
 #: eeschema/libarch.cpp:102
-#, fuzzy, c-format
+#, c-format
 msgid "Failed to add symbol \"%s\" to library file \"%s\"."
-msgstr "Błąd przy tworzeniu pliku biblioteki symboli '%s'"
+msgstr "Dodanie symbolu \"%s\" do biblioteki \"%s\" nie powiodło się."
 
 #: eeschema/libarch.cpp:110
 msgid "Unexpected exception occurred."
-msgstr ""
+msgstr "Wystąpił niespodziewany błąd."
 
 #: eeschema/libarch.cpp:125
 #, c-format
 msgid "Symbol %s not found in any library or cache."
 msgstr ""
+"Symbol %s nie został znaleziony w żadnej z bibliotek lub pamięci podręcznej."
 
 #: eeschema/libarch.cpp:141
 #, c-format
 msgid "Errors occurred creating symbol library %s."
-msgstr ""
+msgstr "Wystąpił błąd podczas tworzenia biblioteki symboli %s."
 
 #: eeschema/libarch.cpp:153
 #, c-format
 msgid "Failed to save symbol library file \"%s\""
-msgstr ""
+msgstr "Nie można było zapisać pliku biblioteki symboli \"%s\""
 
 #: eeschema/libedit.cpp:61
 msgid "Symbol Library Editor - "
-msgstr "Edytor bibliotek symboli -"
+msgstr "Edytor bibliotek symboli - "
 
 #: eeschema/libedit.cpp:70
 msgid "[Read Only]"
@@ -9046,7 +9196,7 @@ msgstr "[Tylko do odczytu]"
 #: eeschema/libedit.cpp:73 eeschema/viewlibs.cpp:183
 #: pcbnew/footprint_viewer_frame.cpp:755
 msgid "no library selected"
-msgstr "Nie wybrano biblioteki"
+msgstr "nie wybrano biblioteki"
 
 #: eeschema/libedit.cpp:96
 msgid ""
@@ -9054,12 +9204,15 @@ msgid ""
 "\n"
 "Discard current changes?"
 msgstr ""
+"Bieżący symbol nie został zapisany.\n"
+"\n"
+"Odrzucić obecne zmiany?"
 
 #: eeschema/libedit.cpp:117 eeschema/sch_edit_frame.cpp:1246
 #: eeschema/selpart.cpp:63
 #, c-format
 msgid "Error occurred loading symbol \"%s\" from library \"%s\"."
-msgstr ""
+msgstr "Wystąpił błąd podczas ładowania \"%s\" z biblioteki \"%s\"."
 
 #: eeschema/libedit.cpp:259
 msgid ""
@@ -9067,20 +9220,23 @@ msgid ""
 "\n"
 "Revert changes?"
 msgstr ""
+"Operacja przywrócenia nie może zostać cofnięta!\n"
+"\n"
+"Przywrócić zmiany?"
 
 #: eeschema/libedit.cpp:294
 msgid "This new symbol has no name and cannot be created."
-msgstr ""
+msgstr "Nowy symbol nie ma nazwy zatem nie można go utworzyć."
 
 #: eeschema/libedit.cpp:305
 #, c-format
 msgid "Symbol \"%s\" already exists in library \"%s\""
-msgstr "Symbol \"%s\" już istnieje w bibliotece \"%s\""
+msgstr "Symbol \"%s\" istnieje już w bibliotece \"%s\""
 
 #: eeschema/libedit.cpp:491
 #, c-format
 msgid "Symbol name \"%s\" not found in library \"%s\""
-msgstr ""
+msgstr "Symbol \"%s\" nie został znaleziony w bibliotece \"%s\""
 
 #: eeschema/libedit.cpp:521
 msgid "No library specified."
@@ -9094,29 +9250,29 @@ msgstr "Zapisz bibliotekę \"%s\" jako..."
 #: eeschema/libedit.cpp:576
 #, c-format
 msgid "Failed to save changes to symbol library file \"%s\""
-msgstr ""
+msgstr "Nie można było zapisać zmian w bibliotece \"%s\""
 
 #: eeschema/libedit.cpp:578
 msgid "Error saving library"
-msgstr "Błąd podczas zapisywania biblioteki"
+msgstr "Błąd podczas zapisu biblioteki"
 
 #: eeschema/libedit.cpp:585
 #, c-format
 msgid "Symbol library file \"%s\" saved"
-msgstr ""
+msgstr "Biblioteka symboli \"%s\" została zapisana"
 
 #: eeschema/libedit.cpp:587
 #, c-format
 msgid "Symbol library documentation file \"%s\" saved"
-msgstr ""
+msgstr "Plik dokumentacji biblioteki \"%s\" został zapisany"
 
 #: eeschema/libedit.cpp:631
 msgid "Save Libraries"
-msgstr "Zapisz biblioteki"
+msgstr "Zapisuje biblioteki"
 
 #: eeschema/libedit.cpp:632
 msgid "Select libraries to save"
-msgstr "Wybierz biblioteki do zapisania"
+msgstr "Wybierz bibliotekę by zapisać"
 
 #: eeschema/libedit.cpp:633
 msgid ""
@@ -9124,6 +9280,10 @@ msgid ""
 "\n"
 "Do you want to save them to a new file?"
 msgstr ""
+"Niektóre z bibliotek nie mogły zostać zapisane w ich oryginalnych "
+"lokacjach.\n"
+"\n"
+"Czy chcesz je zapisać jako nowe pliki?"
 
 #: eeschema/libedit.cpp:672 eeschema/viewlibs.cpp:228
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:50
@@ -9172,7 +9332,7 @@ msgstr "Wklej"
 #: eeschema/onrightclick.cpp:199 pcbnew/menubar_footprint_editor.cpp:182
 #: pcbnew/menubar_pcb_editor.cpp:530
 msgid "Pastes item(s) from the Clipboard"
-msgstr "Wkleja elementy ze schowka"
+msgstr "Wkleja elementy znajdujące się w schowku"
 
 #: eeschema/libedit_onrightclick.cpp:126 eeschema/libedit_onrightclick.cpp:147
 #: eeschema/libedit_onrightclick.cpp:196 eeschema/libedit_onrightclick.cpp:218
@@ -9203,11 +9363,11 @@ msgstr "Przeciągnij obrys okręgu"
 
 #: eeschema/libedit_onrightclick.cpp:156
 msgid "Edit Circle Options..."
-msgstr ""
+msgstr "Edycja właściwości okręgu..."
 
 #: eeschema/libedit_onrightclick.cpp:171
 msgid "Move Rectangle"
-msgstr "Przesuń prostokąt "
+msgstr "Przesuń prostokąt"
 
 #: eeschema/libedit_onrightclick.cpp:177
 msgid "Edit Rectangle Options..."
@@ -9224,7 +9384,7 @@ msgstr "Przeciągnij krawędź prostokąta"
 #: pcbnew/onrightclick.cpp:758 pcbnew/onrightclick.cpp:851
 #: pcbnew/tools/edit_tool.cpp:129
 msgid "Rotate Clockwise"
-msgstr "Obróć blok w prawo"
+msgstr "Obróć w prawo"
 
 #: eeschema/libedit_onrightclick.cpp:222
 msgid "Drag Edge Point"
@@ -9240,27 +9400,27 @@ msgstr "Edycja właściwości linii..."
 
 #: eeschema/libedit_onrightclick.cpp:314
 msgid "Push Pin Size to Selected Pin"
-msgstr ""
+msgstr "Narzuć rozmiar pinu dla wybranego pinu"
 
 #: eeschema/libedit_onrightclick.cpp:315
 msgid "Push Pin Size to Others"
-msgstr ""
+msgstr "Narzuć rozmiar pinu dla pozostłych"
 
 #: eeschema/libedit_onrightclick.cpp:318
 msgid "Push Pin Name Size to Selected Pin"
-msgstr ""
+msgstr "Narzuć rozmiar nazwy pinu dla wybranego pinu"
 
 #: eeschema/libedit_onrightclick.cpp:319
 msgid "Push Pin Name Size to Others"
-msgstr ""
+msgstr "Narzuć rozmiar nazwy pinu dla pozostałych"
 
 #: eeschema/libedit_onrightclick.cpp:322
 msgid "Push Pin Num Size to Selected Pin"
-msgstr ""
+msgstr "Narzuć rozmiar numeru pinu dla wybranego pinu"
 
 #: eeschema/libedit_onrightclick.cpp:323
 msgid "Push Pin Num Size to Others"
-msgstr ""
+msgstr "Narzuć rozmiar numeru pinu dla pozostałych"
 
 #: eeschema/libedit_onrightclick.cpp:332 eeschema/onrightclick.cpp:860
 #: gerbview/onrightclick.cpp:74 pagelayout_editor/onrightclick.cpp:70
@@ -9297,11 +9457,11 @@ msgstr "Duplikuj blok"
 
 #: eeschema/libedit_onrightclick.cpp:356 eeschema/onrightclick.cpp:890
 msgid "Mirror Block Around Horizontal(X) Axis"
-msgstr "Odbicie lustrzane bloku wokół osi poziomej (X)"
+msgstr "Przerzuca blok w poziomie wokół osi X"
 
 #: eeschema/libedit_onrightclick.cpp:360 eeschema/onrightclick.cpp:887
 msgid "Mirror Block Around Vertical(Y) Axis"
-msgstr "Odbicie lustrzane bloku wokół osi pionowej (Y)"
+msgstr "Przerzuca blok w pionie wokół osi Y"
 
 #: eeschema/libedit_onrightclick.cpp:364 eeschema/onrightclick.cpp:385
 #: eeschema/onrightclick.cpp:596 eeschema/onrightclick.cpp:630
@@ -9309,7 +9469,7 @@ msgstr "Odbicie lustrzane bloku wokół osi pionowej (Y)"
 #: pcbnew/footprint_editor_onclick.cpp:295 pcbnew/onrightclick.cpp:440
 #: pcbnew/onrightclick.cpp:754 pcbnew/tools/edit_tool.cpp:134
 msgid "Rotate Counterclockwise"
-msgstr "Obróć blok w lewo"
+msgstr "Obróć w lewo"
 
 #: eeschema/libedit_onrightclick.cpp:367 eeschema/onrightclick.cpp:885
 msgid "Delete Block"
@@ -9327,7 +9487,7 @@ msgstr "Nazwa pliku:"
 #: eeschema/libedit_plot_component.cpp:137
 #, c-format
 msgid "Can't save file \"%s\""
-msgstr "Nie mogę zapisać pliku \"%s\""
+msgstr "Nie można zapisać pliku \"%s\""
 
 #: eeschema/libfield.cpp:56
 msgid "Component Name"
@@ -9344,6 +9504,7 @@ msgid ""
 "The name \"%s\" conflicts with an existing entry in the symbol library \"%s"
 "\"."
 msgstr ""
+"Nazwa \"%s\" jest w konflikcie z obecnym wpisem w bibliotece symboli \"%s\"."
 
 #: eeschema/menubar.cpp:117 eeschema/menubar_libedit.cpp:360
 #: pagelayout_editor/menubar.cpp:236 pcbnew/menubar_footprint_editor.cpp:525
@@ -9354,7 +9515,7 @@ msgstr "&Dodaj"
 #: eeschema/menubar.cpp:118 pcbnew/menubar_footprint_editor.cpp:526
 #: pcbnew/menubar_pcb_editor.cpp:144
 msgid "&Inspect"
-msgstr "&Inspekcja"
+msgstr "Inspekcja"
 
 #: eeschema/menubar.cpp:119 kicad/menubar.cpp:475
 #: pcbnew/menubar_footprint_editor.cpp:527 pcbnew/menubar_pcb_editor.cpp:145
@@ -9369,7 +9530,7 @@ msgstr "Ustawienia"
 
 #: eeschema/menubar.cpp:134
 msgid "Library &Browser"
-msgstr "Przeglądarka &bibliotek"
+msgstr "Przeglądarka bibliotek"
 
 #: eeschema/menubar.cpp:139
 msgid "Show &Hierarchical Navigator"
@@ -9385,9 +9546,8 @@ msgstr "Opuść arkusz"
 
 #: eeschema/menubar.cpp:174 eeschema/menubar_libedit.cpp:162
 #: eeschema/tool_viewlib.cpp:188 pcbnew/menubar_footprint_editor.cpp:226
-#, fuzzy
 msgid "&Zoom to Fit"
-msgstr "Pomniejsz"
+msgstr "Dopasuj powiększenie"
 
 #: eeschema/menubar.cpp:191 gerbview/menubar.cpp:217
 #: pagelayout_editor/menubar.cpp:176 pagelayout_editor/pl_editor_config.cpp:67
@@ -9398,22 +9558,22 @@ msgstr "Pokaż siatkę"
 #: eeschema/menubar.cpp:197 gerbview/menubar.cpp:227
 #: pcbnew/menubar_footprint_editor.cpp:256 pcbnew/menubar_pcb_editor.cpp:651
 msgid "&Imperial"
-msgstr "Calowe"
+msgstr "Cale"
 
 #: eeschema/menubar.cpp:197 gerbview/menubar.cpp:227
 #: pcbnew/menubar_footprint_editor.cpp:256 pcbnew/menubar_pcb_editor.cpp:651
 msgid "Use imperial units"
-msgstr "Calowy system miary"
+msgstr "Użyj cali"
 
 #: eeschema/menubar.cpp:201 gerbview/menubar.cpp:231
 #: pcbnew/menubar_footprint_editor.cpp:260 pcbnew/menubar_pcb_editor.cpp:655
 msgid "&Metric"
-msgstr "&Metryczne"
+msgstr "Metryczne"
 
 #: eeschema/menubar.cpp:201 gerbview/menubar.cpp:231
 #: pcbnew/menubar_footprint_editor.cpp:260 pcbnew/menubar_pcb_editor.cpp:655
 msgid "Use metric units"
-msgstr "Metryczny system miary"
+msgstr "Użyj jednostek metrycznych"
 
 #: eeschema/menubar.cpp:205 gerbview/menubar.cpp:235
 #: pcbnew/menubar_footprint_editor.cpp:264 pcbnew/menubar_pcb_editor.cpp:659
@@ -9423,25 +9583,23 @@ msgstr "Jednostki"
 #: eeschema/menubar.cpp:206 gerbview/menubar.cpp:236
 #: pcbnew/menubar_footprint_editor.cpp:265 pcbnew/menubar_pcb_editor.cpp:660
 msgid "Select which units are displayed"
-msgstr "Wybierz które jednostki będą wyświetlane"
+msgstr "Wybiera jakie jednostki mają być wyświetlane"
 
 #: eeschema/menubar.cpp:212 eeschema/menubar.cpp:217
-#, fuzzy
 msgid "Full &Window Crosshair"
-msgstr "Pełnoekranowy krzyż"
+msgstr "Kursor pełnoekranowy"
 
 #: eeschema/menubar.cpp:218
 msgid "Change cursor shape (not supported in Legacy graphics)"
-msgstr ""
+msgstr "Zmień kształt kursora (nie wspierane w trybie Legacy)"
 
 #: eeschema/menubar.cpp:225
-#, fuzzy
 msgid "Show Hidden &Pins"
 msgstr "Pokaż ukryte piny"
 
 #: eeschema/menubar.cpp:239 eeschema/menubar_libedit.cpp:359
 msgid "&Symbol"
-msgstr "&Symbol"
+msgstr "Symbol"
 
 #: eeschema/menubar.cpp:245
 msgid "&Power Port"
@@ -9465,7 +9623,7 @@ msgstr "Wejście magis&trali do magistrali"
 
 #: eeschema/menubar.cpp:275
 msgid "&No Connect Flag"
-msgstr "Flaga \"&Niepołączone\""
+msgstr "Flaga &Niepołączone"
 
 #: eeschema/menubar.cpp:279
 msgid "&Junction"
@@ -9485,7 +9643,7 @@ msgstr "Etykieta &hierarchiczna"
 
 #: eeschema/menubar.cpp:306
 msgid "Hierar&chical Sheet"
-msgstr "Arkusz &hierarchiczny"
+msgstr "Arkusz hierarchiczny"
 
 #: eeschema/menubar.cpp:314
 msgid "I&mport Hierarchical Label"
@@ -9509,17 +9667,18 @@ msgstr "Obraz"
 
 #: eeschema/menubar.cpp:365
 msgid "&New..."
-msgstr "&Nowy..."
+msgstr "Nowy..."
 
 #: eeschema/menubar.cpp:367
 msgid "Clear current schematic hierarchy and start new schematic root sheet"
 msgstr ""
-"Wyczyść bieżący schemat hierarchiczny i utwórz nowy główny arkusz schematu"
+"Czyści bieżącą hierarchię schematów i rozpoczyna nową z pustym schematem "
+"głównym"
 
 #: eeschema/menubar.cpp:370 pagelayout_editor/menubar.cpp:67
 #: pcbnew/menubar_pcb_editor.cpp:802
 msgid "&Open..."
-msgstr "&Otwórz..."
+msgstr "Otwórz..."
 
 #: eeschema/menubar.cpp:372
 msgid "Open existing schematic"
@@ -9532,7 +9691,7 @@ msgstr "Ostatnio otwie&rane"
 
 #: eeschema/menubar.cpp:377
 msgid "Open recently opened schematic"
-msgstr ""
+msgstr "Otwiera jeden z często otwieranych schematów"
 
 #: eeschema/menubar.cpp:383 kicad/menubar.cpp:254
 #: pagelayout_editor/menubar.cpp:83 pcbnew/menubar_footprint_editor.cpp:78
@@ -9542,11 +9701,11 @@ msgstr "&Zapisz"
 
 #: eeschema/menubar.cpp:386
 msgid "Save all sheets in schematic"
-msgstr "Zapisz wszystkie arkusze schematów"
+msgstr "Zapisz wszystkie arkusze ze schematu"
 
 #: eeschema/menubar.cpp:391
 msgid "Save &Current Sheet"
-msgstr "Zapisz bieżą&cy arkusz"
+msgstr "Zapisz bieżący arkusz"
 
 #: eeschema/menubar.cpp:392
 msgid "Save only current schematic sheet"
@@ -9554,32 +9713,32 @@ msgstr "Zapisuje tylko bieżący arkusz"
 
 #: eeschema/menubar.cpp:397
 msgid "Save C&urrent Sheet As..."
-msgstr "Zapisz bieżący ark&usz jako..."
+msgstr "Zapisz bieżący arkusz jako..."
 
 #: eeschema/menubar.cpp:401
 msgid "Save current schematic sheet with new name"
-msgstr "Zapisz bieżący arkusz schematu z nową nazwą"
+msgstr "Zapisuje bieżący schemat pod nową nazwą"
 
 #: eeschema/menubar.cpp:408
 msgid "App&end Schematic Sheet..."
-msgstr "Dodaj arkusz sch&ematu..."
+msgstr "Dołącz arkusz schematu..."
 
 #: eeschema/menubar.cpp:409
 msgid "Import schematic sheet content from another project to current sheet"
 msgstr ""
-"Importuj zawartość arkusza schematu z innego projektu do bieżącego arkusza"
+"Importuje zawartość arkusza schematu z innego projektu do obecnego arkusza"
 
 #: eeschema/menubar.cpp:413
 msgid "&Import Non KiCad Schematic File..."
-msgstr "&Importuj inne pliki schematów..."
+msgstr "Importuj schemat spoza programu KiCad..."
 
 #: eeschema/menubar.cpp:414
 msgid "Import schematic file from other applications"
-msgstr "Importuje pliki schematów z pozostałych aplikacji "
+msgstr "Importuje plik schematu z innej aplikacji"
 
 #: eeschema/menubar.cpp:423
 msgid "&Footprint Association File..."
-msgstr "Plik skojarzeń &footprintów..."
+msgstr "Pliki przypisywania footprintów..."
 
 #: eeschema/menubar.cpp:429 pcbnew/menubar_footprint_editor.cpp:105
 #: pcbnew/menubar_pcb_editor.cpp:883
@@ -9593,11 +9752,11 @@ msgstr "Importuj pliki"
 
 #: eeschema/menubar.cpp:438
 msgid "Drawing to C&lipboard"
-msgstr "Umieść rysunek w schowku"
+msgstr "Eksportuj rysunki do schowka"
 
 #: eeschema/menubar.cpp:439
 msgid "Export drawings to clipboard"
-msgstr "Eksportuj rysunki do schowka."
+msgstr "Eksportuj rysunki do schowka"
 
 #: eeschema/menubar.cpp:444 pcbnew/menubar_footprint_editor.cpp:123
 #: pcbnew/menubar_pcb_editor.cpp:892
@@ -9606,15 +9765,15 @@ msgstr "Eksportuj"
 
 #: eeschema/menubar.cpp:445 pcbnew/menubar_footprint_editor.cpp:124
 msgid "Export files"
-msgstr "Eksportuj pliki do schowka"
+msgstr "Eksportuj pliki"
 
 #: eeschema/menubar.cpp:452 pcbnew/menubar_pcb_editor.cpp:931
 msgid "Page S&ettings..."
-msgstr "Ustawi&enia strony..."
+msgstr "Ustawienia strony..."
 
 #: eeschema/menubar.cpp:453 pcbnew/menubar_pcb_editor.cpp:932
 msgid "Settings for sheet size and frame references"
-msgstr "Ustawienia rozmiaru arkusza i danych ramki"
+msgstr "Ustawienia rozmiaru strony oraz ramki tytułowej"
 
 #: eeschema/menubar.cpp:456 gerbview/menubar.cpp:163
 #: pagelayout_editor/menubar.cpp:95 pcbnew/menubar_footprint_editor.cpp:132
@@ -9628,7 +9787,7 @@ msgstr "Drukuj schemat"
 
 #: eeschema/menubar.cpp:461 pcbnew/menubar_pcb_editor.cpp:941
 msgid "P&lot..."
-msgstr "Rysuj"
+msgstr "Rysuj..."
 
 #: eeschema/menubar.cpp:462
 msgid "Plot schematic sheet in PostScript, PDF, SVG, DXF or HPGL format"
@@ -9637,7 +9796,7 @@ msgstr ""
 
 #: eeschema/menubar.cpp:468
 msgid "Close Eeschema"
-msgstr "Zamknij Eeschema"
+msgstr "Zamyka Eeschema"
 
 #: eeschema/menubar.cpp:478 eeschema/menubar_libedit.cpp:121
 #: pcbnew/menubar_footprint_editor.cpp:158 pcbnew/menubar_pcb_editor.cpp:508
@@ -9656,7 +9815,7 @@ msgstr "Wytnij"
 #: eeschema/menubar.cpp:491 pcbnew/menubar_footprint_editor.cpp:176
 #: pcbnew/menubar_pcb_editor.cpp:520
 msgid "Cuts the selected item(s) to the Clipboard"
-msgstr "Wycina zaznaczone elementy do schowka"
+msgstr "Wycina zaznaczone elementy i umieszcza je w schowku"
 
 #: eeschema/menubar.cpp:494 pcbnew/menubar_footprint_editor.cpp:177
 #: pcbnew/menubar_pcb_editor.cpp:523
@@ -9666,7 +9825,7 @@ msgstr "Kopiuj"
 #: eeschema/menubar.cpp:496 pcbnew/menubar_footprint_editor.cpp:179
 #: pcbnew/menubar_pcb_editor.cpp:525
 msgid "Copies the selected item(s) to the Clipboard"
-msgstr "Kopiuje zaznaczone elementy do schowka"
+msgstr "Kopiuje wybrane elementy i umieszcza je w schowku"
 
 #: eeschema/menubar.cpp:507 pcbnew/menubar_footprint_editor.cpp:189
 #: pcbnew/menubar_pcb_editor.cpp:535
@@ -9675,19 +9834,19 @@ msgstr "&Usuń"
 
 #: eeschema/menubar.cpp:512 pcbnew/menubar_pcb_editor.cpp:540
 msgid "&Find..."
-msgstr "Znajdź"
+msgstr "Znajdź..."
 
 #: eeschema/menubar.cpp:516
 msgid "Find and Re&place..."
-msgstr "Znajdź i zamień"
+msgstr "Wyszukaj i zamień..."
 
 #: eeschema/menubar.cpp:525
 msgid "Update Field Values..."
-msgstr "Zaktualizuj wartości pól..."
+msgstr "Uaktualnij pola z wartościami..."
 
 #: eeschema/menubar.cpp:526
 msgid "Sets symbol fields to original library values"
-msgstr ""
+msgstr "Ustawia pola symboli do ich wartości oryginalnych z biblioteki"
 
 #: eeschema/menubar.cpp:534
 msgid "Electrical Rules &Checker"
@@ -9699,90 +9858,87 @@ msgstr "Przeprowadza kontrolę reguł projektowych pod względem elektrycznym"
 
 #: eeschema/menubar.cpp:544 pcbnew/menubar_pcb_editor.cpp:423
 msgid "Update PCB from Schematic..."
-msgstr "Aktualizuj płytkę ze schematu..."
+msgstr "Uaktualnij PCB na podstawie schematu..."
 
 #: eeschema/menubar.cpp:549
 msgid "Updates PCB design with current schematic (forward annotation)."
-msgstr ""
-"Aktualizuje projekt płytki z bieżącym schematem  (adnotacja do przodu)."
+msgstr "Uaktualnia projekt PCB na podstawie bieżącego schematu."
 
 #: eeschema/menubar.cpp:555
 msgid "&Open PCB Editor"
-msgstr "&Otwórz edytor PCB"
+msgstr "Otwórz edytor PCB"
 
 #: eeschema/menubar.cpp:556 kicad/menubar.cpp:148
 msgid "Run Pcbnew"
 msgstr "Uruchom Pcbnew"
 
 #: eeschema/menubar.cpp:563
-#, fuzzy
 msgid "Symbol Library &Editor"
-msgstr "Edytor bibliotek symboli -"
+msgstr "Edytor bibliotek symboli"
 
 #: eeschema/menubar.cpp:568
 msgid "&Rescue Symbols..."
-msgstr "Odzyskiwanie symboli..."
+msgstr "Odzyskiwanie zmienionych symboli..."
 
 #: eeschema/menubar.cpp:569
 msgid "Find old symbols in project and rename/rescue them"
-msgstr "Znajduje starsze symbole w projekcie i zmienia ich nazwę - odzyskuje"
+msgstr ""
+"Wyszukuje stare wersje symboli w projekcie, zmienia im nazwy i odzyskuje"
 
 #: eeschema/menubar.cpp:574
 msgid "Remap Symbols..."
-msgstr "Odzyskaj symbole..."
+msgstr "Remapowanie symboli..."
 
 #: eeschema/menubar.cpp:575
 msgid "Remap legacy library symbols to symbol library table"
-msgstr "Przenosi starsze symbole do tabeli bibliotek symboli"
+msgstr ""
+"Przeprowadza mapowanie starszych bibliotek symboli do tabeli bibliotek "
+"symboli"
 
 #: eeschema/menubar.cpp:582
-#, fuzzy
 msgid "Edit Symbol Field&s..."
-msgstr "Edytuj pole..."
+msgstr "Edycja pól symboli..."
 
 #: eeschema/menubar.cpp:587
-#, fuzzy
 msgid "Edit Symbol Library References..."
-msgstr "Edycja linków bibliotek symboli..."
+msgstr "Edycja odnośników w bibliotece symboli..."
 
 #: eeschema/menubar.cpp:588
-#, fuzzy
 msgid "Edit links between schematic symbols and library symbols"
-msgstr "Edycja linków do bibliotek symboli schematowych"
+msgstr ""
+"Pozwala na edycję łącz pomiędzy symbolami na schemacie a biblioteką symboli"
 
 #: eeschema/menubar.cpp:595
 msgid "&Annotate Schematic..."
-msgstr "Numer&acja elementów na schemacie..."
+msgstr "Numeruj schemat..."
 
 #: eeschema/menubar.cpp:600
 msgid "Generate &Netlist File..."
-msgstr "Tworzenie pliku listy połączeń..."
+msgstr "Generuj listę sieci..."
 
 #: eeschema/menubar.cpp:601
 msgid "Generate netlist file"
-msgstr "Generowanie pliku listy połączeń"
+msgstr "Generuje listę sieci w wybranym formacie"
 
 #: eeschema/menubar.cpp:606
 msgid "Generate Bill of &Materials..."
-msgstr "Generowanie listy &materiałów..."
+msgstr "Generuj listę &materiałową..."
 
 #: eeschema/menubar.cpp:615
-#, fuzzy
 msgid "A&ssign Footprints..."
-msgstr "Kojarzenie elementów"
+msgstr "Przypisz footprinty..."
 
 #: eeschema/menubar.cpp:616 eeschema/tool_sch.cpp:162
-#, fuzzy
 msgid "Assign PCB footprints to schematic symbols"
-msgstr "Numeracja elementów na schemacie"
+msgstr "Przypisuje footprinty symbolom na schemacie"
 
 #: eeschema/menubar.cpp:625
 msgid "Simula&tor"
-msgstr "Symula&tor"
+msgstr "Symulator"
 
 #: eeschema/menubar.cpp:625
 msgid "Simulate circuit"
-msgstr "Symulacja obwodu"
+msgstr "Symuluj obwód"
 
 #: eeschema/menubar.cpp:636 eeschema/menubar_libedit.cpp:323
 #: eeschema/tool_viewlib.cpp:205
@@ -9796,71 +9952,67 @@ msgstr "Otwiera podręcznik do programu Eeschema"
 #: eeschema/menubar.cpp:650 pcbnew/menubar_footprint_editor.cpp:503
 msgid "Displays current hotkeys table and corresponding commands"
 msgstr ""
+"Wyświetla bieżącą tabelę skrótów klawiszowych oraz przypisane im polecenia"
 
 #: eeschema/menubar.cpp:673 eeschema/menubar_libedit.cpp:291
 #: kicad/menubar.cpp:337 pcbnew/menubar_footprint_editor.cpp:440
 #: pcbnew/menubar_pcb_editor.cpp:331
 msgid "Configure Pa&ths..."
-msgstr "Konfiguracja ścieżek..."
+msgstr "Konfiguracja ścieżek dostępu..."
 
 #: eeschema/menubar.cpp:680 eeschema/menubar_libedit.cpp:298
 msgid "Manage Symbol Libraries..."
-msgstr ""
+msgstr "Zarządzaj bibliotekami symboli..."
 
 #: eeschema/menubar.cpp:681
-#, fuzzy
 msgid "Edit the global and project symbol library lists"
-msgstr "Edycja linków do bibliotek symboli schematowych"
+msgstr "Edycja globalnej oraz projektowej tabeli bibliotek symboli"
 
 #: eeschema/menubar.cpp:690
 msgid "General &Options"
-msgstr "&Opcje główne"
+msgstr "Opcje główne"
 
 #: eeschema/menubar.cpp:691
 msgid "Edit Eeschema preferences"
-msgstr "Edycja ustawień Eeschema"
+msgstr "Zmienia preferencje Eeschema"
 
 #: eeschema/menubar.cpp:729 pcbnew/menubar_pcb_editor.cpp:245
-#, fuzzy
 msgid "&Save Project File..."
-msgstr "Zapi&sz plik projektu"
+msgstr "Zapisz plik projektu..."
 
 #: eeschema/menubar.cpp:730 pcbnew/menubar_pcb_editor.cpp:246
 msgid "Save project preferences into a project file"
-msgstr ""
+msgstr "Zapisuje ustawienia w pliku projektu"
 
 #: eeschema/menubar.cpp:735 pcbnew/menubar_pcb_editor.cpp:250
-#, fuzzy
 msgid "Load P&roject File..."
-msgstr "Odczytaj plik projektu"
+msgstr "Odczytaj plik projektu..."
 
 #: eeschema/menubar.cpp:736 pcbnew/menubar_pcb_editor.cpp:251
-#, fuzzy
 msgid "Load project preferences from a project file"
-msgstr "Rozpakuj wszystkie pliki projektu z archiwum Zip"
+msgstr "Wczytuje ustawienia z pliku projektu"
 
 #: eeschema/menubar_libedit.cpp:60 eeschema/widgets/cmp_tree_pane.cpp:52
 #: eeschema/widgets/cmp_tree_pane.cpp:93
 msgid "&New Library..."
-msgstr "&Nowa biblioteka..."
+msgstr "Nowa biblioteka..."
 
 #: eeschema/menubar_libedit.cpp:61
 msgid "Creates an empty library"
-msgstr "Utwórz pustą bibliotekę"
+msgstr "Tworzy pustą bibliotekę"
 
 #: eeschema/menubar_libedit.cpp:66 eeschema/widgets/cmp_tree_pane.cpp:54
 #: eeschema/widgets/cmp_tree_pane.cpp:95
 msgid "&Add Library..."
-msgstr "Dod&aj bibliotekę..."
+msgstr "Dodaj bibliotekę..."
 
 #: eeschema/menubar_libedit.cpp:67
 msgid "Adds a previously created library"
-msgstr ""
+msgstr "Dodaje istniejącą już biliotekę"
 
 #: eeschema/menubar_libedit.cpp:77
-#, fuzzy
 msgid "Save the current library"
-msgstr "Zapisz bieżącą bibliotekę"
+msgstr "Zapisuje bieżącą bibliotekę"
 
 #: eeschema/menubar_libedit.cpp:82 eeschema/widgets/cmp_tree_pane.cpp:58
 msgid "Save Library As..."
@@ -9868,31 +10020,31 @@ msgstr "Zapisz bibliotekę jako..."
 
 #: eeschema/menubar_libedit.cpp:83
 msgid "Save the current library to a new file"
-msgstr "Zapisuje bieżąca bibliotekę w nowym pliku"
+msgstr "Zapisuje bieżącą bibliotekę jako nowy plik"
 
 #: eeschema/menubar_libedit.cpp:87
 msgid "Save all library changes"
-msgstr "Zapisz wszystkie zmiany w bibliotece"
+msgstr "Zapisuje wszystkie zmiany w bibliotekach"
 
 #: eeschema/menubar_libedit.cpp:96
 msgid "Export Current View as &PNG..."
-msgstr "Eksportuj bieżący widok jako &PNG..."
+msgstr "Eksportuj bieżący widok jako plik PNG..."
 
 #: eeschema/menubar_libedit.cpp:97
 msgid "Create a PNG file from the current view"
-msgstr "Utwórz plik PNG z bieżącego widoku"
+msgstr "Tworzy obrazek PNG z aktualnie załadowanego symbolu"
 
 #: eeschema/menubar_libedit.cpp:103
 msgid "Create S&VG File..."
-msgstr "Utwórz plik S&VG..."
+msgstr "Utwórz plik SVG..."
 
 #: eeschema/menubar_libedit.cpp:104
 msgid "Create a SVG file from the current symbol"
-msgstr "Utwórz plik SVG z bieżącego symbolu"
+msgstr "Tworzy obrazek SVG z aktualnie załadowanego symbolu"
 
 #: eeschema/menubar_libedit.cpp:113
 msgid "&Quit"
-msgstr "Zakończ "
+msgstr "Zakończ"
 
 #: eeschema/menubar_libedit.cpp:114
 msgid "Quit Library Editor"
@@ -9908,9 +10060,8 @@ msgstr "Ponów ostatnio cofniętą operację"
 
 #: eeschema/menubar_libedit.cpp:163 eeschema/tool_lib.cpp:184
 #: eeschema/tool_viewlib.cpp:81 eeschema/tool_viewlib.cpp:189
-#, fuzzy
 msgid "Zoom to fit symbol"
-msgstr "Importuj symbol"
+msgstr "Dopasuj powiększenie by zmieścić symbol"
 
 #: eeschema/menubar_libedit.cpp:179
 msgid "&Search Tree"
@@ -9918,23 +10069,23 @@ msgstr "Drzewo wyszukiwania"
 
 #: eeschema/menubar_libedit.cpp:180
 msgid "Toggles the search tree visibility"
-msgstr ""
+msgstr "Przełącza widoczność drzewa wyszukiwania bibliotek"
 
 #: eeschema/menubar_libedit.cpp:188
 msgid "&New Symbol..."
-msgstr "&Nowy symbol..."
+msgstr "Nowy symbol..."
 
 #: eeschema/menubar_libedit.cpp:189
 msgid "Create a new empty symbol"
-msgstr ""
+msgstr "Tworzy nowy pusty symbol"
 
 #: eeschema/menubar_libedit.cpp:195
 msgid "Saves the current symbol to the library"
-msgstr ""
+msgstr "Zapisuje bieżący symbol w bibliotece"
 
 #: eeschema/menubar_libedit.cpp:202 eeschema/widgets/cmp_tree_pane.cpp:66
 msgid "&Import Symbol..."
-msgstr "&Importuj symbol..."
+msgstr "Importuj symbol..."
 
 #: eeschema/menubar_libedit.cpp:203
 msgid "Import a symbol to the current library"
@@ -9942,11 +10093,11 @@ msgstr "Importuje symbol do bieżącej biblioteki"
 
 #: eeschema/menubar_libedit.cpp:208
 msgid "&Export Symbol..."
-msgstr "&Eksportuj symbol..."
+msgstr "Eksportuj symbol..."
 
 #: eeschema/menubar_libedit.cpp:209
 msgid "Export the current symbol"
-msgstr "Eksportuje bieżący symbol "
+msgstr "Eksportuje bieżący symbol"
 
 #: eeschema/menubar_libedit.cpp:216
 msgid "&Properties..."
@@ -9954,7 +10105,7 @@ msgstr "Właściwości..."
 
 #: eeschema/menubar_libedit.cpp:217 eeschema/tool_lib.cpp:161
 msgid "Edit symbol properties"
-msgstr ""
+msgstr "Zmień właściwości symbolu"
 
 #: eeschema/menubar_libedit.cpp:222
 msgid "&Fields..."
@@ -9962,11 +10113,11 @@ msgstr "Pola..."
 
 #: eeschema/menubar_libedit.cpp:223 eeschema/tool_lib.cpp:165
 msgid "Edit field properties"
-msgstr "Edycja właściwości pól"
+msgstr "Zmienia właściwości pola"
 
 #: eeschema/menubar_libedit.cpp:230
 msgid "Pi&n Table..."
-msgstr ""
+msgstr "Tabela pinów..."
 
 #: eeschema/menubar_libedit.cpp:231 eeschema/tool_lib.cpp:234
 msgid "Show pin table"
@@ -9974,7 +10125,7 @@ msgstr "Pokaż tabelę pinów"
 
 #: eeschema/menubar_libedit.cpp:237 eeschema/tool_lib.cpp:170
 msgid "Check duplicate and off grid pins"
-msgstr ""
+msgstr "Sprawdza czy istnieją duplikaty pinów lub piny poza siatką"
 
 #: eeschema/menubar_libedit.cpp:246
 msgid "&Pin"
@@ -10004,15 +10155,15 @@ msgstr "&Linia lub wielokąt (grafika)"
 
 #: eeschema/menubar_libedit.cpp:299
 msgid "Edit the global and project symbol library tables."
-msgstr ""
+msgstr "Edycja globalnej oraz projektowej tabeli bibliotek symboli."
 
 #: eeschema/menubar_libedit.cpp:307
 msgid "General &Options..."
-msgstr "&Opcje główne..."
+msgstr "Opcje główne..."
 
 #: eeschema/menubar_libedit.cpp:308
 msgid "Set Symbol Editor default values and options"
-msgstr ""
+msgstr "Ustala domyślne wartości oraz opcje Edytora symboli"
 
 #: eeschema/menubar_libedit.cpp:324
 msgid "Open the Eeschema Manual"
@@ -10022,19 +10173,19 @@ msgstr "Otwiera podręcznik programu Eeschema"
 #: pcbnew/menubar_footprint_editor.cpp:497 pcbnew/tool_footprint_viewer.cpp:181
 msgid "Open the \"Getting Started in KiCad\" guide for beginners"
 msgstr ""
-"Otwiera przewodnik dla początkujących zatytułowany \"Pierwsze kroki w "
-"programie KiCad\""
+"Otwiera przewodnik \"Pierwsze kroki w programie KiCad\" przeznaczony dla "
+"początkujących"
 
 #: eeschema/netlist_exporters/netlist_exporter_cadstar.cpp:47
 #: eeschema/netlist_exporters/netlist_exporter_orcadpcb2.cpp:53
 #, c-format
 msgid "Failed to create file \"%s\""
-msgstr "Nie można utworzyć pliku \"%s\""
+msgstr "Nie można było utworzyć pliku \"%s\""
 
 #: eeschema/netlist_exporters/netlist_exporter_pspice.cpp:103
 #, c-format
 msgid "Could not find library file %s"
-msgstr ""
+msgstr "Nie można odnaleźć pliku biblioteki %s"
 
 #: eeschema/netlist_generator.cpp:115
 msgid "Run command:"
@@ -10060,6 +10211,8 @@ msgstr "Błędy:"
 #: eeschema/netlist_generator.cpp:175
 msgid "Exporting the netlist requires a completely annotated schematic."
 msgstr ""
+"Eksport listy sieci wymaga by elementy na schemacie zostały w pełni "
+"ponumerowane."
 
 #: eeschema/netlist_generator.cpp:184
 msgid "Error: duplicate sheet names. Continue?"
@@ -10096,7 +10249,7 @@ msgstr "Edytuj obraz..."
 
 #: eeschema/onrightclick.cpp:220
 msgid "Delete No Connect"
-msgstr "Usuń \"Nie Połączone\""
+msgstr "Usuń znaczniki Niepołączone"
 
 #: eeschema/onrightclick.cpp:278 pcbnew/onrightclick.cpp:159
 msgid "End Drawing"
@@ -10169,16 +10322,16 @@ msgstr "Przeciągnij"
 #: eeschema/onrightclick.cpp:387 eeschema/onrightclick.cpp:800
 #: eeschema/onrightclick.cpp:927
 msgid "Mirror Around Horizontal(X) Axis"
-msgstr "Odbicie wokół osi poziomej (X)"
+msgstr "Odbija poziomo wokół osi X"
 
 #: eeschema/onrightclick.cpp:390 eeschema/onrightclick.cpp:803
 #: eeschema/onrightclick.cpp:930
 msgid "Mirror Around Vertical(Y) Axis"
-msgstr "Odbicie wokół osi pionowej (Y)"
+msgstr "Odbija pionowo wokół osi Y"
 
 #: eeschema/onrightclick.cpp:393
 msgid "Reset to Default"
-msgstr "Przywróć ustawienia domyślne"
+msgstr "Resetuj do domyślnych"
 
 #: eeschema/onrightclick.cpp:403 eeschema/onrightclick.cpp:519
 #: eeschema/onrightclick.cpp:591 eeschema/onrightclick.cpp:625
@@ -10201,7 +10354,7 @@ msgstr "Edytuj właściwości..."
 
 #: eeschema/onrightclick.cpp:458
 msgid "Edit Footprint..."
-msgstr "Edycja footprintu..."
+msgstr "Eydycja footprintu..."
 
 #: eeschema/onrightclick.cpp:495
 msgid "Edit with Library Editor"
@@ -10292,15 +10445,15 @@ msgstr "Wejdź w arkusz"
 
 #: eeschema/onrightclick.cpp:788
 msgid "Select Items On PCB"
-msgstr "Zaznacz elementy na PCB"
+msgstr "Wybierz elementy na PCB"
 
 #: eeschema/onrightclick.cpp:813
 msgid "Place"
-msgstr "Umieść"
+msgstr "Wstaw"
 
 #: eeschema/onrightclick.cpp:820
 msgid "Resize"
-msgstr "Zmień"
+msgstr "Zmień rozmiar"
 
 #: eeschema/onrightclick.cpp:823
 msgid "Import Sheet Pins"
@@ -10421,6 +10574,9 @@ msgid ""
 "It will be not easy to connect in schematic\n"
 "Do you want to continue?"
 msgstr ""
+"Ten pin nie pasuje do siatki %d mils.\n"
+"Nie będzie łatwo go połączyć na schemacie!\n"
+"Czy chcesz kontynuować?"
 
 #: eeschema/pinedit.cpp:272
 #, c-format
@@ -10428,6 +10584,8 @@ msgid ""
 "This position is already occupied by another pin, in unit %d.\n"
 "Continue?"
 msgstr ""
+"Ta pozycja jest zajmowana przez inny pin w elemencie %d.\n"
+"Kontynuować?"
 
 #: eeschema/pinedit.cpp:697
 msgid "No pins!"
@@ -10449,7 +10607,7 @@ msgstr ""
 #: eeschema/pinedit.cpp:742
 #, c-format
 msgid " in units %c and %c"
-msgstr ""
+msgstr " w jednostkach %c oraz %c"
 
 #: eeschema/pinedit.cpp:750 eeschema/pinedit.cpp:790
 msgid "  of converted"
@@ -10467,7 +10625,7 @@ msgstr "<b>Pin poza siatką %s</b> \"%s\" na pozycji <b>(%.3f, %.3f)</b>"
 #: eeschema/pinedit.cpp:784
 #, c-format
 msgid " in symbol %c"
-msgstr "w symbolu %c"
+msgstr " w symbolu %c"
 
 #: eeschema/pinedit.cpp:801
 msgid "No off grid or duplicate pins were found."
@@ -10478,18 +10636,18 @@ msgstr "Nie znaleziono pinów zdblowanych lub poza siatką."
 #: eeschema/plot_schematic_SVG.cpp:82
 #, c-format
 msgid "Plot: \"%s\" OK.\n"
-msgstr "Rysunek: \"%s\" OK.\n"
+msgstr "Rysowanie: \"%s\" OK.\n"
 
 #: eeschema/plot_schematic_DXF.cpp:84 eeschema/plot_schematic_HPGL.cpp:181
 #: eeschema/plot_schematic_PDF.cpp:90 eeschema/plot_schematic_PS.cpp:112
 #, c-format
 msgid "Unable to create file \"%s\".\n"
-msgstr "Nie mogę utworzyć pliku \"%s\".\n"
+msgstr "Nie można utworzyć pliku \"%s\".\n"
 
 #: eeschema/plot_schematic_SVG.cpp:76
 #, c-format
 msgid "Cannot create file \"%s\".\n"
-msgstr "Nie mogę utworzyć pliku \"%s\".\n"
+msgstr "Nie dało się utworzyć pliku \"%s\".\n"
 
 #: eeschema/project_rescue.cpp:189
 #, c-format
@@ -10501,16 +10659,20 @@ msgstr "Zmień nazwę na %s"
 msgid ""
 "Cannot rescue symbol %s which is not available in any library or the cache."
 msgstr ""
+"Symbol %s nie został znaleziony w żadnej z bibliotek lub pamięci podręcznej "
+"i nie może zostać odzyskany."
 
 #: eeschema/project_rescue.cpp:291 eeschema/project_rescue.cpp:424
 #, c-format
 msgid "Rescue symbol %s found only in cache library to %s."
 msgstr ""
+"Odzyskany symbol %s został odnaleziony tylko w pamięci podręcznej biblioteki "
+"%s."
 
 #: eeschema/project_rescue.cpp:294 eeschema/project_rescue.cpp:427
 #, c-format
 msgid "Rescue modified symbol %s to %s"
-msgstr ""
+msgstr "Odzyskiwanie zmodyfikowało symbol %s do %s"
 
 #: eeschema/project_rescue.cpp:528
 msgid "This project has nothing to rescue."
@@ -10523,21 +10685,21 @@ msgstr "Żadne symbole nie zostały odzyskake."
 #: eeschema/project_rescue.cpp:663
 #, c-format
 msgid "Failed to create symbol library file \"%s\""
-msgstr ""
+msgstr "Nie dało się utworzyć pliku bibliotek symboli \"%s\""
 
 #: eeschema/project_rescue.cpp:787
 #, c-format
 msgid "Failed to save rescue library %s."
-msgstr ""
+msgstr "Zapis biblioteki odzyskiwania %s nie powiódł się."
 
 #: eeschema/project_rescue.cpp:811
 msgid "Error occurred saving project specific symbol library table."
-msgstr ""
+msgstr "Wystąpił błąd podczas zapisywania tabeli bibliotek projektu."
 
 #: eeschema/sch_base_frame.cpp:62
 #, c-format
 msgid "Could not load symbol \"%s\" from library \"%s\"."
-msgstr ""
+msgstr "Nie można załadować symbolu \"%s\" z biblioteki \"%s\"."
 
 #: eeschema/sch_base_frame.cpp:332
 #, c-format
@@ -10546,6 +10708,9 @@ msgid ""
 "\n"
 "%s"
 msgstr ""
+"Wystąpił błąd podczas zapisywania globalnej tabeli bibliotek:\n"
+"\n"
+"%s"
 
 #: eeschema/sch_base_frame.cpp:350
 #, c-format
@@ -10554,6 +10719,9 @@ msgid ""
 "\n"
 "%s"
 msgstr ""
+"Wystąpił błąd podczas zapisywania tabeli bibliotek projektu:\n"
+"\n"
+"%s"
 
 #: eeschema/sch_bitmap.h:129
 msgid "Image"
@@ -10569,7 +10737,7 @@ msgstr "Wejście magistrali do magistrali"
 
 #: eeschema/sch_collectors.cpp:348
 msgid "(Deleted Item)"
-msgstr "(Usunięty element)"
+msgstr "(Element usunięty)"
 
 #: eeschema/sch_collectors.cpp:497
 #, c-format
@@ -10594,7 +10762,7 @@ msgstr "Biblioteka"
 
 #: eeschema/sch_component.cpp:1417
 msgid "Undefined!!!"
-msgstr "Nieokreślony!!!"
+msgstr "Niezdefiniowany!!!"
 
 #: eeschema/sch_component.cpp:1423
 msgid "<Unknown>"
@@ -10607,7 +10775,7 @@ msgstr "Nie zdefiniowano biblioteki!!!"
 #: eeschema/sch_component.cpp:1452
 #, c-format
 msgid "Symbol not found in %s!!!"
-msgstr "Symbolu nie znaleziono w %s!!!"
+msgstr "Symbou nie znaleziono w %s!!!"
 
 #: eeschema/sch_component.cpp:1688
 #, c-format
@@ -10618,12 +10786,12 @@ msgstr "Symbol %s, %s"
 #: pcbnew/eagle_plugin.cpp:2320
 #, c-format
 msgid "Unable to read file \"%s\""
-msgstr "Nie mogę wczytać pliku \"%s\""
+msgstr "Nie można odczytać pliku \"%s\""
 
 #: eeschema/sch_eagle_plugin.cpp:1086
-#, fuzzy, c-format
+#, c-format
 msgid "Could not find %s in the imported library"
-msgstr "Nie można znaleźć elementu '%s' w bibliotece"
+msgstr "Nie można odnaleźć %s w zaimportowanej bibliotece."
 
 #: eeschema/sch_edit_frame.cpp:177 pcbnew/class_zone.cpp:1085
 msgid "Not Found"
@@ -10641,6 +10809,9 @@ msgid ""
 "\"%s\"\n"
 "before closing?"
 msgstr ""
+"Zapisać zmiany w\n"
+"\"%s\"\n"
+"przed zamknięciem?"
 
 #: eeschema/sch_edit_frame.cpp:788
 msgid "Draw wires and buses in any direction"
@@ -10664,6 +10835,9 @@ msgid ""
 "mode. In order to create/update PCBs from schematics, you need to launch "
 "Kicad shell and create a PCB project."
 msgstr ""
+"Nie można uaktualnić PCB, ponieważ edytor schematów został uruchomiony jako "
+"samodzielna aplikacja. By utworzyć/uaktualnić PCB na podstawie schematu, "
+"trzeba uruchomić Menadżera projektu i utworzyć projekt."
 
 #: eeschema/sch_edit_frame.cpp:1007
 msgid "Schematic"
@@ -10676,7 +10850,7 @@ msgstr "Nowy schemat"
 #: eeschema/sch_edit_frame.cpp:1053
 #, c-format
 msgid "Schematic file \"%s\" already exists, use Open instead"
-msgstr ""
+msgstr "Plik schematu \"%s\" już istnieje, zamiast tego użyj Otwórz"
 
 #: eeschema/sch_edit_frame.cpp:1074
 msgid "Open Schematic"
@@ -10684,16 +10858,15 @@ msgstr "Otwórz schemat"
 
 #: eeschema/sch_edit_frame.cpp:1173
 msgid "Could not open CvPcb"
-msgstr "Nie można otworzyć CvPcb"
+msgstr "Nie można uruchomić CvPcb"
 
 #: eeschema/sch_edit_frame.cpp:1210
 msgid "Error: not a symbol or no symbol."
-msgstr ""
+msgstr "Błąd: nie jest symbolem lub brak symbolu."
 
 #: eeschema/sch_edit_frame.cpp:1477 eeschema/sch_edit_frame.cpp:1484
-#, fuzzy
 msgid "Eeschema"
-msgstr "Uruchom Eeschema"
+msgstr "Eeschema"
 
 #: eeschema/sch_edit_frame.cpp:1492 kicad/prjconfig.cpp:87
 #: pcbnew/footprint_edit_frame.cpp:768 pcbnew/pcb_edit_frame.cpp:1108
@@ -10718,7 +10891,7 @@ msgstr "Wtyczka \"%s\" nie posiada zaimplementowanej funkcji \"%s\"."
 #: eeschema/sch_io_mgr.cpp:33 pcbnew/io_mgr.cpp:43
 #, c-format
 msgid "Plugin type \"%s\" is not found."
-msgstr "Wtyczka typu \"%s\" nie została znaleziona."
+msgstr "Wtyczka \"%s\" nie została znaleziona."
 
 #: eeschema/sch_io_mgr.cpp:85
 #, c-format
@@ -10737,56 +10910,57 @@ msgstr "Węzeł"
 #: eeschema/sch_legacy_plugin.cpp:416 eeschema/sch_legacy_plugin.cpp:979
 #: eeschema/sch_legacy_plugin.cpp:2740
 msgid "unexpected end of line"
-msgstr "nieoczekiwany koniec linii"
+msgstr "niespodziewany koniec pliku"
 
 #: eeschema/sch_legacy_plugin.cpp:346
 msgid "expected unquoted string"
-msgstr ""
+msgstr "spodziewano się ciągu bez cudzysłowów"
 
 #: eeschema/sch_legacy_plugin.cpp:779
 #, c-format
 msgid "\"%s\" does not appear to be an Eeschema file"
-msgstr ""
+msgstr "\"%s\" nie wygląda na plik przeznaczony dla programu Eeschema"
 
 #: eeschema/sch_legacy_plugin.cpp:807
 msgid "Missing 'EELAYER END'"
-msgstr "Brakujące 'EELAYER END'"
+msgstr "Brakuje 'EELAYER END'"
 
 #: eeschema/sch_legacy_plugin.cpp:855 eeschema/sch_legacy_plugin.cpp:1117
 #: eeschema/sch_legacy_plugin.cpp:1125 eeschema/sch_legacy_plugin.cpp:2312
 msgid "unexpected end of file"
-msgstr "nieoczekiwany koniec pliku"
+msgstr "niespodziewany koniec pliku"
 
 #: eeschema/sch_legacy_plugin.cpp:1084
 msgid "Unexpected end of file"
-msgstr "Nieoczekiwany koniec pliku"
+msgstr "Niespodziewany koniec pliku"
 
 #: eeschema/sch_legacy_plugin.cpp:1372
 msgid "expected 'Italics' or '~'"
-msgstr ""
+msgstr "spodziewano się 'Italics' lub '~'"
 
 #: eeschema/sch_legacy_plugin.cpp:1595
 msgid "component field text attributes must be 3 characters wide"
-msgstr ""
+msgstr "atrybuty tekstu pola komponentu musi składać się z 3 znaków"
 
 #: eeschema/sch_legacy_plugin.cpp:2395
 #, c-format
 msgid "user does not have permission to read library document file \"%s\""
-msgstr ""
+msgstr "użytkownik nie posiada uprawnień by odczytać plik dokumentacji \"%s\""
 
 #: eeschema/sch_legacy_plugin.cpp:2403
 msgid "symbol document library file is empty"
-msgstr ""
+msgstr "biblioteka symboli jest pusta"
 
 #: eeschema/sch_legacy_plugin.cpp:3996 eeschema/sch_legacy_plugin.cpp:4031
 #, c-format
 msgid "library %s does not contain an alias %s"
-msgstr ""
+msgstr "bibliotek %s nie posiada aliasu %s"
 
 #: eeschema/sch_legacy_plugin.cpp:4214
 #, c-format
 msgid "symbol library \"%s\" already exists, cannot create a new library"
 msgstr ""
+"bibliotek symboli \"%s\" już istnieje, nie można utworzyć nowej biblioteki"
 
 #: eeschema/sch_legacy_plugin.cpp:4242 pcbnew/legacy_plugin.cpp:3469
 #, c-format
@@ -10795,16 +10969,16 @@ msgstr "biblioteka \"%s\" nie może zostać usunięta"
 
 #: eeschema/sch_line.cpp:615
 msgid "Vert."
-msgstr "Pionowo"
+msgstr "Pion."
 
 #: eeschema/sch_line.cpp:617
 msgid "Horiz."
-msgstr "Poziomo"
+msgstr "Poz."
 
 #: eeschema/sch_line.cpp:622
 #, c-format
 msgid "%s Graphic Line from (%s,%s) to (%s,%s)"
-msgstr "%s Linia graficzna z (%s,%s) do (%s,%s)"
+msgstr "%s Linia graficzna z punktu (%s,%s) do punktu (%s,%s)"
 
 #: eeschema/sch_line.cpp:626
 #, c-format
@@ -10835,11 +11009,11 @@ msgstr "Niepołączone"
 
 #: eeschema/sch_plugin.cpp:154
 msgid "Enable <b>debug</b> logging for Symbol*() functions in this SCH_PLUGIN."
-msgstr ""
+msgstr "Włącz logowanie <b>debug</b> dla funkcji Symbol*() w tym SCH_PLUGIN."
 
 #: eeschema/sch_plugin.cpp:158
 msgid "Regular expression <b>symbol name</b> filter."
-msgstr ""
+msgstr "Filtr wyrażenia regularnego dla <b>nazwy symbolu</b>."
 
 #: eeschema/sch_plugin.cpp:162 pcbnew/plugin.cpp:144
 msgid ""
@@ -10863,6 +11037,8 @@ msgstr ""
 msgid ""
 "Enter the python symbol which implements the SCH_PLUGIN::Symbol*() functions."
 msgstr ""
+"Wprowadź symbol języka Python, który implementuje funkcje SCH_PLUGIN::"
+"Symbol*()."
 
 #: eeschema/sch_sheet.cpp:654
 msgid "Sheet Name"
@@ -10949,7 +11125,7 @@ msgstr "Etykieta Hierarchiczna %s"
 
 #: eeschema/sch_validators.cpp:85
 msgid "reference designator"
-msgstr ""
+msgstr "oznaczenie"
 
 #: eeschema/sch_validators.cpp:86
 msgid "value"
@@ -10957,7 +11133,7 @@ msgstr "wartość"
 
 #: eeschema/sch_validators.cpp:87
 msgid "footprint"
-msgstr "Footprint"
+msgstr "footprint"
 
 #: eeschema/sch_validators.cpp:88
 msgid "data sheet"
@@ -10965,28 +11141,28 @@ msgstr "dokumentacja"
 
 #: eeschema/sch_validators.cpp:89
 msgid "user defined"
-msgstr ""
+msgstr "użytkownika"
 
 #: eeschema/sch_validators.cpp:97
 #, c-format
 msgid "The %s field cannot be empty."
-msgstr ""
+msgstr "Pole %s nie może być puste."
 
 #: eeschema/sch_validators.cpp:105
 msgid "carriage return"
-msgstr ""
+msgstr "powrót karetki"
 
 #: eeschema/sch_validators.cpp:107
 msgid "line feed"
-msgstr ""
+msgstr "wysuniecie linii"
 
 #: eeschema/sch_validators.cpp:109
 msgid "tab"
-msgstr ""
+msgstr "tabulator"
 
 #: eeschema/sch_validators.cpp:111
 msgid "space"
-msgstr ""
+msgstr "spacja"
 
 #: eeschema/sch_validators.cpp:118
 #, c-format
@@ -10996,21 +11172,21 @@ msgstr "%s lub %s"
 #: eeschema/sch_validators.cpp:120
 #, c-format
 msgid "%s, %s, or %s"
-msgstr "%s, %s, lub %s"
+msgstr "%s, %s lub %s"
 
 #: eeschema/sch_validators.cpp:122
 #, c-format
 msgid "%s, %s, %s, or %s"
-msgstr "%s, %s, %s, lub %s"
+msgstr "%s, %s, %s lub %s"
 
 #: eeschema/sch_validators.cpp:127
 #, c-format
 msgid "The %s field cannot contain %s characters."
-msgstr ""
+msgstr "Pole %s nie może zawierać znaków %s."
 
 #: eeschema/sch_validators.cpp:134
 msgid "Field Validation Error"
-msgstr ""
+msgstr "Błąd walidacji zawartości pola"
 
 #: eeschema/schedit.cpp:255
 msgid "There are no undefined labels in this sheet to clean up."
@@ -11024,11 +11200,11 @@ msgstr "Czy oczyścić ten arkusz?"
 
 #: eeschema/schedit.cpp:510
 msgid "Highlight specific net"
-msgstr "Podświetl konkretną sieć"
+msgstr "Podświetla wybraną sieć"
 
 #: eeschema/schedit.cpp:524
 msgid "Add no connect"
-msgstr "Dodaj flagę \"niepołączony\""
+msgstr "Dodaj flagę Niepołączony"
 
 #: eeschema/schedit.cpp:529
 msgid "Add wire"
@@ -11092,19 +11268,19 @@ msgstr "Dodaj port zasilania"
 
 #: eeschema/schedit.cpp:614
 msgid "Add a simulator probe"
-msgstr "Dodaj sondę symulatora"
+msgstr "Dodaj sondę symulacyjną"
 
 #: eeschema/schedit.cpp:619
 msgid "Select a value to be tuned"
-msgstr ""
+msgstr "Wybierz wartość jaka ma być dostrajana"
 
 #: eeschema/selpart.cpp:51
 msgid "Invalid symbol library identifier!"
-msgstr ""
+msgstr "Niepoprawny identyfikator biblioteki symboli!"
 
 #: eeschema/selpart.cpp:82
 msgid "No symbol libraries are loaded."
-msgstr ""
+msgstr "Żadna z bibliotek nie została załadowana."
 
 #: eeschema/selpart.cpp:104
 msgid "Select Symbol Library"
@@ -11113,11 +11289,11 @@ msgstr "Wybierz bibliotekę symboli"
 #: eeschema/selpart.cpp:144
 #, c-format
 msgid "Error occurred loading symbol library \"%s\"."
-msgstr ""
+msgstr "Wystąpił błąd podczas ładowania biblioteki symboli \"%s\"."
 
 #: eeschema/selpart.cpp:150
 msgid "Library:Symbol"
-msgstr ""
+msgstr "Biblioteka:Symbol"
 
 #: eeschema/selpart.cpp:165
 msgid "Select Symbol"
@@ -11133,39 +11309,38 @@ msgid "A sheet named \"%s\" already exists."
 msgstr "Arkusz o nazwie \"%s\" już istnieje."
 
 #: eeschema/sheet.cpp:142
-#, fuzzy, c-format
+#, c-format
 msgid "\"%s\" already exists."
-msgstr "Ścieżka już istnieje."
+msgstr "Alias \"%s\" już istnieje."
 
 #: eeschema/sheet.cpp:143
 #, c-format
 msgid "Link \"%s\" to this file?"
-msgstr ""
+msgstr "Dołączyć \"%s\" do tego pliku?"
 
 #: eeschema/sheet.cpp:169
-#, fuzzy, c-format
+#, c-format
 msgid "Change \"%s\" link from \"%s\" to \"%s\"?"
-msgstr "Zmieniam wartość footprintu \"%s:%s\" z \"%s\" do \"%s\".\n"
+msgstr "Zmienić łącze \"%s\" z \"%s\" na \"%s\"?"
 
 #: eeschema/sheet.cpp:171
-#, fuzzy, c-format
+#, c-format
 msgid "Create new file \"%s\" with contents of \"%s\"?"
-msgstr "Nie można zapisać zawartości okna wiadomości do pliku \"%s\"."
+msgstr "Utworzyć nowy plik \"%s\" w zawartością \"%s\"?"
 
 #: eeschema/sheet.cpp:173
-#, fuzzy
 msgid "This action cannot be undone."
-msgstr "Zmiana nazwy pliku arkusza nie może być cofnięta."
+msgstr "Ta operacja nie może być cofnięta."
 
 #: eeschema/sheet.cpp:239
 #, c-format
 msgid "Error occurred saving schematic file \"%s\"."
-msgstr ""
+msgstr "Wystąpił błąd podczas zapisu pliku schematu \"%s\"."
 
 #: eeschema/sheet.cpp:242
 #, c-format
 msgid "Failed to save schematic \"%s\""
-msgstr ""
+msgstr "Nie powiódł się zapis schematu \"%s\""
 
 #: eeschema/sheet.cpp:326
 #, c-format
@@ -11174,6 +11349,9 @@ msgid ""
 "if not all of the symbol library links will be broken.  Do you want to "
 "continue?"
 msgstr ""
+"Schemat \"%s\" nie został zremapowany do tabeli bibliotek symboli. Wiele z "
+"nich, jeśli nie wszystkie połączenia z bibliotekami będą uszkodzone.  Czy "
+"chcesz kontynuować?"
 
 #: eeschema/sheetlab.cpp:167
 msgid "No new hierarchical labels found."
@@ -11181,19 +11359,19 @@ msgstr "Nie znaleziono nowych etykiet hierarchicznych."
 
 #: eeschema/sim/sim_plot_frame.cpp:170
 msgid "Run/Stop Simulation"
-msgstr "Uruchom / zatrzymaj symulację"
+msgstr "Uruchom/Zatrzymaj Symulację"
 
 #: eeschema/sim/sim_plot_frame.cpp:171 eeschema/sim/sim_plot_frame_base.cpp:51
 msgid "Run Simulation"
-msgstr "Uruchom symulację"
+msgstr "Uruchom Symulację"
 
 #: eeschema/sim/sim_plot_frame.cpp:172
 msgid "Add Signals"
-msgstr "Dodaj sygnał"
+msgstr "Dodaj Sygnały"
 
 #: eeschema/sim/sim_plot_frame.cpp:173
 msgid "Add signals to plot"
-msgstr "Dodaj sygnał do wykresu"
+msgstr "Dodaj sygnały do wykresu"
 
 #: eeschema/sim/sim_plot_frame.cpp:174
 msgid "Probe"
@@ -11201,15 +11379,15 @@ msgstr "Sonda"
 
 #: eeschema/sim/sim_plot_frame.cpp:175
 msgid "Probe signals on the schematic"
-msgstr "Umieść sondę na schemacie"
+msgstr "Sondy na schemacie"
 
 #: eeschema/sim/sim_plot_frame.cpp:176 eeschema/sim/sim_plot_frame_base.cpp:241
 msgid "Tune"
-msgstr "Dostrojenie"
+msgstr "Dostrajanie"
 
 #: eeschema/sim/sim_plot_frame.cpp:177
 msgid "Tune component values"
-msgstr "Dostrój wartość elementów"
+msgstr "Dostrajanie wartości komponentów"
 
 #: eeschema/sim/sim_plot_frame.cpp:178
 msgid "Settings"
@@ -11217,20 +11395,20 @@ msgstr "Ustawienia"
 
 #: eeschema/sim/sim_plot_frame.cpp:201
 msgid "Welcome!"
-msgstr "Witamy!"
+msgstr "Zapraszamy!"
 
 #: eeschema/sim/sim_plot_frame.cpp:293 eeschema/sim/sim_plot_frame.cpp:1030
 msgid "There were errors during netlist export, aborted."
-msgstr "Wystąpiły błędy podczas eksportu listy połączeń. Przerwano!"
+msgstr "Podczas eksportu wykryto błędy, przerwano."
 
 #: eeschema/sim/sim_plot_frame.cpp:299
 msgid "You need to select the simulation settings first."
-msgstr "Najpierw musisz wybrać ustawienia symulacji."
+msgstr "Musisz wcześniej wybrać opcje symulacji."
 
 #: eeschema/sim/sim_plot_frame.cpp:332
-#, fuzzy, c-format
+#, c-format
 msgid "Plot%u"
-msgstr "Rysuj"
+msgstr "Rysuję%u"
 
 #: eeschema/sim/sim_plot_frame.cpp:570 eeschema/sim/sim_plot_frame.cpp:1167
 msgid "Signal"
@@ -11238,11 +11416,11 @@ msgstr "Sygnał"
 
 #: eeschema/sim/sim_plot_frame.cpp:816
 msgid "Open simulation workbook"
-msgstr "Otwórz skoroszyt symulacji "
+msgstr "Otwórz skoroszyt symulacji"
 
 #: eeschema/sim/sim_plot_frame.cpp:825
 msgid "There was an error while opening the workbook file"
-msgstr "Wystąpił błąd podczas otwierania pliku skoroszytu"
+msgstr "Podczas otwierania skoroszytu wykryto błąd"
 
 #: eeschema/sim/sim_plot_frame.cpp:834
 msgid "Save Simulation Workbook"
@@ -11250,11 +11428,11 @@ msgstr "Zapisz skoroszyt symulacji"
 
 #: eeschema/sim/sim_plot_frame.cpp:843
 msgid "There was an error while saving the workbook file"
-msgstr "Wystąpił błąd podczas zapisywania pliku skoroszytu"
+msgstr "Podczas zapisywania skoroszytu wykryto błąd"
 
 #: eeschema/sim/sim_plot_frame.cpp:852
 msgid "Save Plot as Image"
-msgstr "Zapisz wykres jako obraz"
+msgstr "Zapisz wykres jako obrazek"
 
 #: eeschema/sim/sim_plot_frame.cpp:869
 msgid "Save Plot Data"
@@ -11262,7 +11440,7 @@ msgstr "Zapisz dane wykresu"
 
 #: eeschema/sim/sim_plot_frame.cpp:1064
 msgid "You need to run simulation first."
-msgstr "Najpierw musisz przeprowadzić symulację."
+msgstr "Musisz najpierw uruchomić symulację."
 
 #: eeschema/sim/sim_plot_frame.cpp:1296
 msgid "Hide Signal"
@@ -11270,7 +11448,7 @@ msgstr "Ukryj sygnał"
 
 #: eeschema/sim/sim_plot_frame.cpp:1297
 msgid "Erase the signal from plot screen"
-msgstr "Wymaż sygnały z ekranu symulacji."
+msgstr "Usuń sygnał z ekranu wykresu"
 
 #: eeschema/sim/sim_plot_frame.cpp:1303
 msgid "Hide Cursor"
@@ -11298,11 +11476,11 @@ msgstr "Zapisz jako obraz"
 
 #: eeschema/sim/sim_plot_frame_base.cpp:39
 msgid "Save as .csv file"
-msgstr "Zapisz jako plik CSV"
+msgstr "Zapisz jako plik .csv"
 
 #: eeschema/sim/sim_plot_frame_base.cpp:45
 msgid "Exit Simulation"
-msgstr "Zakończ symulator"
+msgstr "Wyjście z symulacji"
 
 #: eeschema/sim/sim_plot_frame_base.cpp:48
 msgid "File"
@@ -11314,19 +11492,21 @@ msgstr "Dodaj sygnały..."
 
 #: eeschema/sim/sim_plot_frame_base.cpp:59
 msgid "Probe from schematics"
-msgstr "Sonda ze schematu"
+msgstr "Sondy ze schematu"
 
 #: eeschema/sim/sim_plot_frame_base.cpp:62
 msgid "Tune component value"
-msgstr "Dostrój wartość elementu"
+msgstr "Dostrój wartości komponentów"
 
 #: eeschema/sim/sim_plot_frame_base.cpp:65
 msgid "Show SPICE Netlist..."
-msgstr "Pokaż listę połączeń SPICE..."
+msgstr "Pokaż listę sieci SPICE..."
 
 #: eeschema/sim/sim_plot_frame_base.cpp:65
 msgid "Shows current simulation's netlist. Useful for debugging SPICE errors."
 msgstr ""
+"Pokazuje bieżącą listę sieci dla symulacji. Przydatne podczas wykrywania "
+"błędów SPICE."
 
 #: eeschema/sim/sim_plot_frame_base.cpp:70
 msgid "Settings..."
@@ -11342,7 +11522,7 @@ msgstr "Pokaż siatkę"
 
 #: eeschema/sim/sim_plot_frame_base.cpp:95
 msgid "Show &legend"
-msgstr "Pokaż legendę"
+msgstr "Pokaż opisy"
 
 #: eeschema/sim/sim_plot_frame_base.cpp:98
 msgid "View"
@@ -11350,13 +11530,13 @@ msgstr "Widok"
 
 #: eeschema/sim/sim_plot_frame_base.cpp:142
 msgid "Start the simulation by clicking the Run Simulation button"
-msgstr "Rozpocznij symulację, klikając przycisk Uruchom symulację"
+msgstr "Rozpocznij symulację klikając na klawisz Rozpocznij Symulację"
 
 #: eeschema/sim/sim_plot_frame_base.cpp:162
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:502
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:524
 msgid "a page"
-msgstr "Strona"
+msgstr "strona"
 
 #: eeschema/sim/sim_plot_frame_base.cpp:205
 msgid "Signals"
@@ -11376,59 +11556,53 @@ msgstr "Częstotliwość"
 
 #: eeschema/sim/sim_plot_panel.cpp:381
 msgid "Gain"
-msgstr ""
+msgstr "Wzmocnienie"
 
 #: eeschema/sim/sim_plot_panel.cpp:382
 msgid "Phase"
-msgstr ""
+msgstr "Faza"
 
 #: eeschema/sim/sim_plot_panel.cpp:387
-#, fuzzy
 msgid "Voltage (sweeped)"
-msgstr "Spadek napięcia"
+msgstr "Napięcie (zmienne)"
 
 #: eeschema/sim/sim_plot_panel.cpp:388
-#, fuzzy
 msgid "Voltage (measured)"
-msgstr "Spadek napięcia"
+msgstr "Napięcie (zmierzone)"
 
 #: eeschema/sim/sim_plot_panel.cpp:394
 msgid "noise [(V or A)^2/Hz]"
-msgstr ""
+msgstr "szum [(V lub A)^2/Hz]"
 
 #: eeschema/sim/sim_plot_panel.cpp:398
-#, fuzzy
 msgid "Time"
-msgstr "Czas [s]"
+msgstr "Czas"
 
 #: eeschema/sim/spice_value.cpp:41
-#, fuzzy
 msgid "Spice value cannot be empty"
-msgstr "Pole %s nie może być puste."
+msgstr "Wartość zmienne Spice nie może być pusta."
 
 #: eeschema/sim/spice_value.cpp:46
-#, fuzzy
 msgid "Invalid Spice value string"
-msgstr "\"%s\" nie jest prawidłową wartością SPICE"
+msgstr "Niepoprawna wartość ciągu zmiennej Spice"
 
 #: eeschema/sim/spice_value.cpp:79
-#, fuzzy
 msgid "Invalid unit prefix"
-msgstr "Przedrostek nazwy pola:"
+msgstr "Niepoprawny prefiks części składowej"
 
 #: eeschema/sim/spice_value.cpp:252
 msgid "Please, fill required fields"
-msgstr ""
+msgstr "Proszę uzupełnić wymagane pola"
 
 #: eeschema/sim/spice_value.cpp:271
 #, c-format
 msgid "\"%s\" is not a valid Spice value"
-msgstr "\"%s\" nie jest prawidłową wartością SPICE"
+msgstr "\"%s\" to nie jest poprawna wartość programu Spice"
 
 #: eeschema/symbedit.cpp:104
 #, c-format
 msgid "More than one symbol found in symbol file \"%s\"."
-msgstr ""
+msgstr "Znaleziono więcej niż jeden symbol w pliku \"%s\"."
 
 #: eeschema/symbedit.cpp:194
 #, c-format
@@ -11438,18 +11612,20 @@ msgstr "Zapisuję symbol w \"%s\""
 #: eeschema/symbedit.cpp:211
 #, c-format
 msgid "An error occurred attempting to save symbol file \"%s\""
-msgstr ""
+msgstr "Wystąpił błąd przy próbie zapisania pliku symbolu \"%s\""
 
 #: eeschema/symbol_lib_table.cpp:210
 #, c-format
 msgid ""
 "Duplicate library nickname \"%s\" found in symbol library table file line %d"
 msgstr ""
+"Znaleziono zduplikowaną nazwę skrótową biblioteki \"%s\" w tabeli bibliotek "
+"w linii %d"
 
 #: eeschema/symbol_lib_table.cpp:297
 #, c-format
 msgid "sym-lib-table files contain no library with nickname \"%s\""
-msgstr ""
+msgstr "pliki sym-lib-table nie zawierają biblioteki o nazwie skrótowej \"%s\""
 
 #: eeschema/tool_lib.cpp:58
 msgid "Deselect current tool"
@@ -11457,7 +11633,7 @@ msgstr "Odznacz bieżące narzędzie"
 
 #: eeschema/tool_lib.cpp:85
 msgid "Move symbol anchor"
-msgstr "Przesuń zakotwiczenie elelementu"
+msgstr "Przesuń punkt zaczepienia"
 
 #: eeschema/tool_lib.cpp:89
 msgid "Import existing drawings"
@@ -11469,14 +11645,13 @@ msgstr "Eksportuj bieżący rysunek"
 
 #: eeschema/tool_lib.cpp:116
 msgid "Create a new library"
-msgstr "Utwórz nową bibliotekę"
+msgstr "Tworzy nową bibliotekę"
 
 #: eeschema/tool_lib.cpp:120
 msgid "Add an existing library"
-msgstr "Dodaj istniejącą bibliotekę"
+msgstr "Dodaje istniejącą bibliotkę"
 
 #: eeschema/tool_lib.cpp:124
-#, fuzzy
 msgid "Save all libraries"
 msgstr "Zapisz wszystkie biblioteki"
 
@@ -11486,7 +11661,7 @@ msgstr "Utwórz nowy symbol"
 
 #: eeschema/tool_lib.cpp:134
 msgid "Save current symbol"
-msgstr "Zapisz bieżący symbol "
+msgstr "Zapisz bieżący symbol"
 
 #: eeschema/tool_lib.cpp:138
 msgid "Import symbol"
@@ -11494,19 +11669,19 @@ msgstr "Importuj symbol"
 
 #: eeschema/tool_lib.cpp:142
 msgid "Export symbol"
-msgstr "Exportuj symbol"
+msgstr "Eksportuj symbol"
 
 #: eeschema/tool_lib.cpp:196 eeschema/tool_viewlib.cpp:89
 msgid "Show as \"De Morgan\" normal symbol"
-msgstr ""
+msgstr "Pokazuj jako normalny symbol"
 
 #: eeschema/tool_lib.cpp:199 eeschema/tool_viewlib.cpp:94
 msgid "Show as \"De Morgan\" convert symbol"
-msgstr ""
+msgstr "Pokazuj jako postać alternatywna"
 
 #: eeschema/tool_lib.cpp:205
 msgid "Show associated datasheet or document"
-msgstr "Pokaż skojarzoną notę katalogową lub dokumentację"
+msgstr "Pokazuje przypisany do symbolu dokument PDF"
 
 #: eeschema/tool_lib.cpp:227
 msgid ""
@@ -11515,6 +11690,11 @@ msgid ""
 "pin number modification.\n"
 "Enabled by default for multiunit parts with interchangeable units."
 msgstr ""
+"Tryb synchronicznej edycji pinów\n"
+"Tryb synchronicznej edycji przekazuje zmiany we wszystkich pinach do innych "
+"części składowych za wyjątkiem modyfikacji numerów pinów.\n"
+"Tryb włączony jest domyślnie dla elementów wielokrotnych z elementami "
+"wymiennymi."
 
 #: eeschema/tool_lib.cpp:251 eeschema/tool_sch.cpp:288
 #: gerbview/toolbars_gerber.cpp:229
@@ -11523,11 +11703,11 @@ msgstr "Wyłącz siatkę"
 
 #: eeschema/tool_lib.cpp:274
 msgid "Show pins electrical type"
-msgstr ""
+msgstr "Pokazuje typy elektryczne pinów"
 
 #: eeschema/tool_lib.cpp:278
 msgid "Toggles the search tree"
-msgstr ""
+msgstr "Przełącza widoczność drzewa wyszukiwania"
 
 #: eeschema/tool_sch.cpp:61
 msgid "New schematic"
@@ -11543,7 +11723,7 @@ msgstr "Zapisz (wszystkie arkusze)"
 
 #: eeschema/tool_sch.cpp:75
 msgid "Edit Page settings"
-msgstr "Edytuj ustawienia strony"
+msgstr "Edycja ustawień strony"
 
 #: eeschema/tool_sch.cpp:80
 msgid "Print schematic"
@@ -11563,7 +11743,7 @@ msgstr "Opuść arkusz"
 
 #: eeschema/tool_sch.cpp:151
 msgid "Footprint Editor - Create/edit footprints"
-msgstr ""
+msgstr "Edytor footprintów - Tworzy/modyfikuje footprinty"
 
 #: eeschema/tool_sch.cpp:165
 msgid "Generate netlist"
@@ -11571,7 +11751,7 @@ msgstr "Generowanie listy sieci"
 
 #: eeschema/tool_sch.cpp:168
 msgid "Edit symbol fields"
-msgstr ""
+msgstr "Edycja pól symboli"
 
 #: eeschema/tool_sch.cpp:177
 msgid "Run Pcbnew to layout printed circuit board"
@@ -11596,7 +11776,7 @@ msgstr "Orientacja dla połączeń i magistral"
 
 #: eeschema/tool_viewlib.cpp:54
 msgid "Select symbol to browse"
-msgstr ""
+msgstr "Wybierz symbol by przeglądać"
 
 #: eeschema/tool_viewlib.cpp:59
 msgid "Display previous symbol"
@@ -11608,11 +11788,11 @@ msgstr "Pokaż następny symbol"
 
 #: eeschema/tool_viewlib.cpp:107
 msgid "View symbol documents"
-msgstr ""
+msgstr "Pokaż dokumentację symbolu"
 
 #: eeschema/tool_viewlib.cpp:115
 msgid "Insert symbol in schematic"
-msgstr ""
+msgstr "Wstaw symbol do schematu"
 
 #: eeschema/tool_viewlib.cpp:142
 #, c-format
@@ -11625,11 +11805,11 @@ msgstr "Zamknij"
 
 #: eeschema/tool_viewlib.cpp:174
 msgid "Close schematic symbol viewer"
-msgstr ""
+msgstr "Zamknij przeglądarkę symboli"
 
 #: eeschema/tool_viewlib.cpp:197
 msgid "&Show Pin Electrical Type"
-msgstr ""
+msgstr "Pokaż typ elektryczny pinu"
 
 #: eeschema/tool_viewlib.cpp:206
 msgid "Open Eeschema manual"
@@ -11650,15 +11830,15 @@ msgstr "Przeglądarka bibliotek"
 #: eeschema/viewlibs.cpp:182
 #, c-format
 msgid "Symbol Library Browser -- %s"
-msgstr ""
+msgstr "Przeglądarka bibliotek symboli -- %s"
 
 #: eeschema/widgets/cmp_tree_pane.cpp:60
 msgid "Revert Library"
-msgstr "Przywróć biblioteki"
+msgstr "Przywróć bibliotekę"
 
 #: eeschema/widgets/cmp_tree_pane.cpp:64
 msgid "New Sy&mbol..."
-msgstr "Nowy sy&mbol..."
+msgstr "Nowy symbol..."
 
 #: eeschema/widgets/cmp_tree_pane.cpp:68
 msgid "Paste Symbol"
@@ -11666,7 +11846,7 @@ msgstr "Wklej symbol"
 
 #: eeschema/widgets/cmp_tree_pane.cpp:72
 msgid "&Edit Symbol"
-msgstr "&Edytuj symbol"
+msgstr "Edycja symbolu"
 
 #: eeschema/widgets/cmp_tree_pane.cpp:74
 msgid "Remove Symbol"
@@ -11674,11 +11854,11 @@ msgstr "Usuń symbol"
 
 #: eeschema/widgets/cmp_tree_pane.cpp:76
 msgid "E&xport Symbol..."
-msgstr "Eksportuj symbol"
+msgstr "Eksportuj symbol..."
 
 #: eeschema/widgets/cmp_tree_pane.cpp:80
 msgid "Revert Symbol"
-msgstr "Odwróć symbol"
+msgstr "Przywróć symbol"
 
 #: eeschema/widgets/cmp_tree_pane.cpp:84
 msgid "Cut Symbol"
@@ -11686,7 +11866,7 @@ msgstr "Wytnij symbol"
 
 #: eeschema/widgets/cmp_tree_pane.cpp:86
 msgid "Copy Symbol"
-msgstr "Kopiuj symbol"
+msgstr "Skopiuj symbol"
 
 #: eeschema/widgets/cmp_tree_pane.cpp:88
 msgid "Duplicate Symbol"
@@ -11698,7 +11878,7 @@ msgstr "Szukaj"
 
 #: eeschema/widgets/tuner_slider_base.cpp:24
 msgid " X "
-msgstr "X"
+msgstr " X "
 
 #: eeschema/widgets/widget_eeschema_color_config.cpp:58
 msgid "Wire"
@@ -11723,7 +11903,7 @@ msgstr "Notatki"
 
 #: eeschema/widgets/widget_eeschema_color_config.cpp:65
 msgid "No connect symbol"
-msgstr "Symbol \"Nie połączone\""
+msgstr "Symbol Niepołączone"
 
 #: eeschema/widgets/widget_eeschema_color_config.cpp:71
 msgid "Body background"
@@ -11731,11 +11911,11 @@ msgstr "Wypełnienie drugoplanowe"
 
 #: eeschema/widgets/widget_eeschema_color_config.cpp:73
 msgid "Pin number"
-msgstr "N&umer pinu:"
+msgstr "Numer pinu"
 
 #: eeschema/widgets/widget_eeschema_color_config.cpp:74
 msgid "Pin name"
-msgstr "&Nazwa pinu:"
+msgstr "Nazwa pinu"
 
 #: eeschema/widgets/widget_eeschema_color_config.cpp:77
 msgid "Fields"
@@ -11773,7 +11953,7 @@ msgstr "Błąd ERC"
 
 #: eeschema/widgets/widget_eeschema_color_config.cpp:94
 msgid "Brightened"
-msgstr "Podświetlenie"
+msgstr "Rozjaśnienie"
 
 #: eeschema/widgets/widget_eeschema_color_config.cpp:100
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:395
@@ -11859,7 +12039,7 @@ msgstr "Pobierz zapamiętany wybór"
 
 #: gerbview/dialogs/dialog_layers_select_to_pcb_base.h:81
 msgid "Layer Selection"
-msgstr "Wybór warstwy"
+msgstr "Wybór warstw"
 
 #: gerbview/dialogs/dialog_print_using_printer.cpp:112
 #: pagelayout_editor/events_functions.cpp:545
@@ -11935,12 +12115,12 @@ msgstr "Skala 0,7"
 
 #: gerbview/dialogs/dialog_print_using_printer_base.cpp:44
 msgid "Approximate scale 1"
-msgstr "Prrzybliżona skala 1"
+msgstr "Przybliżona skala 1:1"
 
 #: gerbview/dialogs/dialog_print_using_printer_base.cpp:44
 #: pcbnew/dialogs/dialog_print_using_printer_base.cpp:67
 msgid "Accurate scale 1"
-msgstr "Dokładna skala 1"
+msgstr "Dokładna skala 1:1"
 
 #: gerbview/dialogs/dialog_print_using_printer_base.cpp:44
 #: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:22
@@ -11969,9 +12149,8 @@ msgstr "Skala 4"
 #: gerbview/dialogs/dialog_print_using_printer_base.cpp:46
 #: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:24
 #: pcbnew/dialogs/dialog_print_using_printer_base.cpp:69
-#, fuzzy
 msgid "Approximate Scale:"
-msgstr "Przybliżona skala"
+msgstr "Skala przybliżona:"
 
 #: gerbview/dialogs/dialog_print_using_printer_base.cpp:50
 #: pcbnew/dialogs/dialog_plot_base.cpp:295
@@ -12007,9 +12186,8 @@ msgstr "Odbicie"
 #: pcbnew/dialogs/dialog_SVG_print_base.cpp:91
 #: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:36
 #: pcbnew/dialogs/dialog_print_using_printer_base.cpp:129
-#, fuzzy
 msgid "Print Mode:"
-msgstr "Tryb wydruku"
+msgstr "Tryb wydruku:"
 
 #: gerbview/dialogs/dialog_print_using_printer_base.cpp:87
 msgid ""
@@ -12037,7 +12215,7 @@ msgstr "Nie eksportuj"
 
 #: gerbview/dialogs/dialog_show_page_borders_base.cpp:25
 msgid "Full size without page limits"
-msgstr ""
+msgstr "Pełen rozmiar bez ograniczeń strony"
 
 #: gerbview/dialogs/dialog_show_page_borders_base.cpp:25
 #: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:64
@@ -12096,9 +12274,8 @@ msgstr "Współrzędne polarne"
 
 #: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:26
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:110
-#, fuzzy
 msgid "Coordinates:"
-msgstr "Współrzędne"
+msgstr "Współrzędne:"
 
 #: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:30
 #: pcbnew/dialogs/dialog_export_idf_base.cpp:102
@@ -12116,7 +12293,7 @@ msgstr "Milimetry"
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:118
 #: pcbnew/import_dxf/dialog_dxf_import_base.cpp:107
 msgid "Units:"
-msgstr "Jednostki"
+msgstr "Jednostki:"
 
 #: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:36
 #: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:42
@@ -12133,19 +12310,16 @@ msgid "Filled"
 msgstr "Wypełniony"
 
 #: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:38
-#, fuzzy
 msgid "Flashed items:"
-msgstr "Wstaw elementy"
+msgstr "Elementy błyskowe:"
 
 #: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:44
-#, fuzzy
 msgid "Lines:"
-msgstr "Linie"
+msgstr "Linie:"
 
 #: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:50
-#, fuzzy
 msgid "Polygons:"
-msgstr "Wielokąty"
+msgstr "Wielokąty:"
 
 #: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:54
 msgid "Show D codes"
@@ -12156,9 +12330,8 @@ msgid "Full size without limits"
 msgstr "Pełny rozmiar bez ograniczeń"
 
 #: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:66
-#, fuzzy
 msgid "Page:"
-msgstr "Strona"
+msgstr "Strona:"
 
 #: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:73
 msgid "Do not center and warp cursor on zoom"
@@ -12176,12 +12349,12 @@ msgstr "Opcje GerbView"
 #: gerbview/events_called_functions.cpp:246
 #: gerbview/events_called_functions.cpp:493 pcbnew/edit.cpp:1593
 msgid "Unsupported tool in this canvas"
-msgstr ""
+msgstr "Narzędzie nieobsługiwane na tej kanwie"
 
 #: gerbview/events_called_functions.cpp:388
 #, c-format
 msgid "Source file \"%s\" is not available"
-msgstr ""
+msgstr "Plik źródłowy \"%s\" nie jest dostępny"
 
 #: gerbview/events_called_functions.cpp:396
 msgid "No editor defined. Please select one"
@@ -12208,7 +12381,7 @@ msgstr "Nie znaleziono pliku %s"
 
 #: gerbview/excellon_read_drill_file.cpp:200
 msgid "Error reading EXCELLON drill file"
-msgstr ""
+msgstr "Błąd podczas wczytywania pliku wierceń EXCELLON"
 
 #: gerbview/excellon_read_drill_file.cpp:434
 msgid "ICI command has no parameter"
@@ -12220,19 +12393,19 @@ msgstr "Polecenie INI posiada nieprawidłowy parametr"
 
 #: gerbview/excellon_read_drill_file.cpp:498
 msgid "Tool definition shape not found"
-msgstr ""
+msgstr "Nie odnaleziono definicji kształtu narzędzia"
 
 #: gerbview/excellon_read_drill_file.cpp:501
 #, c-format
 msgid "Tool definition '%c' not supported"
-msgstr ""
+msgstr "Definicja narzędzia '%c' nie jest obsługiwana"
 
-#: gerbview/excellon_read_drill_file.cpp:590
+#: gerbview/excellon_read_drill_file.cpp:558
 #, c-format
 msgid "Tool %d not defined"
-msgstr ""
+msgstr "Narzędzie %d nie zostało zdefiniowane"
 
-#: gerbview/excellon_read_drill_file.cpp:737
+#: gerbview/excellon_read_drill_file.cpp:705
 #, c-format
 msgid "Unknown Excellon G Code: &lt;%s&gt;"
 msgstr "Nieznany G-kod Excellon: &lt;%s&gt;"
@@ -12243,7 +12416,7 @@ msgstr "Żadna z warstw Gerbera nie zawiera danych"
 
 #: gerbview/export_to_pcbnew.cpp:183
 msgid "Board File Name"
-msgstr "Nazwa pliku płytki"
+msgstr "Nazwa pliku obwodu drukowanego"
 
 #: gerbview/export_to_pcbnew.cpp:219
 #, c-format
@@ -12252,7 +12425,7 @@ msgstr "Nie mogę utworzyć pliku \"%s\""
 
 #: gerbview/files.cpp:49
 msgid "<b>No more available free graphic layer</b> in Gerbview to load files"
-msgstr ""
+msgstr "<b>Brak dostępnych warstw</b> w GerbView by załadować dalsze pliki"
 
 #: gerbview/files.cpp:50
 #, c-format
@@ -12261,7 +12434,7 @@ msgid ""
 "<b>Not loaded:</b> <i>%s</i>"
 msgstr ""
 "\n"
-"<b>Nie wczytano:</b> <i>%s</i>"
+"<b>Nie załadowano:</b> <i>%s</i>"
 
 #: gerbview/files.cpp:56
 msgid "Gerber files"
@@ -12277,7 +12450,7 @@ msgstr "Pliki ZIP"
 
 #: gerbview/files.cpp:96
 msgid "Job files"
-msgstr "Pliki JOB"
+msgstr "Pliki zadań"
 
 #: gerbview/files.cpp:164
 msgid "Gerber files (.g* .lgr .pho)"
@@ -12285,7 +12458,7 @@ msgstr "Plik Gerber (.g* .lgr .pho)"
 
 #: gerbview/files.cpp:170
 msgid "Top layer (*.GTL)|*.GTL;*.gtl|"
-msgstr "Warstwa górna (*.GTL)|*.GTL;*.gtl|"
+msgstr "Top layer (*.GTL)|*.GTL;*.gtl|"
 
 #: gerbview/files.cpp:171
 msgid "Bottom layer (*.GBL)|*.GBL;*.gbl|"
@@ -12305,7 +12478,7 @@ msgstr "Bottom overlay (*.GBO)|*.GBO;*.gbo|"
 
 #: gerbview/files.cpp:175
 msgid "Top overlay (*.GTO)|*.GTO;*.gto|"
-msgstr "Opis warstw górna (*.GTO)|*.GTO;*.gto|"
+msgstr "Top overlay (*.GTO)|*.GTO;*.gto|"
 
 #: gerbview/files.cpp:176
 msgid "Bottom paste (*.GBP)|*.GBP;*.gbp|"
@@ -12313,7 +12486,7 @@ msgstr "Bottom paste (*.GBP)|*.GBP;*.gbp|"
 
 #: gerbview/files.cpp:177
 msgid "Top paste (*.GTP)|*.GTP;*.gtp|"
-msgstr "Górna warstwa pasy (*.GTP)|*.GTP;*.gtp|"
+msgstr "Top paste (*.GTP)|*.GTP;*.gtp|"
 
 #: gerbview/files.cpp:178
 msgid "Keep-out layer (*.GKO)|*.GKO;*.gko|"
@@ -12337,21 +12510,21 @@ msgstr "Otwórz plik(i) Gerber"
 
 #: gerbview/files.cpp:251 gerbview/files.cpp:253
 msgid "Loading Gerber files..."
-msgstr "Wczytywanie plików Gerber..."
+msgstr "Wczytaj pliki Gerber..."
 
 #: gerbview/files.cpp:355
 msgid "Open Excellon Drill File(s)"
-msgstr "Otwórz plik(i) wierceń Excellon"
+msgstr "Otwórz plik(i) wierceń"
 
 #: gerbview/files.cpp:454
 #, c-format
 msgid "Zip file \"%s\" cannot be opened"
-msgstr ""
+msgstr "Plik ZIP \"%s\" nie może zostać otwarty"
 
 #: gerbview/files.cpp:496
 #, c-format
 msgid "Info: skip file <i>\"%s\"</i> (unknown type)\n"
-msgstr ""
+msgstr "Informacja: pomijam plik <i> \"%s\" </i> (nieznany typ)\n"
 
 #: gerbview/files.cpp:538
 #, c-format
@@ -12361,11 +12534,11 @@ msgstr "<b>Nie można utworzyć pliku tymczasowego \"%s\"</b>\n"
 #: gerbview/files.cpp:568
 #, c-format
 msgid "<b>unzipped file %s read error</b>\n"
-msgstr "<b>rozpakowywany plik %s błąd odczytu</b>\n"
+msgstr "<b>Błąd odczytu przy rozpakowywaniu pliku %s</b>\n"
 
 #: gerbview/files.cpp:605
 msgid "Open Zip File"
-msgstr "Otwórz plik ZIP"
+msgstr "Otwórz archiwum ZIP"
 
 #: gerbview/files.cpp:642 gerbview/job_file_reader.cpp:220
 #: pcbnew/dialogs/dialog_footprint_wizard_list_base.cpp:91
@@ -12375,11 +12548,11 @@ msgstr "Wiadomości"
 #: gerbview/gerber_draw_item.cpp:695
 #, c-format
 msgid "D Code %d"
-msgstr ""
+msgstr "D-Kod %d"
 
 #: gerbview/gerber_draw_item.cpp:699
 msgid "No attribute"
-msgstr "Bez atrybutów"
+msgstr "Brak atrybutu"
 
 #: gerbview/gerber_draw_item.cpp:707
 msgid "Graphic Layer"
@@ -12403,7 +12576,7 @@ msgstr "Polaryzacja"
 
 #: gerbview/gerber_draw_item.cpp:728
 msgid "AB axis"
-msgstr "oś AB"
+msgstr "Oś AB"
 
 #: gerbview/gerber_draw_item.cpp:740 gerbview/toolbars_gerber.cpp:137
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:53
@@ -12414,16 +12587,16 @@ msgstr "Sieć:"
 #: gerbview/gerber_draw_item.cpp:751
 #, c-format
 msgid "Cmp: %s;  Pad: %s"
-msgstr ""
+msgstr "Komp: %s;  Pole: %s"
 
 #: gerbview/gerber_draw_item.cpp:758
 msgid "Cmp:"
-msgstr "Cmp:"
+msgstr "Komp:"
 
 #: gerbview/gerber_draw_item.cpp:991
 #, c-format
 msgid "%s (D%d) on layer %d: %s"
-msgstr ""
+msgstr "%s (D%d) na warstwie %d: %s"
 
 #: gerbview/gerber_file_image.cpp:341
 msgid "Image name"
@@ -12435,7 +12608,7 @@ msgstr "Warstwa grafiki"
 
 #: gerbview/gerber_file_image.cpp:350
 msgid "Img Rot."
-msgstr "Obróć obraz"
+msgstr "Obrót obr."
 
 #: gerbview/gerber_file_image.cpp:358
 msgid "X Justify"
@@ -12452,7 +12625,7 @@ msgstr "Przesunięcie obrazu dla wyśrodkowania"
 #: gerbview/gerber_file_image_list.cpp:191
 #, c-format
 msgid "Graphic layer %d"
-msgstr "Warstwa graficzna %d"
+msgstr "Warstwa grafiki %d"
 
 #: gerbview/gerbview_frame.cpp:212 pcbnew/pcb_edit_frame.cpp:468
 msgid ""
@@ -12465,18 +12638,26 @@ msgid ""
 "If you'd like to choose later, select Modern Toolset (Accelerated) in the "
 "Preferences menu."
 msgstr ""
+"KiCad może wykorzystać zasoby karty graficznej by praca stała się prostsza i "
+"szybsza. Opcja ta jest domyślnie wyłączona ponieważ nie jest kompatybilna z "
+"wszystkimi komputerami.\n"
+"\n"
+"Czy chcesz spróbować włączyć tryb graficznej akceleracji?\n"
+"\n"
+"Jeśli chcesz później wybrać, wybierz Nowoczesny (Akcelerowany) zestaw "
+"narzędzi w menu Ustawień."
 
 #: gerbview/gerbview_frame.cpp:219 pcbnew/pcb_edit_frame.cpp:475
 msgid "Enable Graphics Acceleration"
-msgstr ""
+msgstr "Włączyć akcelerację grafiki"
 
 #: gerbview/gerbview_frame.cpp:222 pcbnew/pcb_edit_frame.cpp:478
 msgid "&Enable Acceleration"
-msgstr "Włącz przyśpi&eszenie"
+msgstr "Włącz akcelerację grafiki"
 
 #: gerbview/gerbview_frame.cpp:222 pcbnew/pcb_edit_frame.cpp:478
 msgid "&No Thanks"
-msgstr "&Nie, dziękuję"
+msgstr "Nie włączaj"
 
 #: gerbview/gerbview_frame.cpp:656
 msgid "D Codes"
@@ -12485,26 +12666,24 @@ msgstr "D Codes"
 #: gerbview/gerbview_frame.cpp:765
 #, c-format
 msgid "Drawing layer %d not in use"
-msgstr ""
+msgstr "Warstwa rysunkowa %d nie jest w użyciu"
 
 #: gerbview/gerbview_frame.cpp:777
-#, fuzzy
 msgid "GerbView"
-msgstr "Zamknij GerbView"
+msgstr "GerbView"
 
 #: gerbview/gerbview_frame.cpp:779
-#, fuzzy
 msgid " (with X2 attributes)"
-msgstr "(z atrybutami X2)"
+msgstr " (z atrybutami X2)"
 
 #: gerbview/gerbview_frame.cpp:787
 #, c-format
 msgid "Image name: \"%s\"  Layer name: \"%s\""
-msgstr ""
+msgstr "Nazwa obrazu: \"%s\"  Nazwa warstwy: \"%s\""
 
 #: gerbview/gerbview_frame.cpp:801
 msgid "X2 attr"
-msgstr "atrybuty X2"
+msgstr "Atrybuty X2"
 
 #: gerbview/gerbview_layer_widget.cpp:95 pcbnew/class_track.cpp:1284
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:315
@@ -12515,7 +12694,7 @@ msgstr "Warstwy"
 #: gerbview/gerbview_layer_widget.cpp:96 pcbnew/layer_widget.cpp:517
 #: pcbnew/pcb_layer_widget.cpp:385
 msgid "Items"
-msgstr "Pozostałe"
+msgstr "Elementy"
 
 #: gerbview/gerbview_layer_widget.cpp:116 pcbnew/pcb_layer_widget.cpp:91
 msgid "Show the (x,y) grid dots"
@@ -12531,7 +12710,7 @@ msgstr "Pokaż identyfikatory DCodes"
 
 #: gerbview/gerbview_layer_widget.cpp:118
 msgid "Neg. Obj."
-msgstr "Obiekty negatywowe"
+msgstr "Obiekty negatywowe."
 
 #: gerbview/gerbview_layer_widget.cpp:119
 msgid "Show negative objects in this color"
@@ -12591,23 +12770,22 @@ msgstr "Przełącz na poprzednią warstwę"
 
 #: gerbview/hotkeys.cpp:89
 msgid "Switch to Legacy Toolset"
-msgstr ""
-"Przełącz na starszy zestaw narzędzi (nie wszystkie funkcje będą dostępne)"
+msgstr "Przełącz na zestaw Legacy"
 
 #: gerbview/hotkeys.cpp:95 pcbnew/hotkeys.cpp:178
 msgid ""
 "Switch to Modern Toolset with hardware-accelerated graphics (recommended)"
 msgstr ""
-"Przełącz na nowoczesny zestaw narzędzi ze sprzętową akceleracją grafiki "
-"(zalecane)"
+"Użyj nowoczesnego zestawu narzędzi ze wsparciem akceleracji OpenGL (zalecany)"
 
 #: gerbview/hotkeys.cpp:101 pcbnew/hotkeys.cpp:184
 msgid "Switch to Modern Toolset with software graphics (fall-back)"
 msgstr ""
+"Przełącz na Nowoczesny zestaw narzędzi w trybie programowym (fall-back)"
 
 #: gerbview/hotkeys.cpp:108 pcbnew/hotkeys.cpp:310
 msgid "Measure Distance (Modern Toolset only)"
-msgstr ""
+msgstr "Pomiar odległości (Tylko nowoczesny zestaw narzędzi)"
 
 #: gerbview/hotkeys.cpp:131
 msgid "Gerbview Hotkeys"
@@ -12616,10 +12794,11 @@ msgstr "Klawisze skrótów Gerbview"
 #: gerbview/job_file_reader.cpp:148
 msgid "This job file uses an outdated format. Please, recreate it"
 msgstr ""
+"Ten plik zadań używa przestarzałego formatu. Proszę utworzyć go ponownie"
 
 #: gerbview/job_file_reader.cpp:172
 msgid "Open Gerber Job File"
-msgstr ""
+msgstr "Otwórz plik zadań Gerber"
 
 #: gerbview/menubar.cpp:56
 msgid "Open &Gerber File(s)..."
@@ -12628,33 +12807,38 @@ msgstr "Otwórz plik(i) Gerber..."
 #: gerbview/menubar.cpp:57 gerbview/toolbars_gerber.cpp:60
 msgid "Open Gerber file(s) on the current layer. Previous data will be deleted"
 msgstr ""
+"Wczytaj nowe pliki Gerbera na bieżącą warstwę. Poprzednie dane zostaną "
+"usunięte"
 
 #: gerbview/menubar.cpp:62
 msgid "Open &Excellon Drill File(s)..."
-msgstr ""
+msgstr "Otwórz plik(i) wierceń..."
 
 #: gerbview/menubar.cpp:63 gerbview/toolbars_gerber.cpp:64
 msgid ""
 "Open Excellon drill file(s) on the current layer. Previous data will be "
 "deleted"
 msgstr ""
+"Wczytaj pliki wierceń Excellon na bieżącej warstwie. Poprzednie dane zostaną "
+"usunięte"
 
 #: gerbview/menubar.cpp:68
 msgid "Open Gerber &Job File..."
-msgstr ""
+msgstr "Otwórz plik zadań Gerber..."
 
 #: gerbview/menubar.cpp:69
 msgid ""
 "Open a Gerber job file, and it's associated gerber files depending on the job"
 msgstr ""
+"Wczytuje plik zadań oraz odczytuje pliki Gerber powiązane z tym zadaniem"
 
 #: gerbview/menubar.cpp:74
 msgid "Open &Zip Archive File..."
-msgstr ""
+msgstr "Wczytaj archiwum ZIP..."
 
 #: gerbview/menubar.cpp:75
 msgid "Open a zipped archive (Gerber and Drill) file"
-msgstr ""
+msgstr "Wczytuje plik skompresowanego archiwum (pliki Gerber i Excellon)"
 
 #: gerbview/menubar.cpp:92
 msgid "Open &Recent Gerber File"
@@ -12662,35 +12846,35 @@ msgstr "Otwórz często używany plik Ge&rber"
 
 #: gerbview/menubar.cpp:93
 msgid "Open a recently opened Gerber file"
-msgstr ""
+msgstr "Otwiera często używany plik Gerber"
 
 #: gerbview/menubar.cpp:106
 msgid "Open Recent Excellon Dri&ll File"
-msgstr ""
+msgstr "Otwórz ostatnio otwierany plik wierceń"
 
 #: gerbview/menubar.cpp:107
 msgid "Open a recently opened Excellon drill file"
-msgstr ""
+msgstr "Otwiera ostatnio używany plik wierceń"
 
 #: gerbview/menubar.cpp:120
 msgid "Open Recent Gerber &Job File"
-msgstr ""
+msgstr "Otwórz ostatnio używany plik zadań Gerber"
 
 #: gerbview/menubar.cpp:121
 msgid "Open a recently opened gerber job file"
-msgstr ""
+msgstr "Otwiera ostatnio użyty plik zadań"
 
 #: gerbview/menubar.cpp:134
 msgid "Open Recent Zip &Archive File"
-msgstr ""
+msgstr "Otwórz ostatnie archiwum ZIP"
 
 #: gerbview/menubar.cpp:135
 msgid "Open a recently opened zip archive file"
-msgstr ""
+msgstr "Otwiera ostatnio otwierane archiwum ZIP"
 
 #: gerbview/menubar.cpp:144
 msgid "Clear &All Layers"
-msgstr "Wyczyść wszystkie biblioteki"
+msgstr "Wyczyść wszystkie warstwy"
 
 #: gerbview/menubar.cpp:145
 msgid "Clear all layers. All data will be deleted"
@@ -12698,7 +12882,7 @@ msgstr "Wyczyść wszystkie warstwy. Wszystkie dane zostaną usunięte"
 
 #: gerbview/menubar.cpp:154
 msgid "E&xport to Pcbnew..."
-msgstr "Eksportuj do Pcbnew"
+msgstr "Eksportuj do Pcbnew..."
 
 #: gerbview/menubar.cpp:155
 msgid "Export data in Pcbnew format"
@@ -12721,127 +12905,104 @@ msgid "Show &Layers Manager"
 msgstr "Pokaż menadżera warstw"
 
 #: gerbview/menubar.cpp:179
-#, fuzzy
 msgid "Show or hide the layer manager"
 msgstr "Pokaż/Ukryj pasek menadżera warstw"
 
 #: gerbview/menubar.cpp:204 gerbview/toolbars_gerber.cpp:84
-#, fuzzy
 msgid "Zoom to fit"
-msgstr "Pomniejsz"
+msgstr "Dopasuj powiększenie"
 
 #: gerbview/menubar.cpp:212
-#, fuzzy
 msgid "Refresh screen"
 msgstr "Odśwież ekran"
 
 #: gerbview/menubar.cpp:221 pcbnew/menubar_footprint_editor.cpp:250
 #: pcbnew/menubar_pcb_editor.cpp:645
 msgid "Display &Polar Coordinates"
-msgstr "Wyświetl współrzędne &polarne"
+msgstr "Pokaż współrzędne polarne"
 
 #: gerbview/menubar.cpp:242
-#, fuzzy
 msgid "Sketch F&lashed Items"
-msgstr "Zarys obiektów graficznych"
+msgstr "Elementy błyskowe jako zarys"
 
 #: gerbview/menubar.cpp:242 gerbview/toolbars_gerber.cpp:257
 #: gerbview/toolbars_gerber.cpp:538
-#, fuzzy
 msgid "Show flashed items in outline mode"
-msgstr "Pokaż pola lutownicze jako zarys"
+msgstr "Pokaż tylko zarys elementów błyskowych"
 
 #: gerbview/menubar.cpp:246
-#, fuzzy
 msgid "Sketch &Lines"
-msgstr "Zarys przelotek"
+msgstr "Zarysy linii"
 
 #: gerbview/menubar.cpp:246 gerbview/toolbars_gerber.cpp:261
 #: gerbview/toolbars_gerber.cpp:550
-#, fuzzy
 msgid "Show lines in outline mode"
-msgstr "Pokaż przelotki jako zarys"
+msgstr "Pokaż linie jako zarys"
 
 #: gerbview/menubar.cpp:250
-#, fuzzy
 msgid "Sketch Pol&ygons"
-msgstr "Zarys stref"
+msgstr "Zarysy stref"
 
 #: gerbview/menubar.cpp:250 gerbview/toolbars_gerber.cpp:265
 #: gerbview/toolbars_gerber.cpp:562
-#, fuzzy
 msgid "Show polygons in outline mode"
-msgstr "Pokaż pola lutownicze jako zarys"
+msgstr "Pokaż strefy jako zarys"
 
 #: gerbview/menubar.cpp:254
-#, fuzzy
 msgid "Show &DCodes"
 msgstr "Pokaż D-kody"
 
 #: gerbview/menubar.cpp:254
-#, fuzzy
 msgid "Show or hide DCodes"
-msgstr "Pokaż ukryte nazwy pinów"
+msgstr "Pokaż/ukryj D-Kody"
 
 #: gerbview/menubar.cpp:258
-#, fuzzy
 msgid "Show &Negative Objects"
-msgstr "Pokaż obiekty negatywowe w tym kolorze"
+msgstr "Pokaż obiekty negatywowe"
 
 #: gerbview/menubar.cpp:258 gerbview/toolbars_gerber.cpp:586
-#, fuzzy
 msgid "Show negative objects in ghost color"
 msgstr "Pokaż obiekty negatywowe jako duszki"
 
 #: gerbview/menubar.cpp:264
-#, fuzzy
 msgid "Show in Differential Mode"
-msgstr "Pokaż pin i jego typ &elektryczny"
+msgstr "Pokaż w trybie różnicowym"
 
 #: gerbview/menubar.cpp:264 gerbview/toolbars_gerber.cpp:598
-#, fuzzy
 msgid "Show layers in differential mode"
-msgstr "Pokaż pola lutownicze jako pełne"
+msgstr "Pokazuje warstwy w trybie różnicowym (porównawczym)"
 
 #: gerbview/menubar.cpp:268
-#, fuzzy
 msgid "Show in High Contrast"
-msgstr "Zwiększ wysokość kontrastu"
+msgstr "Pokaż w trybie wysokiego kontrastu"
 
 #: gerbview/menubar.cpp:268
-#, fuzzy
 msgid "Show in high contrast mode"
-msgstr "Wyświetlaj w trybie wysokiego kontrastu"
+msgstr "Wyświetla całość w trybie wysokiego kontrastu"
 
 #: gerbview/menubar.cpp:274
-#, fuzzy
 msgid "Show Normal Mode"
-msgstr "Pokaż modele 3D"
+msgstr "Pokaż normalnie"
 
 #: gerbview/menubar.cpp:274 gerbview/toolbars_gerber.cpp:597
-#, fuzzy
 msgid "Show layers in normal mode"
-msgstr "Pokaż pola lutownicze jako pełne"
+msgstr "Pokazuje warstwy w normalnym trybie"
 
 #: gerbview/menubar.cpp:277
-#, fuzzy
 msgid "Show Stacked Mode"
-msgstr "Pokaż tylko zarys ścieżek"
+msgstr "Pokaż w trybie stosu"
 
 #: gerbview/menubar.cpp:277
-#, fuzzy
 msgid "Show layers in stacked mode"
-msgstr "Pokaż zarys linii"
+msgstr "Pokaż warstwy w trybie stosu (nakładkowym)"
 
 #: gerbview/menubar.cpp:280
-#, fuzzy
 msgid "Show Transparency Mode"
-msgstr "Pokaż ścieżkę"
+msgstr "Pokaż w trybie przeźroczystym"
 
 #: gerbview/menubar.cpp:280
-#, fuzzy
 msgid "Show layers in transparency mode"
-msgstr "Pokaż zarys linii"
+msgstr "Pokazuje warstwy w trybie przeźroczystym"
 
 #: gerbview/menubar.cpp:292
 msgid "&Options"
@@ -12854,31 +13015,32 @@ msgstr "Wybierz opcje rysowania elementów"
 #: gerbview/menubar.cpp:309 pcbnew/menubar_footprint_editor.cpp:460
 #: pcbnew/menubar_pcb_editor.cpp:216
 msgid "Legacy Tool&set"
-msgstr "Star&sze narzędzia..."
+msgstr "Zestaw narzędzi Legacy"
 
 #: gerbview/menubar.cpp:312 pcbnew/menubar_footprint_editor.cpp:463
 #: pcbnew/menubar_pcb_editor.cpp:219
 msgid "Use Legacy Toolset (not all features will be available)"
-msgstr ""
+msgstr "Użyj zestawu Legacy (nie wszystkie funkcje będą dostępne)"
 
 #: gerbview/menubar.cpp:315 pcbnew/menubar_footprint_editor.cpp:466
 #: pcbnew/menubar_pcb_editor.cpp:222
 msgid "Modern Toolset (&Accelerated)"
-msgstr "Nowoczesne narzędzi&a (przyśpieszone)"
+msgstr "Nowoczesny zestaw narzędzi (Akcelerowany)"
 
 #: gerbview/menubar.cpp:318 pcbnew/menubar_footprint_editor.cpp:469
 #: pcbnew/menubar_pcb_editor.cpp:225
 msgid "Use Modern Toolset with hardware-accelerated graphics (recommended)"
 msgstr ""
+"Użyj nowoczesnego zestawu narzędzi ze wsparciem akceleracji OpenGL (zalecany)"
 
 #: gerbview/menubar.cpp:321 pcbnew/menubar_pcb_editor.cpp:228
 msgid "Modern Toolset (Fallba&ck)"
-msgstr "Nowoczesne narzędzia (wy&cofane)"
+msgstr "Nowoczesny zestaw narzędzi (Programowy)"
 
 #: gerbview/menubar.cpp:324 pcbnew/menubar_footprint_editor.cpp:475
 #: pcbnew/menubar_pcb_editor.cpp:231
 msgid "Use Modern Toolset with software graphics (fall-back)"
-msgstr ""
+msgstr "Użyj Nowoczesnego zestawu narzędzi w trybie programowym (fall-back)"
 
 #: gerbview/menubar.cpp:332
 msgid "&List DCodes"
@@ -12886,7 +13048,7 @@ msgstr "&Lista D-Kodów"
 
 #: gerbview/menubar.cpp:333
 msgid "List D-codes defined in Gerber files"
-msgstr ""
+msgstr "Tworzy listę D-kodów zdefiniowanych w plikach Gerber"
 
 #: gerbview/menubar.cpp:338
 msgid "&Show Source"
@@ -12898,11 +13060,11 @@ msgstr "Pokaż plik źródłowy dla bieżącej warstwy"
 
 #: gerbview/menubar.cpp:347
 msgid "&Clear Current Layer"
-msgstr "Wy&czyść bieżącą warstwę"
+msgstr "Wyczyść bieżącą warstwę"
 
 #: gerbview/menubar.cpp:348
 msgid "Clear the graphic layer currently selected"
-msgstr "Wyczyść aktualnie wybraną warstwę graficzną"
+msgstr "Wyczyść aktualnie wybraną warstwę"
 
 #: gerbview/menubar.cpp:356 pagelayout_editor/menubar.cpp:182
 msgid "Set &Text Editor..."
@@ -12932,21 +13094,21 @@ msgstr "Podświetl elementy komponentu \"%s\""
 #: gerbview/onrightclick.cpp:115 gerbview/tools/selection_tool.cpp:112
 #, c-format
 msgid "Highlight Items of Net \"%s\""
-msgstr "Podświetl elementy w sieci \"%s\""
+msgstr "Podświetl elementy sieci \"%s\""
 
 #: gerbview/onrightclick.cpp:126 gerbview/tools/selection_tool.cpp:122
 #, c-format
 msgid "Highlight Aperture Type \"%s\""
-msgstr "Podświetl Aperturę typu \"%s\""
+msgstr "Podświetl elementy o typie apertury \"%s\""
 
 #: gerbview/onrightclick.cpp:137 gerbview/tools/gerbview_control.cpp:42
 msgid "Clear Highlight"
-msgstr "Wyczyść podświetlenie"
+msgstr "Skasuj podświetlenie"
 
 #: gerbview/readgerb.cpp:61 pcbnew/footprint_libraries_utils.cpp:65
 #, c-format
 msgid "File \"%s\" not found"
-msgstr "Pliku \"%s\" nie znaleziono"
+msgstr "Plik \"%s\" nie został znaleziony"
 
 #: gerbview/readgerb.cpp:79
 msgid ""
@@ -12961,12 +13123,12 @@ msgstr ""
 #: gerbview/rs274x.cpp:272
 #, c-format
 msgid "RS274X: Invalid GERBER format command '%c' at line %d: \"%s\""
-msgstr ""
+msgstr "RS274X: Niepoprawny format polecenia Gerber '%c' w linii %d: \"%s\""
 
 #: gerbview/rs274x.cpp:275
 #, c-format
 msgid "GERBER file \"%s\" may not display as intended."
-msgstr ""
+msgstr "Plik GERBER \"%s\" może nie być wyświetlany jak powinien."
 
 #: gerbview/rs274x.cpp:550
 msgid "RS274X: Command \"IR\" rotation value not allowed"
@@ -12999,38 +13161,40 @@ msgstr "Pokaż/ukryj ramkę referenycją oraz wybierz rozmiar papieru do druku"
 
 #: gerbview/toolbars_gerber.cpp:124
 msgid "Select a component and highlight items belonging to this component"
-msgstr ""
+msgstr "Wybiera komponent i podświetla elementy należące do tego komponentu"
 
 #: gerbview/toolbars_gerber.cpp:125
-#, fuzzy
 msgid "Cmp: "
-msgstr "Cmp:"
+msgstr "Komp: "
 
 #: gerbview/toolbars_gerber.cpp:136
 msgid "Select a net name and highlight graphic items belonging to this net"
 msgstr ""
+"Wybiera nazwę sieci i podświetla elementy graficzne należące do tej sieci"
 
 #: gerbview/toolbars_gerber.cpp:148
 msgid ""
 "Select an aperture attribute and highlight graphic items having this "
 "attribute"
 msgstr ""
+"Wybiera atrybut apertury i podświetla elementy graficzne posiadające ten "
+"atrybut"
 
 #: gerbview/toolbars_gerber.cpp:149
 msgid "Attr:"
-msgstr "Atrybut:"
+msgstr "Atr:"
 
 #: gerbview/toolbars_gerber.cpp:160
 msgid "DCode:"
-msgstr ""
+msgstr "DCode:"
 
 #: gerbview/toolbars_gerber.cpp:221
 msgid "Measure distance between two points"
-msgstr ""
+msgstr "Mierzy odległość pomiędzy dwoma punktami"
 
 #: gerbview/toolbars_gerber.cpp:233
 msgid "Turn polar coordinates on"
-msgstr ""
+msgstr "Włącz współrzędne polarne"
 
 #: gerbview/toolbars_gerber.cpp:270
 msgid "Show negatives objects in ghost color"
@@ -13046,22 +13210,29 @@ msgid ""
 "(could have problems with negative items when more than one gerber file is "
 "shown)"
 msgstr ""
+"Pokaż warstwy w trybie RAW\n"
+"(Mogą wystąpić problemy z obiektami negatywowymi gdy wyświetlane jest więcej "
+"warstw)"
 
 #: gerbview/toolbars_gerber.cpp:288
 msgid ""
 "Show layers in stacked mode\n"
 "(show negative items without artifacts)"
 msgstr ""
+"Pokaż warstwy w trybie nakładkowym\n"
+"(Pokazuje obiekty negatywowe bez artefaktów)"
 
 #: gerbview/toolbars_gerber.cpp:293
 msgid ""
 "Show layers in transparency mode\n"
 "(show negative items without artifacts)"
 msgstr ""
+"Pokaż warstwy w trybie transparentnym\n"
+"(Pokazuje obiekty negatywowe z artefaktami)"
 
 #: gerbview/toolbars_gerber.cpp:301
 msgid "Show layers in diff (compare) mode"
-msgstr ""
+msgstr "Pokazuje warstwy w trybie różnicowym (porównawczym)"
 
 #: gerbview/toolbars_gerber.cpp:306 pcbnew/tool_footprint_editor.cpp:255
 #: pcbnew/tool_pcb_editor.cpp:407
@@ -13074,57 +13245,47 @@ msgstr "Pokaż/Ukryj pasek menadżera warstw"
 
 #: gerbview/toolbars_gerber.cpp:324
 msgid "<No selection>"
-msgstr "<Nie wybrano>"
+msgstr "<Bez wyboru>"
 
 #: gerbview/toolbars_gerber.cpp:526
-#, fuzzy
 msgid "Turn on rectangular coordinates"
-msgstr "Pokaż współrzędne kartezyjskie"
+msgstr "Pokaż współrzędne kartezjańskie"
 
 #: gerbview/toolbars_gerber.cpp:527
-#, fuzzy
 msgid "Turn on polar coordinates"
 msgstr "Włącz współrzędne polarne"
 
 #: gerbview/toolbars_gerber.cpp:539
-#, fuzzy
 msgid "Show flashed items in fill mode"
-msgstr "Pokaż pola lutownicze jako pełne"
+msgstr "Pokaż elementy błyskowe jako pełne"
 
 #: gerbview/toolbars_gerber.cpp:551
-#, fuzzy
 msgid "Show lines in fill mode"
-msgstr "Pokaż szkic jako wypełniony"
+msgstr "Pokaż linie jako wypełnione"
 
 #: gerbview/toolbars_gerber.cpp:563
-#, fuzzy
 msgid "Show polygons in fill mode"
-msgstr "Pokaż pola lutownicze jako pełne"
+msgstr "Pokaż strefy jako wypełnione"
 
 #: gerbview/toolbars_gerber.cpp:574
-#, fuzzy
 msgid "Hide DCodes"
-msgstr "DCodes"
+msgstr "Ukryj D-Kody"
 
 #: gerbview/toolbars_gerber.cpp:574
-#, fuzzy
 msgid "Show DCodes"
 msgstr "Pokaż D-kody"
 
 #: gerbview/toolbars_gerber.cpp:585
-#, fuzzy
 msgid "Show negative objects in normal color"
-msgstr "Pokaż obiekty negatywowe jako duszki"
+msgstr "Pokaż obiekty negatywowe w normalnym kolorze"
 
 #: gerbview/toolbars_gerber.cpp:609
-#, fuzzy
 msgid "Disable high contrast mode"
-msgstr "Wyświetlaj w trybie wysokiego kontrastu"
+msgstr "Wyłącz tryb wysokiego kontrastu"
 
 #: gerbview/toolbars_gerber.cpp:610
-#, fuzzy
 msgid "Enable high contrast mode"
-msgstr "Wyświetlaj w trybie wysokiego kontrastu"
+msgstr "Włącz tryb wysokiego kontrastu"
 
 #: gerbview/toolbars_gerber.cpp:621
 msgid "Hide layers manager"
@@ -13148,15 +13309,15 @@ msgstr "Podświetl atrybut"
 
 #: gerbview/tools/selection_tool.cpp:74
 msgid "Measure Tool"
-msgstr "Miarka"
+msgstr "Miernik odległości"
 
 #: gerbview/tools/selection_tool.cpp:74 pcbnew/tools/edit_tool.cpp:175
 msgid "Interactively measure distance between points"
-msgstr ""
+msgstr "Interaktywnie mierzy odległość pomiędzy dwoma punktami"
 
 #: gerbview/tools/selection_tool.cpp:84
 msgid "Highlight"
-msgstr "Podświetl"
+msgstr "Podświetlenie"
 
 #: gerbview/tools/selection_tool.cpp:664
 msgid "Clarify selection"
@@ -13167,51 +13328,11 @@ msgstr "Sprecyzuj Wybór"
 #: pcbnew/tool_footprint_editor.cpp:199 pcbnew/tool_pcb_editor.cpp:511
 #: pcbnew/tools/edit_tool.cpp:1179
 msgid "Measure distance"
-msgstr "Pomiar odległosci"
-
-#: include/confirm.h:55
-msgid "Do not show again"
-msgstr "Nie pokazuj tej wiadomości ponownie"
-
-#: include/drc_item.h:174
-#, c-format
-msgid "ErrType(%d): <b>%s</b><ul><li> %s </li></ul>"
-msgstr ""
-
-#: include/drc_item.h:187
-#, c-format
-msgid "ErrType(%d): <b>%s</b><ul><li> %s: %s </li><li> %s: %s </li></ul>"
-msgstr ""
-
-#: include/drc_item.h:195
-#, c-format
-msgid "ErrType(%d): <b>%s</b><ul><li> %s: %s </li></ul>"
-msgstr ""
-
-#: include/kiway_player.h:274
-msgid "This file is already open."
-msgstr ""
-
-#: include/lib_table_grid.h:190 pcbnew/footprint_libraries_utils.cpp:713
-#: pcbnew/footprint_libraries_utils.cpp:902
-msgid "Nickname"
-msgstr "Nazwa skrótowa"
-
-#: include/lib_table_grid.h:191
-msgid "Library Path"
-msgstr "Ścieżka"
-
-#: include/lib_table_grid.h:194
-msgid "Plugin Type"
-msgstr "Typ wtyczki"
-
-#: include/lib_table_grid.h:197
-msgid "Active"
-msgstr "Aktywny"
+msgstr "Pomiar odległości"
 
 #: kicad/commandframe.cpp:72
 msgid "Schematic layout editor"
-msgstr ""
+msgstr "Edytor schematów"
 
 #: kicad/commandframe.cpp:76
 msgid "Symbol library editor"
@@ -13219,7 +13340,7 @@ msgstr "Edytor bibliotek symboli"
 
 #: kicad/commandframe.cpp:83
 msgid "PCB layout editor"
-msgstr ""
+msgstr "Edytor obwodów drukowanych"
 
 #: kicad/commandframe.cpp:87
 msgid "Footprint library editor"
@@ -13227,21 +13348,23 @@ msgstr "Edytor bibliotek footprintów"
 
 #: kicad/commandframe.cpp:94
 msgid "Gerber viewer"
-msgstr "Przeglądarka Gerber"
+msgstr "Przeglądarka plików Gerber"
 
 #: kicad/commandframe.cpp:98
 msgid ""
 "Import bitmap\n"
 "Convert bitmap images to schematic or PCB elements"
 msgstr ""
+"Importuje bitmapy\n"
+"Tworzy komponenty lub footprinty na podstawie obrazów bitmapowych"
 
 #: kicad/commandframe.cpp:103
 msgid "Calculator tools"
-msgstr "Kalkulator"
+msgstr "Narzędzia do kalkulacji"
 
 #: kicad/commandframe.cpp:107
 msgid "Worksheet layout editor"
-msgstr ""
+msgstr "Edytor obramowań strony"
 
 #: kicad/dialogs/dialog_template_selector.cpp:123
 msgid "<html><h1>Template Selector</h1></html>"
@@ -13252,9 +13375,8 @@ msgid "Select Templates Directory"
 msgstr "Wybierz folder z szablonami"
 
 #: kicad/dialogs/dialog_template_selector_base.cpp:26
-#, fuzzy
 msgid "Template path:"
-msgstr "Ścieżka szablonu"
+msgstr "Ścieżka szablonów:"
 
 #: kicad/dialogs/dialog_template_selector_base.cpp:114
 msgid "Project Template Title"
@@ -13288,12 +13410,12 @@ msgstr "Folder docelowy"
 #: kicad/files-io.cpp:80
 #, c-format
 msgid "Unzipping project in \"%s\"\n"
-msgstr "Rozpakowywanie projektu w \"%s\"\n"
+msgstr "Rozpakowywanie projektu z \"%s\"\n"
 
 #: kicad/files-io.cpp:104
 #, c-format
 msgid "Extract file \"%s\""
-msgstr "Wypakowuję plik \"%s\""
+msgstr "Ekstrakcja pliku \"%s\""
 
 #: kicad/files-io.cpp:113
 msgid " OK\n"
@@ -13310,12 +13432,12 @@ msgstr "Zarchiwizuj pliki projektu"
 #: kicad/files-io.cpp:174
 #, c-format
 msgid "Unable to create zip archive file \"%s\""
-msgstr ""
+msgstr "Nie można utworzyć archiwum ZIP \"%s\""
 
 #: kicad/files-io.cpp:201
 #, c-format
 msgid "Archive file \"%s\""
-msgstr ""
+msgstr "Plik archiwum \"%s\""
 
 #: kicad/files-io.cpp:215
 #, c-format
@@ -13333,15 +13455,15 @@ msgid ""
 "Zip archive \"%s\" created (%d bytes)"
 msgstr ""
 "\n"
-"Utworzono archiwum ZIP \"%s\" - (%d bajtów)"
+"Archiwum ZIP \"%s\" zostało utworzone (%d bajtów)"
 
 #: kicad/import_project.cpp:60
 msgid "Import Eagle Project Files"
-msgstr "Import plików projektów z Eagle"
+msgstr "Import projektów z programu EAGLE"
 
 #: kicad/import_project.cpp:81
 msgid "KiCad Project Destination"
-msgstr ""
+msgstr "Folder docelowy dla projektu KiCad"
 
 #: kicad/import_project.cpp:97
 msgid ""
@@ -13350,24 +13472,24 @@ msgid ""
 "\n"
 "Do you want to create a new empty directory for the project?"
 msgstr ""
-"Wybrany folder nie jest pusty. Zalecane jest tworzenie projektów w ich "
+"Wybrany folder nie jest pusty.  Zaleca się, by projekty tworzyć w ich "
 "własnych, pustych folderach.\n"
 "\n"
-"Czy chcesz by program utworzył nowy pusty folder dla projektu?"
+"Czy chcesz utworzyć nowy, pusty folder dla projektu?"
 
 #: kicad/import_project.cpp:135 kicad/mainframe.cpp:316
 msgid "Eeschema failed to load:\n"
-msgstr ""
+msgstr "Eeschema nie może załadować:\n"
 
 #: kicad/import_project.cpp:136 kicad/import_project.cpp:170
 #: kicad/mainframe.cpp:317 kicad/mainframe.cpp:364 kicad/mainframe.cpp:389
 #: kicad/mainframe.cpp:436
 msgid "KiCad Error"
-msgstr "Błąd KiCada"
+msgstr "Błąd programu KiCad"
 
 #: kicad/import_project.cpp:170 kicad/mainframe.cpp:389
 msgid "Pcbnew failed to load:\n"
-msgstr ""
+msgstr "Program Pcbnew nie mógł załadować:\n"
 
 #: kicad/mainframe.cpp:253
 #, c-format
@@ -13381,11 +13503,11 @@ msgstr "%s %s otwarty [pid=%ld]\n"
 
 #: kicad/mainframe.cpp:363
 msgid "Component library editor failed to load:\n"
-msgstr ""
+msgstr "Edytor bibliotek nie może załadować:\n"
 
 #: kicad/mainframe.cpp:435
 msgid "Footprint library editor failed to load:\n"
-msgstr ""
+msgstr "Edytor footprintó nie może załadować:\n"
 
 #: kicad/mainframe.cpp:502
 msgid "Load File to Edit"
@@ -13402,7 +13524,7 @@ msgstr ""
 
 #: kicad/menubar.cpp:143
 msgid "New Project From Template"
-msgstr "Nowy projekt na bazie szablonu"
+msgstr "Nowy projekt na podstawie szablonu"
 
 #: kicad/menubar.cpp:145
 msgid "Refresh Project Tree"
@@ -13454,7 +13576,7 @@ msgstr "Klawisze skrótów Menedżera"
 
 #: kicad/menubar.cpp:219
 msgid "&Project..."
-msgstr "&Projekt..."
+msgstr "Projekt..."
 
 #: kicad/menubar.cpp:221
 msgid "Create new blank project"
@@ -13462,7 +13584,7 @@ msgstr "Tworzy pusty projekt"
 
 #: kicad/menubar.cpp:223
 msgid "Project from &Template..."
-msgstr ""
+msgstr "Projekt z szablonu..."
 
 #: kicad/menubar.cpp:226 kicad/menubar.cpp:512
 msgid "Create new project from template"
@@ -13471,7 +13593,7 @@ msgstr "Tworzy nowy projekt na podstawie szablonu"
 #: kicad/menubar.cpp:230 pagelayout_editor/menubar.cpp:62
 #: pcbnew/menubar_pcb_editor.cpp:797
 msgid "&New"
-msgstr "&Nowy"
+msgstr "Nowy"
 
 #: kicad/menubar.cpp:231 kicad/menubar.cpp:508
 msgid "Create new project"
@@ -13479,7 +13601,7 @@ msgstr "Utwórz nowy projekt"
 
 #: kicad/menubar.cpp:235
 msgid "&Open Project..."
-msgstr "&Otwórz projekt..."
+msgstr "Otwórz projekt..."
 
 #: kicad/menubar.cpp:237
 msgid "Open an existing project"
@@ -13487,7 +13609,7 @@ msgstr "Otwiera istniejący projekt"
 
 #: kicad/menubar.cpp:247
 msgid "Open a recent project"
-msgstr "Otwiera ostatnio otwierany projekt"
+msgstr "Otwiera ostatnio używane projekty"
 
 #: kicad/menubar.cpp:256 kicad/menubar.cpp:525
 msgid "Save current project"
@@ -13495,31 +13617,32 @@ msgstr "Zapisz bieżący projekt"
 
 #: kicad/menubar.cpp:263
 msgid "EAGLE CAD..."
-msgstr "Eagle CAD..."
+msgstr "EAGLE CAD..."
 
 #: kicad/menubar.cpp:264
 msgid "Import EAGLE CAD XML schematic and board"
-msgstr "Import schematów i płytek w formacie XML Eagle CAD"
+msgstr ""
+"Importuje schemat oraz obwód drukowany programu EAGLE CAD w formacie XML"
 
 #: kicad/menubar.cpp:270
 msgid "Import Project"
-msgstr "Import projektów"
+msgstr "Importuj projekt"
 
 #: kicad/menubar.cpp:271
 msgid "Import project files from other software"
-msgstr "Importuj pliku projektów z innych programów"
+msgstr "Importuje projekt z innego programu"
 
 #: kicad/menubar.cpp:280
 msgid "&Archive Project..."
-msgstr "&Archiwizuj projekt..."
+msgstr "Archiwizuj projekt..."
 
 #: kicad/menubar.cpp:281
 msgid "Archive all needed project files into zip archive"
-msgstr "Archiwizuje wszystkie potrzebne pliki projektu w archiwum ZIP"
+msgstr "Archiwizuje wszystkie potrzebne pliki projektu w jedno archiwum ZIP"
 
 #: kicad/menubar.cpp:287
 msgid "&Unarchive Project..."
-msgstr "Rozpak&uj projekt"
+msgstr "Zdearchiwizuj projekt..."
 
 #: kicad/menubar.cpp:288 kicad/menubar.cpp:538
 msgid "Unarchive project files from zip archive"
@@ -13547,7 +13670,7 @@ msgstr "Uruchom preferowany edytor tekstu"
 
 #: kicad/menubar.cpp:327
 msgid "&Open Local File..."
-msgstr "&Otwórz plik lokalny..."
+msgstr "Otwórz plik lokalny..."
 
 #: kicad/menubar.cpp:328
 msgid "Edit local file"
@@ -13571,11 +13694,11 @@ msgstr "Użyj systemowej przeglądarki PDF do przeglądania dokumentacji"
 
 #: kicad/menubar.cpp:362
 msgid "&Favorite PDF Viewer"
-msgstr "Ulubiona przeglądarka PDF"
+msgstr "Preferowana przeglądarka PDF"
 
 #: kicad/menubar.cpp:363
 msgid "Use favorite PDF viewer"
-msgstr "Użyj ulubionej przeglądarki PDF"
+msgstr "Użyj preferowanej przeglądarki PDF do przeglądania dokumentacji"
 
 #: kicad/menubar.cpp:373
 msgid "Set &PDF Viewer..."
@@ -13583,7 +13706,7 @@ msgstr "Wybierz przeglądarkę PDF..."
 
 #: kicad/menubar.cpp:374
 msgid "Set favorite PDF viewer"
-msgstr "Ustaw ulubioną przeglądarkę PDF"
+msgstr "Wybierz preferowaną przeglądarkę PDF do przeglądania dokumentacji"
 
 #: kicad/menubar.cpp:379
 msgid "&PDF Viewer"
@@ -13595,37 +13718,39 @@ msgstr "Ustawienia przeglądarki PDF"
 
 #: kicad/menubar.cpp:399
 msgid "Edit Schematic"
-msgstr "Edytuj Schemat"
+msgstr "Edytuj schemat"
 
 #: kicad/menubar.cpp:402
 msgid "Edit Schematic Symbols"
-msgstr "Edytuj symbole schematowe"
+msgstr "Edycja symboli schematowych"
 
 #: kicad/menubar.cpp:406
 msgid "Edit PCB Layout"
-msgstr "Edytuj płytkę drukowaną"
+msgstr "Edytuj obwód drukowany"
 
 #: kicad/menubar.cpp:410
 msgid "Edit PCB Footprints"
-msgstr "Edytuj footprinty"
+msgstr "Edycja footprintów obwodów drukowanych"
 
 #: kicad/menubar.cpp:414
 msgid "View Gerber Files"
-msgstr "Przeglądarka plików Gerber"
+msgstr "Przeglądaj pliki Gerber"
 
 #: kicad/menubar.cpp:418
 msgid "Convert Image"
-msgstr "Konwersja obrazu na biblioteki"
+msgstr "Konwertowanie obrazu na symbol lub footprint"
 
 #: kicad/menubar.cpp:421
 msgid ""
 "Bitmap2Component - Convert bitmap images to schematic\n"
 "or PCB elements"
 msgstr ""
+"Bitmap2Component - Konwertuje obrazy bitmapowe na symbole\n"
+"programu Eeschema lub footprinty programu Pcbnew"
 
 #: kicad/menubar.cpp:425
 msgid "Run PCB Calculator"
-msgstr "Uruchom kalkulator PCB"
+msgstr "Uruchom PCB Calculator"
 
 #: kicad/menubar.cpp:427
 msgid "Pcb calculator - Calculator for components, track width, etc."
@@ -13633,7 +13758,7 @@ msgstr "PCB Calculator - Kalkulator elementów, szerokości ścieżek, itp."
 
 #: kicad/menubar.cpp:430
 msgid "Edit Page Layout"
-msgstr "Edycja układu strony"
+msgstr "Edytuj układ strony"
 
 #: kicad/menubar.cpp:432
 msgid "Pl editor - Worksheet layout editor"
@@ -13649,7 +13774,7 @@ msgstr "Otwórz podręcznik programu KiCad"
 
 #: kicad/menubar.cpp:451 pagelayout_editor/menubar.cpp:211
 msgid "&List Hotkeys"
-msgstr "&Lista skrótów klawiszowych"
+msgstr "&Lista klawiszy skrótów"
 
 #: kicad/menubar.cpp:476
 msgid "&Browse"
@@ -13681,7 +13806,7 @@ msgstr "Otwórz istniejący projekt"
 
 #: kicad/prjconfig.cpp:195
 msgid "Create a new directory for the project"
-msgstr ""
+msgstr "Utwórz nowy folder dla projektu"
 
 #: kicad/prjconfig.cpp:222
 msgid "Create New Project"
@@ -13694,6 +13819,10 @@ msgid ""
 "\n"
 "Please make sure you have write permissions and try again."
 msgstr ""
+"Folder \"%s\" nie może zostać utworzony.\n"
+"\n"
+"Należy upewnić się czy użytkownik posiada uprawnienia do zapisu i spróbować "
+"ponownie."
 
 #: kicad/prjconfig.cpp:258
 msgid ""
@@ -13702,6 +13831,10 @@ msgid ""
 "\n"
 "Do you want to continue?"
 msgstr ""
+"Wybrany folder nie jest pusty. Zalecane tworzenie projektów w ich własnych "
+"folderach.\n"
+"\n"
+"Czy chcesz kontynuować?"
 
 #: kicad/prjconfig.cpp:284
 msgid "System Templates"
@@ -13722,27 +13855,27 @@ msgstr "Nowy folder projektu"
 #: kicad/prjconfig.cpp:334
 #, c-format
 msgid "Cannot write to folder \"%s\"."
-msgstr ""
+msgstr "Nie można zapisywać do folderu \"%s\"."
 
 #: kicad/prjconfig.cpp:335
 msgid "Error!"
-msgstr "Błąd!!!"
+msgstr "Błąd!"
 
 #: kicad/prjconfig.cpp:336
 msgid "Please check your access permissions to this folder and try again."
-msgstr ""
+msgstr "Proszę sprawdzić swoje uprawnienia do folderu i ponowić próbę."
 
 #: kicad/prjconfig.cpp:359
 msgid "Overwriting files:"
-msgstr ""
+msgstr "Nadpisywane pliki:"
 
 #: kicad/prjconfig.cpp:367
 msgid "Are you sure you want to overwrite files in the destination folder?"
-msgstr ""
+msgstr "Jesteś pewien by nadpisać pliki w folderze docelowym?"
 
 #: kicad/prjconfig.cpp:372
 msgid "Overwrite"
-msgstr "Nadpisanie"
+msgstr "Nadpisz"
 
 #: kicad/prjconfig.cpp:372
 msgid "Do Not Overwrite"
@@ -13750,7 +13883,7 @@ msgstr "Nie nadpisuj"
 
 #: kicad/prjconfig.cpp:386
 msgid "A problem occurred creating new project from template!"
-msgstr ""
+msgstr "Wystąpił problem przy tworzeniu nowego projektu na podstawie szablonu!"
 
 #: kicad/prjconfig.cpp:387
 msgid "Template Error"
@@ -13758,25 +13891,25 @@ msgstr "Błąd wzorca projektu"
 
 #: kicad/project_template.cpp:52
 msgid "Could open the template path! "
-msgstr ""
+msgstr "Nie można otworzyć ścieżki z szablonami! "
 
 #: kicad/project_template.cpp:57
 msgid "Couldn't open the meta information directory for this template! "
-msgstr ""
+msgstr "Nie można otworzyć meta-informacji z folderu tego szablonu!  "
 
 #: kicad/project_template.cpp:63
 msgid "Cound't find the meta HTML information file for this template!"
-msgstr ""
+msgstr "Nie można odnaleźć pliku HTML z informacji 'meta' dla tego szablonu!"
 
 #: kicad/project_template.cpp:205
 #, c-format
 msgid "Cannot create folder \"%s\"."
-msgstr "Nie mogę utworzyć folderu \"%s\"."
+msgstr "Nie można utworzyć folderu \"%s\"."
 
 #: kicad/project_template.cpp:227
 #, c-format
 msgid "Cannot copy file \"%s\"."
-msgstr "Nie mogę skopiować pliku \"%s\"."
+msgstr "Nie można skopiować \"%s\"."
 
 #: kicad/tree_project_frame.cpp:220
 #, c-format
@@ -13793,7 +13926,7 @@ msgstr "Utwórz nowy folder"
 
 #: kicad/tree_project_frame.cpp:682 kicad/tree_project_frame.cpp:689
 msgid "New D&irectory..."
-msgstr "Nowy folder..."
+msgstr "Nowy &folder..."
 
 #: kicad/tree_project_frame.cpp:683 kicad/tree_project_frame.cpp:690
 msgid "Create a New Directory"
@@ -13830,7 +13963,7 @@ msgstr "&Usuń plik"
 #: kicad/tree_project_frame.cpp:758
 #, c-format
 msgid "Change filename: \"%s\""
-msgstr "Zmień nazwę pliku: \"%s\""
+msgstr "Nie można zmienić nazwy: \"%s\""
 
 #: kicad/tree_project_frame.cpp:761
 msgid "Change filename"
@@ -13859,21 +13992,19 @@ msgstr "Błąd uprawnień ?"
 #: kicad/treeproject_item.cpp:132
 #, c-format
 msgid "Do you really want to delete \"%s\""
-msgstr ""
+msgstr "Czy chcesz usunąć \"%s\""
 
 #: kicad/treeproject_item.cpp:137
 msgid "Delete File"
 msgstr "Usuń plik"
 
 #: pagelayout_editor/dialogs/dialog_new_dataitem_base.cpp:30
-#, fuzzy
 msgid "Y start:"
-msgstr "Start"
+msgstr "Start Y:"
 
 #: pagelayout_editor/dialogs/dialog_new_dataitem_base.cpp:44
-#, fuzzy
 msgid "X start:"
-msgstr "Start"
+msgstr "Start X:"
 
 #: pagelayout_editor/dialogs/dialog_new_dataitem_base.cpp:64
 #: pagelayout_editor/dialogs/dialog_new_dataitem_base.cpp:124
@@ -13912,11 +14043,11 @@ msgstr "Dolny lewy"
 
 #: pagelayout_editor/dialogs/dialog_new_dataitem_base.cpp:90
 msgid "X end:"
-msgstr ""
+msgstr "Koniec X:"
 
 #: pagelayout_editor/dialogs/dialog_new_dataitem_base.cpp:104
 msgid "Y end:"
-msgstr ""
+msgstr "Koniec Y:"
 
 #: pagelayout_editor/dialogs/dialog_new_dataitem_base.h:72
 msgid "New Item"
@@ -13931,9 +14062,8 @@ msgid "An error occurred attempting to print the page layout."
 msgstr "Wystąpił błąd podczas próby wydruku układu strony."
 
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:44
-#, fuzzy
 msgid "Page 1 option:"
-msgstr "Opcja wyświetlania"
+msgstr "Opcje pierwszej strony:"
 
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:50
 msgid "Page 1 only"
@@ -13944,57 +14074,47 @@ msgid "Not on page 1"
 msgstr "Nie umieszczaj na pierwszej stronie"
 
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:82
-#, fuzzy
 msgid "Horizontal align:"
-msgstr "Odstęp poziomo:"
+msgstr "Wyrównanie poziomo:"
 
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:95
-#, fuzzy
 msgid "Vertical align:"
-msgstr "Odstęp pionowo:"
+msgstr "Wyrównanie pionowo:"
 
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:149
 msgid "Constraints:"
 msgstr "Stałe:"
 
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:162
-#, fuzzy
 msgid "Maximum width:"
-msgstr "Szerokośc minimalna"
+msgstr "Maksymalna szerokość:"
 
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:169
-#, fuzzy
 msgid "Maximum height:"
-msgstr "Maksymalna wysokość Y (mm)"
+msgstr "Maksymalna wysokość:"
 
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:206
-#, fuzzy
 msgid "Comment:"
-msgstr "Komentarz"
+msgstr "Komentarz:"
 
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:225
-#, fuzzy
 msgid "Start X:"
 msgstr "Pozycja początkowa X:"
 
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:239
-#, fuzzy
 msgid "Start Y:"
 msgstr "Pozycja początkowa Y:"
 
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:259
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:319
-#, fuzzy
 msgid "Origin:"
-msgstr "Punkt bazowy siatki"
+msgstr "Punkt bazowy:"
 
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:285
-#, fuzzy
 msgid "End X:"
 msgstr "Pozycja końcowa X:"
 
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:299
-#, fuzzy
 msgid "End Y:"
 msgstr "Pozycja końcowa Y:"
 
@@ -14019,33 +14139,28 @@ msgid "Rotation:"
 msgstr "Obrót:"
 
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:376
-#, fuzzy
 msgid "Bitmap PPI:"
-msgstr "Rozdzielczość"
+msgstr "Rozdzielczość PPI:"
 
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:403
 msgid "Repeat parameters:"
 msgstr "Parametry powtarzania:"
 
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:414
-#, fuzzy
 msgid "Repeat count:"
-msgstr "Ilość powtórzeń"
+msgstr "Ilość powtórzeń:"
 
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:421
-#, fuzzy
 msgid "Text Increment:"
-msgstr "Zwiększaj tekst co"
+msgstr "Zwiększaj tekst co:"
 
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:440
-#, fuzzy
 msgid "Step X:"
-msgstr "Skok X (mm)"
+msgstr "Skok X:"
 
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:447
-#, fuzzy
 msgid "Step Y:"
-msgstr "Skok Y (mm)"
+msgstr "Skok Y:"
 
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:475
 msgid "Item Properties"
@@ -14056,9 +14171,8 @@ msgid "Default Values:"
 msgstr "Domyślne wartości:"
 
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:523
-#, fuzzy
 msgid "Line thickness:"
-msgstr "Grubość &linii:"
+msgstr "Grubość linii:"
 
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:530
 #: pcbnew/dialogs/dialog_dimension_editor_base.cpp:51
@@ -14071,28 +14185,24 @@ msgid "Set to Default"
 msgstr "Ustaw jako domyślne"
 
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:565
-#, fuzzy
 msgid "Page Margins:"
-msgstr "Marginesy strony"
+msgstr "Marginesy strony:"
 
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:576
-#, fuzzy
 msgid "Left:"
-msgstr "Lewo"
+msgstr "Lewo:"
 
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:583
-#, fuzzy
 msgid "Right:"
-msgstr "Prawo"
+msgstr "Prawo:"
 
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:604
 msgid "Top:"
-msgstr ""
+msgstr "Najwyższy:"
 
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:611
-#, fuzzy
 msgid "Bottom:"
-msgstr "Dolna"
+msgstr "Dół:"
 
 #: pagelayout_editor/dialogs/properties_frame_base.cpp:646
 msgid "General Options"
@@ -14117,7 +14227,7 @@ msgstr "Plik \"%s\" został załadowany"
 
 #: pagelayout_editor/files.cpp:108
 msgid "Append Existing Page Layout File"
-msgstr ""
+msgstr "Dodaj istniejący plik definicji strony"
 
 #: pagelayout_editor/files.cpp:119 pagelayout_editor/files.cpp:145
 #, c-format
@@ -14127,24 +14237,24 @@ msgstr "Nie mogę załadować pliku %s"
 #: pagelayout_editor/files.cpp:127
 #, c-format
 msgid "File \"%s\" inserted"
-msgstr "Plik \"%s\" został wstawiony"
+msgstr "Plik \"%s\" został dołączony"
 
 #: pagelayout_editor/files.cpp:160
 #, c-format
 msgid "Unable to write \"%s\""
-msgstr ""
+msgstr "Nie można zapisać \"%s\""
 
 #: pagelayout_editor/files.cpp:165 pagelayout_editor/files.cpp:196
 #, c-format
 msgid "File \"%s\" written"
-msgstr "Plik \"%s\" został zapisany"
+msgstr "Plik \"%s\" zapisany"
 
 #: pagelayout_editor/files.cpp:190 pagelayout_editor/pl_editor_frame.cpp:257
 #: pcbnew/exporters/export_gencad.cpp:287
 #: pcbnew/exporters/gen_footprints_placefile.cpp:644
 #, c-format
 msgid "Unable to create \"%s\""
-msgstr "Nie mogę utworzyć \"%s\""
+msgstr "Nie można utworzyć \"%s\""
 
 #: pagelayout_editor/hotkeys.cpp:84 pagelayout_editor/onrightclick.cpp:114
 #: pcbnew/dialogs/dialog_move_exact_base.h:77 pcbnew/hotkeys.cpp:136
@@ -14170,27 +14280,27 @@ msgstr "Edytor Układu Strony"
 
 #: pagelayout_editor/menubar.cpp:64
 msgid "Create new page layout design"
-msgstr ""
+msgstr "Tworzy nowy układ definicji strony"
 
 #: pagelayout_editor/menubar.cpp:69 pagelayout_editor/toolbars_pl_editor.cpp:54
 msgid "Open an existing page layout design file"
-msgstr ""
+msgstr "Otwiera istniejący projekt obramowania strony"
 
 #: pagelayout_editor/menubar.cpp:78
 msgid "Open recent page layout design file"
-msgstr ""
+msgstr "Otwiera ostatnio otwierany projekt obramowania strony"
 
 #: pagelayout_editor/menubar.cpp:85
 msgid "Save current page layout design file"
-msgstr ""
+msgstr "Zapisuje bieżący projekt obramowania strony"
 
 #: pagelayout_editor/menubar.cpp:88
 msgid "Save &As..."
-msgstr "Z&apisz jako..."
+msgstr "Zapisz jako..."
 
 #: pagelayout_editor/menubar.cpp:90
 msgid "Save current page layout design file with a different name"
-msgstr ""
+msgstr "Zapisuje bieżący projekt obramowania strony z inną nazwą"
 
 #: pagelayout_editor/menubar.cpp:99
 msgid "Print Pre&view..."
@@ -14198,31 +14308,31 @@ msgstr "Podgląd wydruku..."
 
 #: pagelayout_editor/menubar.cpp:105
 msgid "Close Page Layout Editor"
-msgstr ""
+msgstr "Zamknij Edytor układu strony"
 
 #: pagelayout_editor/menubar.cpp:146
 msgid "&Line..."
-msgstr "&Linia..."
+msgstr "Linia..."
 
 #: pagelayout_editor/menubar.cpp:149
 msgid "&Rectangle..."
-msgstr "P&rostokąt..."
+msgstr "Prostokąt..."
 
 #: pagelayout_editor/menubar.cpp:152
 msgid "&Text..."
-msgstr "&Tekst..."
+msgstr "Tekst..."
 
 #: pagelayout_editor/menubar.cpp:155
 msgid "&Bitmap..."
-msgstr "&Bitmapa..."
+msgstr "Mapa bitowa..."
 
 #: pagelayout_editor/menubar.cpp:160
 msgid "&Append Existing Page Layout Design File..."
-msgstr ""
+msgstr "Dołącz istniejący projekt obramowania strony..."
 
 #: pagelayout_editor/menubar.cpp:161
 msgid "Append an existing page layout design file to current file"
-msgstr ""
+msgstr "Dołącza do obecnego projektu istniejący projekt obramowania strony"
 
 #: pagelayout_editor/menubar.cpp:171 pagelayout_editor/pl_editor_config.cpp:58
 msgid "&Background Black"
@@ -14262,26 +14372,26 @@ msgstr "Dodaj bitmapę..."
 
 #: pagelayout_editor/onrightclick.cpp:54
 msgid "Append Existing Page Layout Design File..."
-msgstr ""
+msgstr "Dołącz istniejący projekt obramowania strony..."
 
 #: pagelayout_editor/page_layout_writer.cpp:100
 #: pagelayout_editor/page_layout_writer.cpp:128
 msgid "Error writing page layout design file"
-msgstr ""
+msgstr "Wystąpił błąd podczas zapisu projektu obramowania strony"
 
 #: pagelayout_editor/pl_editor.cpp:149
 msgid "pl_editor is already running. Continue?"
-msgstr "PL_Editor jest już uruchomiony. Kontynuować?"
+msgstr "pL_Editor jest już uruchomiony. Kontynuować?"
 
 #: pagelayout_editor/pl_editor.cpp:186
 #: pagelayout_editor/pl_editor_frame.cpp:202
 #, c-format
 msgid "Error when loading file \"%s\""
-msgstr ""
+msgstr "Błąd podczas ładowania pliku \"%s\""
 
 #: pagelayout_editor/pl_editor_frame.cpp:116
 msgid "coord origin: Right Bottom page corner"
-msgstr "Punkt bazowy: Prawy dolny narożnik strony"
+msgstr "punkt bazowy: Prawy dolny narożnik strony"
 
 #: pagelayout_editor/pl_editor_frame.cpp:148
 msgid "Design"
@@ -14293,7 +14403,7 @@ msgstr "Zapisać zmiany w nowym pliku przed zamknięciem?"
 
 #: pagelayout_editor/pl_editor_frame.cpp:334
 msgid "no file selected"
-msgstr "nie wybrano pliku"
+msgstr "nie zaznaczono pliku"
 
 #: pagelayout_editor/pl_editor_frame.cpp:444
 #, c-format
@@ -14303,7 +14413,7 @@ msgstr "Rozmiar strony: szerokość %.4g wysokość %.4g"
 #: pagelayout_editor/pl_editor_frame.cpp:489
 #, c-format
 msgid "coord origin: %s"
-msgstr "Punkt bazowy: %s"
+msgstr "punkt bazowy: %s"
 
 #: pagelayout_editor/pl_editor_frame.cpp:718
 msgid "(start or end point)"
@@ -14342,9 +14452,8 @@ msgid "Delete selected item"
 msgstr "Usuń wybrany element"
 
 #: pagelayout_editor/toolbars_pl_editor.cpp:92
-#, fuzzy
 msgid "Zoom to fit page"
-msgstr "Powiększ, aby dopasować płytkę do ekranu"
+msgstr "Powiększa by widoczna była cała płytka"
 
 #: pagelayout_editor/toolbars_pl_editor.cpp:104
 msgid ""
@@ -14384,7 +14493,7 @@ msgstr "Lewy górny wierzchołek"
 
 #: pagelayout_editor/toolbars_pl_editor.cpp:128
 msgid "Origin of coordinates displayed to the status bar"
-msgstr ""
+msgstr "Ustawia punkt bazowy dla koordynatów na pasku statusu"
 
 #: pagelayout_editor/toolbars_pl_editor.cpp:141
 msgid "Page 1"
@@ -14424,7 +14533,7 @@ msgstr "cale"
 
 #: pcb_calculator/UnitSelector.cpp:75
 msgid "oz/ft^2"
-msgstr ""
+msgstr "oz/ft^2"
 
 #: pcb_calculator/UnitSelector.cpp:104
 msgid "GHz"
@@ -14456,7 +14565,7 @@ msgstr "Ω"
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:96
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:110
 msgid "KOhm"
-msgstr "kΩ"
+msgstr "KΩ"
 
 #: pcb_calculator/attenuators.cpp:114
 #, c-format
@@ -14469,9 +14578,8 @@ msgstr "Błąd pliku danych."
 
 #: pcb_calculator/dialogs/dialog_regulator_data_base.cpp:36
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:131
-#, fuzzy
 msgid "Vref:"
-msgstr "Vref"
+msgstr "Vref:"
 
 #: pcb_calculator/dialogs/dialog_regulator_data_base.cpp:43
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:403
@@ -14489,9 +14597,8 @@ msgstr "Regulator trójkońcówkowy"
 
 #: pcb_calculator/dialogs/dialog_regulator_data_base.cpp:60
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:147
-#, fuzzy
 msgid "Iadj:"
-msgstr "Iadj"
+msgstr "Iadj:"
 
 #: pcb_calculator/dialogs/dialog_regulator_data_base.cpp:67
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:156
@@ -14503,28 +14610,24 @@ msgid "Regulator Parameters"
 msgstr "Parametry regulatora"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:62
-#, fuzzy
 msgid "Formula:"
-msgstr "Wzór"
+msgstr "Wzór:"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:64
 msgid "Vout = Vref * (R1 + R2) / R2"
 msgstr "Vout = Vref * (R1 + R2) / R2"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:89
-#, fuzzy
 msgid "R1:"
-msgstr "R1"
+msgstr "R1:"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:103
-#, fuzzy
 msgid "R2:"
-msgstr "R2"
+msgstr "R2:"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:117
-#, fuzzy
 msgid "Vout:"
-msgstr "Vout"
+msgstr "Vout:"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:124
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:140
@@ -14569,9 +14672,8 @@ msgid "Calculate"
 msgstr "Oblicz"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:185
-#, fuzzy
 msgid "Regulator:"
-msgstr "Regulatory napięcia"
+msgstr "Regulator:"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:192
 msgid "Regulators data file:"
@@ -14617,55 +14719,47 @@ msgid "Parameters:"
 msgstr "Parametry:"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:262
-#, fuzzy
 msgid "Current:"
-msgstr "Prąd"
+msgstr "Prąd:"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:275
-#, fuzzy
 msgid "Temperature rise:"
-msgstr "Przyrost temperatury"
+msgstr "Przyrost temperatury:"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:282
 msgid "deg C"
 msgstr "st. C"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:286
-#, fuzzy
 msgid "Conductor length:"
-msgstr "Długość łącza"
+msgstr "Długość łącza:"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:298
-#, fuzzy
 msgid "Resistivity:"
-msgstr "Rezystywność"
+msgstr "Rezystywność:"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:305
 msgid "Ohm-meter"
 msgstr "Parametry"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:328
-#, fuzzy
 msgid "External layer traces:"
-msgstr "Zewnętrzne ścieżki"
+msgstr "Ścieżki na zewnętrznej warstwie:"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:336
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:434
-#, fuzzy
 msgid "Trace width:"
-msgstr "Szerokość ścieżki"
+msgstr "Szerokość ścieżki:"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:350
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:448
-#, fuzzy
 msgid "Trace thickness:"
-msgstr "Grubość ścieżki"
+msgstr "Grubość ścieżki:"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:371
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:460
-#, fuzzy
 msgid "Cross-section area:"
-msgstr "Powierzchnia przekroju"
+msgstr "Powierzchnia przekroju:"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:375
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:387
@@ -14701,21 +14795,18 @@ msgstr "mm²"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:383
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:472
-#, fuzzy
 msgid "Resistance:"
-msgstr "Rezystancja"
+msgstr "Rezystancja:"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:395
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:484
-#, fuzzy
 msgid "Voltage drop:"
-msgstr "Spadek napięcia"
+msgstr "Spadek napięcia:"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:407
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:496
-#, fuzzy
 msgid "Power loss:"
-msgstr "Straty"
+msgstr "Straty mocy:"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:415
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:504
@@ -14723,9 +14814,8 @@ msgid "Watt"
 msgstr "W"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:426
-#, fuzzy
 msgid "Internal layer traces:"
-msgstr "Wewnętrzne ścieżki"
+msgstr "Ścieżki na wewnętrznej warstwie:"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:521
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:49
@@ -14882,9 +14972,8 @@ msgstr "Parametry podłoża"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:649
 #: pcb_calculator/transline_ident.cpp:142
-#, fuzzy
 msgid "Er:"
-msgstr "Er"
+msgstr "Er:"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:656
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:666
@@ -14895,14 +14984,13 @@ msgstr "..."
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:659
 #: pcb_calculator/transline_ident.cpp:145
-#, fuzzy
 msgid "TanD:"
-msgstr "TanD"
+msgstr "TanD:"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:669
 #: pcb_calculator/transline_ident.cpp:150
 msgid "Rho:"
-msgstr ""
+msgstr "Rho:"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:671
 msgid "Specific resistance in ohms * meters"
@@ -14914,15 +15002,14 @@ msgstr "Rezystancja charakterystyczna w Ω * metr"
 #: pcb_calculator/transline_ident.cpp:240
 #: pcb_calculator/transline_ident.cpp:341
 #: pcb_calculator/transline_ident.cpp:377
-#, fuzzy
 msgid "H:"
-msgstr "H"
+msgstr "H:"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:693
 #: pcb_calculator/transline_ident.cpp:173
 #: pcb_calculator/transline_ident.cpp:343
 msgid "H_t:"
-msgstr ""
+msgstr "H_t:"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:705
 #: pcb_calculator/transline_ident.cpp:175
@@ -14930,21 +15017,18 @@ msgstr ""
 #: pcb_calculator/transline_ident.cpp:242
 #: pcb_calculator/transline_ident.cpp:345
 #: pcb_calculator/transline_ident.cpp:382
-#, fuzzy
 msgid "T:"
-msgstr "T"
+msgstr "T:"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:717
 #: pcb_calculator/transline_ident.cpp:177
 #: pcb_calculator/transline_ident.cpp:347
-#, fuzzy
 msgid "Rough:"
-msgstr "Chropowatość"
+msgstr "Chropowatość:"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:729
-#, fuzzy
 msgid "mu Rel:"
-msgstr "mu Rel"
+msgstr "mu Rel:"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:741
 #: pcb_calculator/transline_ident.cpp:182
@@ -14955,9 +15039,8 @@ msgstr "mu Rel"
 #: pcb_calculator/transline_ident.cpp:349
 #: pcb_calculator/transline_ident.cpp:384
 #: pcb_calculator/transline_ident.cpp:412
-#, fuzzy
 msgid "mu Rel C:"
-msgstr "mu Rel C"
+msgstr "mu Rel C:"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:760
 msgid "Component Parameters:"
@@ -14965,16 +15048,15 @@ msgstr "Parametry komponentów:"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:798
 msgid "Zdiff = Zodd * 2"
-msgstr ""
+msgstr "Zdiff = Zodd * 2"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:804
 msgid "Zcommon = Zeven / 2"
-msgstr ""
+msgstr "Zcommon = Zeven / 2"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:823
-#, fuzzy
 msgid "Physical Parameters:"
-msgstr "Parametry fizyczne"
+msgstr "Parametry fizyczne:"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:834
 msgid "Prm1"
@@ -14994,7 +15076,7 @@ msgstr "Analizuj"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:900
 msgid "Synthesize"
-msgstr ""
+msgstr "Syntetyzuj"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:913
 msgid "Electrical Parameters:"
@@ -15117,7 +15199,7 @@ msgstr "Trzeci pasek"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1223
 msgid "4th Band"
-msgstr "Czwarty pasek"
+msgstr "4th Band"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1227
 msgid "Multiplier"
@@ -15161,7 +15243,7 @@ msgstr "Szerokość ścieżek"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1305
 msgid "Min clearance"
-msgstr "Prześwit min."
+msgstr "Minimalny prześwit"
 
 #: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1306
 msgid "Via: (diam - drill)"
@@ -15201,6 +15283,8 @@ msgid ""
 "Unable to write file \"%s\"\n"
 "Do you want to exit and abandon your change?"
 msgstr ""
+"Nie można zapisać pliku \"%s\"\n"
+"Czy chcesz opuścić program i porzucić zmiany?"
 
 #: pcb_calculator/pcb_calculator_frame.cpp:161
 msgid "Write Data File Error"
@@ -15214,11 +15298,11 @@ msgstr "Złe lub brakujące parametry!"
 #: pcb_calculator/regulators_funct.cpp:227
 #, c-format
 msgid "PCB Calculator data file (*.%s)|*.%s"
-msgstr ""
+msgstr "Plik danych programu PCB Calculator (*.%s)|*.%s"
 
 #: pcb_calculator/regulators_funct.cpp:232
 msgid "Select PCB Calculator Data File"
-msgstr ""
+msgstr "Wybierz plik danych programu PCB Calculator"
 
 #: pcb_calculator/regulators_funct.cpp:247
 msgid "Do you want to load this file and replace current regulator list?"
@@ -15227,19 +15311,19 @@ msgstr "Czy chcesz załadować ten plik i zastąpić bieżącą listę regulator
 #: pcb_calculator/regulators_funct.cpp:263
 #, c-format
 msgid "Unable to read data file \"%s\""
-msgstr ""
+msgstr "Nie można odczytać pliku danych \"%s\""
 
 #: pcb_calculator/regulators_funct.cpp:294
 msgid "This regulator is already in list. Aborted"
-msgstr "Ten regulator jest już na liście. Przerwano."
+msgstr "Ten regulator jest już na liście. Przerwano"
 
 #: pcb_calculator/regulators_funct.cpp:398
 msgid "Vout must be greater than vref"
-msgstr ""
+msgstr "Vout musi być większe niż Vref"
 
 #: pcb_calculator/regulators_funct.cpp:404
 msgid "Vref set to 0 !"
-msgstr "Vref wynosi 0!"
+msgstr "Vref ustawiony na zero!"
 
 #: pcb_calculator/regulators_funct.cpp:410
 msgid "Incorrect value for R1 R2"
@@ -15265,7 +15349,7 @@ msgstr ""
 
 #: pcb_calculator/tracks_width_versus_current.cpp:455
 msgid "The controlling value is shown in bold."
-msgstr "Wartości sterujące są pokazywane jako pogrubione"
+msgstr "Wartości sterujące są pokazywane jako pogrubione."
 
 #: pcb_calculator/tracks_width_versus_current.cpp:456
 msgid ""
@@ -15329,7 +15413,7 @@ msgstr "Rezystywność lub rezystancja charakterystyczna łącza (Ω * metr)"
 
 #: pcb_calculator/transline_ident.cpp:156
 msgid "Frequency of the input signal"
-msgstr ""
+msgstr "Częstotliwość sygnału wejściowego"
 
 #: pcb_calculator/transline_ident.cpp:165
 #: pcb_calculator/transline_ident.cpp:202
@@ -15338,9 +15422,8 @@ msgstr ""
 #: pcb_calculator/transline_ident.cpp:301
 #: pcb_calculator/transline_ident.cpp:371
 #: pcb_calculator/transline_ident.cpp:404
-#, fuzzy
 msgid "ErEff:"
-msgstr "ErEff"
+msgstr "ErEff:"
 
 #: pcb_calculator/transline_ident.cpp:166
 #: pcb_calculator/transline_ident.cpp:203
@@ -15349,9 +15432,8 @@ msgstr "ErEff"
 #: pcb_calculator/transline_ident.cpp:302
 #: pcb_calculator/transline_ident.cpp:372
 #: pcb_calculator/transline_ident.cpp:405
-#, fuzzy
 msgid "Conductor Losses:"
-msgstr "Straty łączeniowe"
+msgstr "Straty łączeniowe:"
 
 #: pcb_calculator/transline_ident.cpp:167
 #: pcb_calculator/transline_ident.cpp:204
@@ -15360,9 +15442,8 @@ msgstr "Straty łączeniowe"
 #: pcb_calculator/transline_ident.cpp:303
 #: pcb_calculator/transline_ident.cpp:373
 #: pcb_calculator/transline_ident.cpp:406
-#, fuzzy
 msgid "Dielectric Losses:"
-msgstr "Straty izolatora"
+msgstr "Straty izolatora:"
 
 #: pcb_calculator/transline_ident.cpp:168
 #: pcb_calculator/transline_ident.cpp:205
@@ -15370,9 +15451,8 @@ msgstr "Straty izolatora"
 #: pcb_calculator/transline_ident.cpp:338
 #: pcb_calculator/transline_ident.cpp:374
 #: pcb_calculator/transline_ident.cpp:407
-#, fuzzy
 msgid "Skin Depth:"
-msgstr "Naskórkowość"
+msgstr "Naskórkowość:"
 
 #: pcb_calculator/transline_ident.cpp:171
 #: pcb_calculator/transline_ident.cpp:208
@@ -15401,9 +15481,8 @@ msgid "Conductor Roughness"
 msgstr "Chropowatość łącza"
 
 #: pcb_calculator/transline_ident.cpp:179
-#, fuzzy
 msgid "mu Rel S:"
-msgstr "mu Rel S"
+msgstr "mu Rel S:"
 
 #: pcb_calculator/transline_ident.cpp:180
 msgid "Relative Permeability (mu) of Substrate"
@@ -15425,9 +15504,8 @@ msgstr "Względna przenikalność (mu) łącza"
 #: pcb_calculator/transline_ident.cpp:248
 #: pcb_calculator/transline_ident.cpp:353
 #: pcb_calculator/transline_ident.cpp:388
-#, fuzzy
 msgid "W:"
-msgstr "W"
+msgstr "W:"
 
 #: pcb_calculator/transline_ident.cpp:188
 #: pcb_calculator/transline_ident.cpp:220
@@ -15437,9 +15515,8 @@ msgstr "W"
 #: pcb_calculator/transline_ident.cpp:357
 #: pcb_calculator/transline_ident.cpp:390
 #: pcb_calculator/transline_ident.cpp:422
-#, fuzzy
 msgid "L:"
-msgstr "L"
+msgstr "L:"
 
 #: pcb_calculator/transline_ident.cpp:188
 #: pcb_calculator/transline_ident.cpp:220
@@ -15457,9 +15534,8 @@ msgstr "Długość linii"
 #: pcb_calculator/transline_ident.cpp:321
 #: pcb_calculator/transline_ident.cpp:393
 #: pcb_calculator/transline_ident.cpp:425
-#, fuzzy
 msgid "Z0:"
-msgstr "Z:"
+msgstr "Z0:"
 
 #: pcb_calculator/transline_ident.cpp:191
 #: pcb_calculator/transline_ident.cpp:223
@@ -15479,9 +15555,8 @@ msgstr "Impedancja charakterystyczna"
 #: pcb_calculator/transline_ident.cpp:364
 #: pcb_calculator/transline_ident.cpp:396
 #: pcb_calculator/transline_ident.cpp:428
-#, fuzzy
 msgid "Ang_l:"
-msgstr "Kąt"
+msgstr "Kąt_I:"
 
 #: pcb_calculator/transline_ident.cpp:194
 #: pcb_calculator/transline_ident.cpp:226
@@ -15497,9 +15572,8 @@ msgstr "Długość elektryczna"
 #: pcb_calculator/transline_ident.cpp:218
 #: pcb_calculator/transline_ident.cpp:250
 #: pcb_calculator/transline_ident.cpp:355
-#, fuzzy
 msgid "S:"
-msgstr "S"
+msgstr "S:"
 
 #: pcb_calculator/transline_ident.cpp:218
 #: pcb_calculator/transline_ident.cpp:250
@@ -15508,27 +15582,23 @@ msgid "Gap Width"
 msgstr "Szerokość przerwy"
 
 #: pcb_calculator/transline_ident.cpp:267
-#, fuzzy
 msgid "ZF(H10) = Ey / Hx:"
-msgstr "ZF(H10) = Ey / Hx"
+msgstr "ZF(H10) = Ey / Hx:"
 
 #: pcb_calculator/transline_ident.cpp:271
 #: pcb_calculator/transline_ident.cpp:304
-#, fuzzy
 msgid "TE-Modes:"
-msgstr "TE-Modes"
+msgstr "TE-Modes:"
 
 #: pcb_calculator/transline_ident.cpp:272
 #: pcb_calculator/transline_ident.cpp:305
-#, fuzzy
 msgid "TM-Modes:"
-msgstr "TM-Modes"
+msgstr "TM-Modes:"
 
 #: pcb_calculator/transline_ident.cpp:275
 #: pcb_calculator/transline_ident.cpp:308
-#, fuzzy
 msgid "mu Rel I:"
-msgstr "mu Rel I"
+msgstr "mu Rel I:"
 
 #: pcb_calculator/transline_ident.cpp:275
 #: pcb_calculator/transline_ident.cpp:308
@@ -15536,9 +15606,8 @@ msgid "Relative Permeability (mu) of Insulator"
 msgstr "Względna przenikalność (mu) izolacji"
 
 #: pcb_calculator/transline_ident.cpp:277
-#, fuzzy
 msgid "TanM:"
-msgstr "TanM"
+msgstr "TanM:"
 
 #: pcb_calculator/transline_ident.cpp:277
 msgid "Magnetic Loss Tangent"
@@ -15546,18 +15615,16 @@ msgstr "Tangens strat magnetycznych"
 
 #: pcb_calculator/transline_ident.cpp:283
 #: pcb_calculator/transline_ident.cpp:379
-#, fuzzy
 msgid "a:"
-msgstr "a"
+msgstr "a:"
 
 #: pcb_calculator/transline_ident.cpp:283
 msgid "Width of Waveguide"
 msgstr "Szerokość falowodu"
 
 #: pcb_calculator/transline_ident.cpp:285
-#, fuzzy
 msgid "b:"
-msgstr "b"
+msgstr "b:"
 
 #: pcb_calculator/transline_ident.cpp:285
 msgid "Height of Waveguide"
@@ -15570,7 +15637,7 @@ msgstr "Długość falowodu"
 #: pcb_calculator/transline_ident.cpp:314
 #: pcb_calculator/transline_ident.cpp:418
 msgid "Din:"
-msgstr ""
+msgstr "Din:"
 
 #: pcb_calculator/transline_ident.cpp:314
 #: pcb_calculator/transline_ident.cpp:418
@@ -15579,9 +15646,8 @@ msgstr "Wewnętrzna średnica (łącza)"
 
 #: pcb_calculator/transline_ident.cpp:316
 #: pcb_calculator/transline_ident.cpp:420
-#, fuzzy
 msgid "Dout:"
-msgstr "Dout"
+msgstr "Dout:"
 
 #: pcb_calculator/transline_ident.cpp:316
 #: pcb_calculator/transline_ident.cpp:420
@@ -15589,48 +15655,40 @@ msgid "Outer Diameter (insulator)"
 msgstr "Zewnętrzna średnica (izolacji)"
 
 #: pcb_calculator/transline_ident.cpp:332
-#, fuzzy
 msgid "ErEff Even:"
-msgstr "ErEff Parzysty"
+msgstr "ErEff Parzysty:"
 
 #: pcb_calculator/transline_ident.cpp:333
-#, fuzzy
 msgid "ErEff Odd:"
-msgstr "ErEff Nieparzysty"
+msgstr "ErEff Nieparzysty:"
 
 #: pcb_calculator/transline_ident.cpp:334
-#, fuzzy
 msgid "Conductor Losses Even:"
-msgstr "Straty łączeniowe Parzysty"
+msgstr "Straty łączeniowe Parzysty:"
 
 #: pcb_calculator/transline_ident.cpp:335
-#, fuzzy
 msgid "Conductor Losses Odd:"
-msgstr "Straty łączeniowe Nieparzysty"
+msgstr "Straty łączeniowe Nieparzysty:"
 
 #: pcb_calculator/transline_ident.cpp:336
-#, fuzzy
 msgid "Dielectric Losses Even:"
-msgstr "Straty dielektryka Parzysty"
+msgstr "Straty dielektryka Parzysty:"
 
 #: pcb_calculator/transline_ident.cpp:337
-#, fuzzy
 msgid "Dielectric Losses Odd:"
-msgstr "Straty dielektryka Nieparzysty"
+msgstr "Straty dielektryka Nieparzysty:"
 
 #: pcb_calculator/transline_ident.cpp:360
-#, fuzzy
 msgid "Zeven:"
-msgstr "Zparzyste"
+msgstr "Zparzyste:"
 
 #: pcb_calculator/transline_ident.cpp:360
 msgid "Even mode impedance (lines driven by common voltages)"
 msgstr "Impedancja w trybie parzystym (linie sterowane przez wspólne napięcia)"
 
 #: pcb_calculator/transline_ident.cpp:362
-#, fuzzy
 msgid "Zodd:"
-msgstr "Znieparzyste"
+msgstr "Znieparzyste:"
 
 #: pcb_calculator/transline_ident.cpp:362
 msgid "Odd mode impedance (lines driven by opposite (differential) voltages)"
@@ -15639,21 +15697,19 @@ msgstr ""
 
 #: pcb_calculator/transline_ident.cpp:379
 msgid "distance between strip and top metal"
-msgstr "Odległość pomiędzy paskiem a górnym przewodnikiem"
+msgstr "odległość pomiędzy paskiem a górnym przewodnikiem"
 
 #: pcb_calculator/transline_ident.cpp:410
-#, fuzzy
 msgid "Twists:"
-msgstr "Skrętów"
+msgstr "Skrętów:"
 
 #: pcb_calculator/transline_ident.cpp:410
 msgid "Number of Twists per Length"
 msgstr "Liczba skrętów w na podanej długości"
 
 #: pcb_calculator/transline_ident.cpp:415
-#, fuzzy
 msgid "ErEnv:"
-msgstr "ErEnv"
+msgstr "ErEnv:"
 
 #: pcb_calculator/transline_ident.cpp:415
 msgid "Relative Permittivity of Environment"
@@ -15665,11 +15721,11 @@ msgstr "Długość przewodu"
 
 #: pcbnew/append_board_to_current.cpp:93
 msgid "Error loading board in AppendBoardFile"
-msgstr ""
+msgstr "Błąd podczas wczytywania płytki przez funkcję AppendBoardFile"
 
 #: pcbnew/array_creator.cpp:113
 msgid "Create an array"
-msgstr "Tworzy szyk"
+msgstr "Utwórz szyk"
 
 #: pcbnew/autorouter/auto_place_footprints.cpp:164
 msgid "Footprints NOT LOCKED will be moved"
@@ -15746,122 +15802,127 @@ msgstr "Operacje na blokach"
 #: pcbnew/board_netlist_updater.cpp:125 pcbnew/class_board.cpp:2460
 #, c-format
 msgid "Adding new symbol \"%s:%s\" footprint \"%s\".\n"
-msgstr ""
+msgstr "Dodaję nowemu symbolowi \"%s:%s\" footprint \"%s\".\n"
 
 #: pcbnew/board_netlist_updater.cpp:131
 #, c-format
 msgid "Add symbol %s, footprint: %s.\n"
-msgstr "Dodaj symbol %s, footprint: %s.\n"
+msgstr "Dodanie symbolu %s, footprint: %s.\n"
 
 #: pcbnew/board_netlist_updater.cpp:153
 #, c-format
 msgid "Cannot add symbol %s due to missing footprint %s.\n"
-msgstr ""
+msgstr "Nie można dodać symbolu %s ponieważ brakuje footprintu %s.\n"
 
 #: pcbnew/board_netlist_updater.cpp:159 pcbnew/class_board.cpp:2469
 #, c-format
 msgid "Cannot add new symbol \"%s:%s\" due to missing footprint \"%s\".\n"
 msgstr ""
+"Nie można dodać nowego symbolu \"%s:%s\" ponieważ brakuje footprintu \"%s"
+"\".\n"
 
 #: pcbnew/board_netlist_updater.cpp:186
 #, c-format
 msgid "Change symbol %s footprint from %s to %s.\n"
-msgstr ""
+msgstr "Zmiana symbolu %s footprint z %s na %s.\n"
 
 #: pcbnew/board_netlist_updater.cpp:193 pcbnew/class_board.cpp:2502
 #, c-format
 msgid "Replacing symbol \"%s:%s\" footprint \"%s\" with \"%s\".\n"
-msgstr ""
+msgstr "Zamieniam symbol \"%s:%s\" footprint \"%s\" na \"%s\".\n"
 
 #: pcbnew/board_netlist_updater.cpp:223
 #, c-format
 msgid "Cannot change symbol %s footprint due to missing footprint %s.\n"
 msgstr ""
+"Nie można zmienić footprintu symbolu %s ponieważ brakuje footprintu %s.\n"
 
 #: pcbnew/board_netlist_updater.cpp:230 pcbnew/class_board.cpp:2513
 #, c-format
 msgid "Cannot replace symbol \"%s:%s\" due to missing footprint \"%s\".\n"
 msgstr ""
+"Nie można zamienić symbolu \"%s:%s\" ponieważ brakuje footprintu \"%s\".\n"
 
 #: pcbnew/board_netlist_updater.cpp:259
 #, c-format
 msgid "Change symbol %s reference to %s.\n"
-msgstr ""
+msgstr "Zmiana referencji symbolu %s na %s.\n"
 
 #: pcbnew/board_netlist_updater.cpp:265
 #, c-format
 msgid "Changing symbol \"%s:%s\" reference to \"%s\".\n"
-msgstr ""
+msgstr "Zmieniam referencję symbolu \"%s:%s\" na \"%s\".\n"
 
 #: pcbnew/board_netlist_updater.cpp:282
 #, c-format
 msgid "Change symbol %s value from %s to %s.\n"
-msgstr ""
+msgstr "Zmiana wartości symbolu %s z %s na %s.\n"
 
 #: pcbnew/board_netlist_updater.cpp:289
 #, c-format
 msgid "Changing symbol \"%s:%s\" value from \"%s\" to \"%s\".\n"
-msgstr ""
+msgstr "Zmieniam wartość symbolu \"%s:%s\" z \"%s\" na \"%s\".\n"
 
 #: pcbnew/board_netlist_updater.cpp:307
 #, c-format
 msgid "Changing symbol path \"%s:%s\" to \"%s\".\n"
-msgstr ""
+msgstr "Zmieniam ścieżkę symbolu \"%s:%s\" na \"%s\".\n"
 
 #: pcbnew/board_netlist_updater.cpp:347
 #, c-format
 msgid "Disconnect symbol %s pin %s.\n"
-msgstr ""
+msgstr "Rozłączony symbol %s pin %s.\n"
 
 #: pcbnew/board_netlist_updater.cpp:352
 #, c-format
 msgid "Clearing symbol \"%s:%s\" pin \"%s\" net name.\n"
-msgstr ""
+msgstr "Kasowanie nazwy sieci z symbolu \"%s:%s\" pin \"%s\".\n"
 
 #: pcbnew/board_netlist_updater.cpp:392
 #, c-format
 msgid "Add net %s.\n"
-msgstr "Doda sieć %s.\n"
+msgstr "Dodaję sieć %s.\n"
 
 #: pcbnew/board_netlist_updater.cpp:398
 #, c-format
 msgid "Reconnect symbol %s pin %s from net %s to net %s.\n"
-msgstr ""
+msgstr "Ponowne podłączenie symbolu %s pin %s z sieci %s do sieci %s.\n"
 
 #: pcbnew/board_netlist_updater.cpp:405
 #, c-format
 msgid "Connect symbol %s pin %s to net %s.\n"
-msgstr ""
+msgstr "Podłączenie symbolu %s pin %s do sieci %s.\n"
 
 #: pcbnew/board_netlist_updater.cpp:413
 #, c-format
 msgid "Changing symbol \"%s:%s\" pin \"%s\" net name from \"%s\" to \"%s\".\n"
 msgstr ""
+"Zmieniam nazwę sieci w symbolu \"%s:%s\" pin \"%s\" z \"%s\" na \"%s\".\n"
 
 #: pcbnew/board_netlist_updater.cpp:497
 #, c-format
 msgid "Reconnect copper zone from net \"%s\" to net \"%s\"."
-msgstr ""
+msgstr "Ponowne podłączenie strefy z sieci \"%s\" do sieci \"%s\"."
 
 #: pcbnew/board_netlist_updater.cpp:501
-#, fuzzy, c-format
+#, c-format
 msgid "Changing copper zone net name from \"%s\" to \"%s\"."
-msgstr "Zmieniam wartość footprintu \"%s:%s\" z \"%s\" do \"%s\".\n"
+msgstr "Zmiana nazwy sieci strefy z \"%s\" na \"%s\"."
 
 #: pcbnew/board_netlist_updater.cpp:521
-#, fuzzy, c-format
+#, c-format
 msgid "Copper zone (net \"%s\") has no pads connected."
-msgstr "Strefa (nazwa sieci '%s'): sieć nie posiada żadnych pól lutowniczych."
+msgstr "Strefa miedzi (sieć \"%s\") nie ma połączenia z żadnym polem."
 
 #: pcbnew/board_netlist_updater.cpp:552
 #, c-format
 msgid "Footprint %s is locked, skipping removal.\n"
-msgstr ""
+msgstr "Footprint %s jest zablokowany, pomijam usunięcie.\n"
 
 #: pcbnew/board_netlist_updater.cpp:558
 #, c-format
 msgid "Remove footprint %s."
-msgstr "Usuń footprint %s."
+msgstr "Usuwanie footprintu %s."
 
 #: pcbnew/board_netlist_updater.cpp:562 pcbnew/class_board.cpp:2694
 #, c-format
@@ -15871,41 +15932,43 @@ msgstr "Usuwam nieużywany footprint \"%s:%s\".\n"
 #: pcbnew/board_netlist_updater.cpp:631
 #, c-format
 msgid "Remove single pad net %s."
-msgstr ""
+msgstr "Usuwam sieć %s z uwagi na brak dalszych połączeń."
 
 #: pcbnew/board_netlist_updater.cpp:635 pcbnew/class_board.cpp:2760
 #, c-format
 msgid "Remove single pad net \"%s\" on \"%s\" pad \"%s\"\n"
-msgstr ""
+msgstr "Usunięcie samotnej nazwy sieci \"%s\" z pola w \"%s\" pole \"%s\"\n"
 
 #: pcbnew/board_netlist_updater.cpp:700
 #, c-format
 msgid "Component %s pad %s not found in footprint %s\n"
-msgstr ""
+msgstr "Komponent %s, pole %s nie zostało znalezione w footprincie %s\n"
 
 #: pcbnew/board_netlist_updater.cpp:731
 #, c-format
 msgid "Processing component \"%s:%s:%s\".\n"
-msgstr ""
+msgstr "Przetwarzam komponent \"%s:%s:%s\".\n"
 
 #: pcbnew/board_netlist_updater.cpp:771
 msgid "Update netlist"
-msgstr "Uaktualnij listę połączeń"
+msgstr "Uaktualnij listę sieci"
 
 #: pcbnew/board_netlist_updater.cpp:780
 #, c-format
 msgid "Total warnings: %d, errors: %d."
-msgstr ""
+msgstr "Ostrzeżeń w sumie: %d, błędów w sumie: %d."
 
 #: pcbnew/board_netlist_updater.cpp:785
 msgid ""
 "Errors occurred during the netlist update. Unless you fix them, your board "
 "will not be consistent with the schematics."
 msgstr ""
+"Wystąpiły błędy podczas aktualizacji listy sieci. Do czasu ich poprawy, "
+"obwód drukowany nie będzie zgodny ze schematem."
 
 #: pcbnew/board_netlist_updater.cpp:793
 msgid "Netlist update successful!"
-msgstr "Aktualizacja listy połączeń zakończona powodzeniem!"
+msgstr "Aktualizacja listy sieci zakończona powodzeniem!"
 
 #: pcbnew/build_BOM_from_board.cpp:85
 msgid "Cannot export BOM: there are no footprints in the PCB"
@@ -15919,7 +15982,7 @@ msgstr "Zapisz listę materiałów"
 #: pcbnew/dialogs/dialog_export_vrml.cpp:253
 #, c-format
 msgid "Unable to create file \"%s\""
-msgstr "Nie mogę utworzyć pliku \"%s\""
+msgstr "Nie można utworzyć pliku \"%s\""
 
 #: pcbnew/build_BOM_from_board.cpp:115
 msgid "Id"
@@ -15976,24 +16039,23 @@ msgid "Nets"
 msgstr "Sieci"
 
 #: pcbnew/class_board.cpp:1148 pcbnew/pcb_draw_panel_gal.cpp:349
-#, fuzzy
 msgid "Unrouted"
-msgstr "Resetuj niepołączone"
+msgstr "Niepołączone"
 
 #: pcbnew/class_board.cpp:2442
 #, c-format
 msgid "Checking netlist symbol footprint \"%s:%s:%s\".\n"
-msgstr ""
+msgstr "Sprawdzam footprint symbolu z listy sieci \"%s:%s:%s\".\n"
 
 #: pcbnew/class_board.cpp:2566
 #, c-format
 msgid "Changing footprint \"%s:%s\" reference to \"%s\".\n"
-msgstr ""
+msgstr "Zmieniam odnośnik footprintu \"%s:%s\" na \"%s\".\n"
 
 #: pcbnew/class_board.cpp:2582
 #, c-format
 msgid "Changing footprint \"%s:%s\" value from \"%s\" to \"%s\".\n"
-msgstr ""
+msgstr "Zmieniam wartość footprintu \"%s:%s\" z \"%s\" na \"%s\".\n"
 
 #: pcbnew/class_board.cpp:2599
 #, c-format
@@ -16010,21 +16072,26 @@ msgstr "Kasuje nazwę sieci z komponentu \"%s:%s\" pin \"%s\".\n"
 msgid ""
 "Changing footprint \"%s:%s\" pad \"%s\" net name from \"%s\" to \"%s\".\n"
 msgstr ""
+"Zmieniam nazwę sieci footprintu \"%s:%s\" pole \"%s\" z \"%s\" na \"%s\".\n"
 
 #: pcbnew/class_board.cpp:2799
 #, c-format
 msgid "Component \"%s\" pad \"%s\" not found in footprint \"%s\"\n"
 msgstr ""
+"Pole komponentu \"%s\" pole \"%s\" nie zostało znalezione w footprincie \"%s"
+"\"\n"
 
 #: pcbnew/class_board.cpp:2836
-#, fuzzy, c-format
+#, c-format
 msgid "Updating copper zone (net name \"%s\") to net name \"%s\"."
-msgstr "Zmieniam ścieżkę footprintu \"%s:%s\" na \"%s\".\n"
+msgstr ""
+"Uaktualniam strefę miedzi (sieć \"%s\") przypisując ją do sieci o nazwie \"%s"
+"\"."
 
 #: pcbnew/class_board.cpp:2842
-#, fuzzy, c-format
+#, c-format
 msgid "Copper zone (net name \"%s\") has no pads connected."
-msgstr "Strefa (nazwa sieci '%s'): sieć nie posiada żadnych pól lutowniczych."
+msgstr "Strefa miedzi (sieć \"%s\") nie ma połączenia z żadnym polem."
 
 #: pcbnew/class_board_item.cpp:44 pcbnew/class_pad.cpp:1163
 msgid "Rect"
@@ -16110,7 +16177,7 @@ msgstr "Strona płytki"
 
 #: pcbnew/class_module.cpp:572
 msgid "Back (Flipped)"
-msgstr ""
+msgstr "Dolna (Odwrócona)"
 
 #: pcbnew/class_module.cpp:572
 #: pcbnew/dialogs/dialog_edit_footprint_for_BoardEditor_base.cpp:63
@@ -16170,7 +16237,7 @@ msgstr "Sieć"
 #: pcbnew/class_pad.cpp:736 pcbnew/class_track.cpp:1297
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:305
 msgid "Drill"
-msgstr "Średnica otworu"
+msgstr "Wiercenie"
 
 #: pcbnew/class_pad.cpp:744
 msgid "Drill X / Y"
@@ -16191,11 +16258,11 @@ msgstr "Trap"
 
 #: pcbnew/class_pad.cpp:1169
 msgid "Roundrect"
-msgstr "Zaokrąglony prostokąt"
+msgstr "Zaokrąglony kwadrat"
 
 #: pcbnew/class_pad.cpp:1172
 msgid "CustomShape"
-msgstr ""
+msgstr "Kształt własny"
 
 #: pcbnew/class_pad.cpp:1185
 msgid "Std"
@@ -16259,7 +16326,7 @@ msgstr "Tekst PCB \"%s\" na %s"
 
 #: pcbnew/class_text_mod.cpp:374
 msgid "Ref."
-msgstr "Oznaczenie"
+msgstr "Ozn."
 
 #: pcbnew/class_text_mod.cpp:425
 #, c-format
@@ -16462,6 +16529,8 @@ msgid ""
 "Unable to find the next boundary segment with an endpoint of (%s mm, %s mm). "
 "graphic outline must form a contiguous, closed polygon."
 msgstr ""
+"Nie można odnaleźć następnego segmentu z punktem końcowym w (%s mm, %s mm). "
+"Obrys graficzny musi być ciągłą, zamkniętą linią łamaną."
 
 #: pcbnew/convert_drawsegment_list_to_polygon.cpp:535
 #, c-format
@@ -16469,6 +16538,8 @@ msgid ""
 "Unable to find the next graphic segment with an endpoint of (%s mm, %s mm).\n"
 "Edit graphics, making them contiguous polygons each."
 msgstr ""
+"Nie można odnaleźć następnego segmentu z punktem końcowym w (%s mm, %s mm).\n"
+"Należy poprawić rysunek, by stał się ciągłą, zamkniętą linią łamaną."
 
 #: pcbnew/cross-probing.cpp:158
 #, c-format
@@ -16483,7 +16554,7 @@ msgstr "Nie znaleziono %s"
 #: pcbnew/cross-probing.cpp:169
 #, c-format
 msgid "Selecting all from sheet \"%s\""
-msgstr ""
+msgstr "Wybieram wszystko z arkusza \"%s\""
 
 #: pcbnew/cross-probing.cpp:219
 #, c-format
@@ -16519,13 +16590,13 @@ msgstr ""
 #: pcbnew/dialogs/dialog_SVG_print.cpp:304
 #, c-format
 msgid "Plot: \"%s\" OK."
-msgstr "Rysunek: \"%s\" OK."
+msgstr "Rysowanie: \"%s\" OK."
 
 #: pcbnew/dialogs/dialog_SVG_print.cpp:310 pcbnew/dialogs/dialog_plot.cpp:913
 #: pcbnew/exporters/gen_footprints_placefile.cpp:340
 #, c-format
 msgid "Unable to create file \"%s\"."
-msgstr "Nie mogę utworzyć pliku \"%s\"."
+msgstr "Nie można utworzyć pliku \"%s\"."
 
 #: pcbnew/dialogs/dialog_SVG_print_base.cpp:29
 msgid ""
@@ -16542,7 +16613,7 @@ msgstr "Przeglądaj..."
 #: pcbnew/dialogs/dialog_SVG_print_base.cpp:49
 #: pcbnew/dialogs/dialog_print_using_printer_base.cpp:28
 msgid "Copper layers:"
-msgstr "Warstwy ścieżek:"
+msgstr "Warstwy miedzi:"
 
 #: pcbnew/dialogs/dialog_SVG_print_base.cpp:63
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:348
@@ -16581,9 +16652,8 @@ msgid "Board area only"
 msgstr "Tylko obszar płytki"
 
 #: pcbnew/dialogs/dialog_SVG_print_base.cpp:99
-#, fuzzy
 msgid "SVG Page Size:"
-msgstr "Rozmiar strony SVG"
+msgstr "Rozmiar strony SVG:"
 
 #: pcbnew/dialogs/dialog_SVG_print_base.cpp:103
 msgid "Print board edges"
@@ -16647,9 +16717,8 @@ msgid "Include &board outline layer"
 msgstr "Uwzględnij warstwę krawędzi płytki"
 
 #: pcbnew/dialogs/dialog_block_options_base.cpp:48
-#, fuzzy
 msgid "Include &vias"
-msgstr "Uwzględnij ścieżki"
+msgstr "Uwzględnij przelotki"
 
 #: pcbnew/dialogs/dialog_block_options_base.cpp:51
 msgid "Include &zones"
@@ -16665,13 +16734,14 @@ msgstr "Rysuj wybrane elementy podczas przesuwania"
 
 #: pcbnew/dialogs/dialog_cleaning_options_base.cpp:22
 msgid "Delete &track segments connecting different nets"
-msgstr ""
+msgstr "Usuń segmenty ścieżek łączących różne sieci"
 
 #: pcbnew/dialogs/dialog_cleaning_options_base.cpp:23
 msgid ""
 "remove track segments connecting nodes belonging to different nets (short "
 "circuit)"
 msgstr ""
+"usuwa segmenty ścieżek łączących węzły należące do różnych sieci (zwarcia)"
 
 #: pcbnew/dialogs/dialog_cleaning_options_base.cpp:27
 msgid "&Delete redundant vias"
@@ -16680,6 +16750,8 @@ msgstr "Usuń nadmiarowe przelotki"
 #: pcbnew/dialogs/dialog_cleaning_options_base.cpp:28
 msgid "remove vias on through hole pads and superimposed vias"
 msgstr ""
+"usuwa przelotki z miejsc pól lutowniczych oraz wielokrotnie nałożone "
+"przelotki"
 
 #: pcbnew/dialogs/dialog_cleaning_options_base.cpp:32
 msgid "&Merge overlapping segments"
@@ -16687,15 +16759,15 @@ msgstr "Połącz współliniowe segmenty"
 
 #: pcbnew/dialogs/dialog_cleaning_options_base.cpp:33
 msgid "merge aligned track segments, and remove null segments"
-msgstr "Połącz wstawione segmenty ścieżki i usuń puste segmenty"
+msgstr "mołącz wstawione segmenty ścieżki i usuń puste segmenty"
 
 #: pcbnew/dialogs/dialog_cleaning_options_base.cpp:37
 msgid "Delete &dangling tracks"
-msgstr "Usuwa niepołączone ścieżki"
+msgstr "Usuń niedokończone ścieżki"
 
 #: pcbnew/dialogs/dialog_cleaning_options_base.cpp:38
 msgid "delete tracks having at least one dangling end"
-msgstr ""
+msgstr "usuwa ścieżki, które przynajmniej z jednej strony są niedokończone"
 
 #: pcbnew/dialogs/dialog_cleaning_options_base.h:48
 msgid "Cleaning Options"
@@ -16744,9 +16816,8 @@ msgid "Layer:"
 msgstr "Warstwa:"
 
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:64
-#, fuzzy
 msgid "Net Filtering:"
-msgstr "Filtrowanie Sieci"
+msgstr "Filtrowanie Sieci:"
 
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:66
 #: pcbnew/dialogs/dialog_dimension_editor_base.cpp:80
@@ -16804,9 +16875,8 @@ msgid "Apply Filters"
 msgstr "Zastosuj filtry"
 
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:104
-#, fuzzy
 msgid "Settings:"
-msgstr "Ustawienia"
+msgstr "Ustawienia:"
 
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:109
 #: pcbnew/dialogs/dialog_drc_base.cpp:48
@@ -16815,13 +16885,12 @@ msgid "Clearance:"
 msgstr "Prześwit:"
 
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:116
-#, fuzzy
 msgid "Minimum width:"
-msgstr "Szerokośc minimalna"
+msgstr "Szerokość minimalna:"
 
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:118
 msgid "Minimum thickness of filled areas."
-msgstr "Minimalna grubość wypełnionych obszarów."
+msgstr "Minimalna szerokość wypełnianych stref."
 
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:125
 msgid "Corner smoothing:"
@@ -16841,13 +16910,15 @@ msgstr "Odległość ścięcia (mm):"
 
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:148
 msgid "Default pad connection:"
-msgstr "Domyślne połączenie pola lutowniczego:"
+msgstr "Domyślne łączenie pól lutowniczych:"
 
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:150
 msgid ""
 "Default pad connection type to zone.\n"
 "This setting can be overridden by local  pad settings"
 msgstr ""
+"Domyślny sposób połączenia pola ze strefą.\n"
+"To ustawienie może zostać zmienione przez lokalne ustawienia pól lutowniczych"
 
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:154
 #: pcbnew/dialogs/dialog_edit_footprint_for_BoardEditor_base.cpp:220
@@ -16861,23 +16932,20 @@ msgid "THT thermal"
 msgstr "Połączenia termiczne z elem. THT"
 
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:161
-#, fuzzy
 msgid "Thermal Reliefs:"
-msgstr "Połączenia termiczne"
+msgstr "Połączenia termiczne:"
 
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:163
-#, fuzzy
 msgid "Antipad clearance:"
-msgstr "Prześwit pola lutowniczego"
+msgstr "Prześwit anty-padu:"
 
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:168
 msgid "Clearance between pads in the same net and filled areas."
 msgstr "Prześwit pomiędzy polami lutowniczymi z tej samej sieci a strefą."
 
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:172
-#, fuzzy
 msgid "Spoke width:"
-msgstr "Szerokość łącza"
+msgstr "Szerokość łącza:"
 
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:177
 msgid "Width of copper in thermal reliefs."
@@ -16885,10 +16953,9 @@ msgstr "Określ szerokość łącza dla połączeń termicznych."
 
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:190
 msgid "Zone priority level:"
-msgstr "Poziom priorytetu stref:"
+msgstr "Poziom priorytetu strefy:"
 
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:192
-#, fuzzy
 msgid ""
 "Zones are filled by priority level, level 3 has higher priority than level "
 "2.\n"
@@ -16896,11 +16963,12 @@ msgid ""
 "* If its priority is higher, its outlines are removed from the other zone.\n"
 "* If its priority is equal, a DRC error is set."
 msgstr ""
-"Na każdej warstwie sygnałowej, strefy są wypełniane zgodnie z ich "
-"priorytetem.\n"
-"Dlatego też, gdy strefa znajduje się wewnątrz innej strefy:\n"
-"* Jeśli jej priorytet jest wyższy: jej obrysy są usuwane z innej warstwy.\n"
-"* Jeśli jej priorytet jest taki sam: zostaje zgłoszony błąd DRC."
+"Strefy są wypełniane według poziomu priorytetów, poziom 3 ma wyższy "
+"priorytet niż poziom 2.\n"
+"Gdy strefa znajduje się wewnątrz innej strefy:\n"
+"* Jeśli jej priorytet jest wyższy, jej obrys jest usuwany z pozostałej "
+"strefy.\n"
+"* Jeśli jej priorytet jest taki sam, zgłaszany jest błąd DRC."
 
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:199
 msgid "Fill mode:"
@@ -16908,17 +16976,15 @@ msgstr "Tryb wypełnienia:"
 
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:209
 msgid "Boundary mode:"
-msgstr ""
+msgstr "Tryb graniczny:"
 
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:213
-#, fuzzy
 msgid "Low Resolution"
-msgstr "Rozdzielczość:"
+msgstr "Niska rozdzielczość"
 
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:213
-#, fuzzy
 msgid "High Resolution"
-msgstr "Rozdzielczość:"
+msgstr "Wysoka rozdzielczość"
 
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:225
 #: pcbnew/dialogs/dialog_keepout_area_properties_base.cpp:54
@@ -16956,6 +17022,9 @@ msgid ""
 "in an unconnected \n"
 "copper island."
 msgstr ""
+"Brak podłączonej sieci\n"
+"spowoduje, że powstaną\n"
+"izolowane strefy."
 
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:266
 msgid "Export Settings to Other Zones"
@@ -16992,7 +17061,7 @@ msgstr "Alfabetycznie, pełne 26 znaków"
 #: pcbnew/dialogs/dialog_create_array.cpp:233
 #, c-format
 msgid "Unrecognized numbering scheme: %d"
-msgstr ""
+msgstr "Nierozpoznany schemat numeracji: %d"
 
 #: pcbnew/dialogs/dialog_create_array.cpp:247
 #, c-format
@@ -17000,35 +17069,37 @@ msgid ""
 "Could not determine numbering start from \"%s\": expected value consistent "
 "with alphabet \"%s\""
 msgstr ""
+"Nie można określić początku numeracji od \"%s\": spodziewana wartość ma "
+"zawierać się w \"%s\""
 
 #: pcbnew/dialogs/dialog_create_array.cpp:276
 #, c-format
 msgid "Bad numeric value for %s: %s"
-msgstr ""
+msgstr "Zła wartość numeryczna dla %s: %s"
 
 #: pcbnew/dialogs/dialog_create_array.cpp:299
 msgid "horizontal count"
-msgstr "Ilość poziomo"
+msgstr "ilość poziomo"
 
 #: pcbnew/dialogs/dialog_create_array.cpp:301
 msgid "vertical count"
-msgstr ""
+msgstr "ilość pionowo"
 
 #: pcbnew/dialogs/dialog_create_array.cpp:311
 msgid "stagger"
-msgstr ""
+msgstr "przeplot"
 
 #: pcbnew/dialogs/dialog_create_array.cpp:360
 msgid "point count"
-msgstr ""
+msgstr "ilość wyprowadzeń"
 
 #: pcbnew/dialogs/dialog_create_array.cpp:373
 msgid "numbering start"
-msgstr ""
+msgstr "rozpoczęcie numeracji pól"
 
 #: pcbnew/dialogs/dialog_create_array.cpp:399
 msgid "Bad parameters"
-msgstr "Złe parametry"
+msgstr "Niepoprawne parametry"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:31
 msgid "Horizontal count:"
@@ -17081,9 +17152,8 @@ msgid "Columns"
 msgstr "Kolumnami"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:98
-#, fuzzy
 msgid "Stagger Type:"
-msgstr "Typ przeplotu"
+msgstr "Typ przeplotu:"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:110
 msgid "Horizontal, then vertical"
@@ -17094,29 +17164,27 @@ msgid "Vertical, then horizontal"
 msgstr "Najpierw pionowo, potem poziomo"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:112
-#, fuzzy
 msgid "Pad Numbering Direction:"
-msgstr "Kierunek numeracji szyku"
+msgstr "Kierunek numeracji pół w szyku:"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:116
 msgid "Reverse numbering on alternate rows/columns"
-msgstr ""
+msgstr "Odwrotna numeracja pól przy zmianie rzędu lub kolumny"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:119
 #: pcbnew/dialogs/dialog_create_array_base.cpp:260
 msgid "Use first free number"
-msgstr ""
+msgstr "Użyj pierwszego wolnego numeru"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:119
 #: pcbnew/dialogs/dialog_create_array_base.cpp:260
 msgid "From start value"
-msgstr ""
+msgstr "Od wartości początkowej"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:121
 #: pcbnew/dialogs/dialog_create_array_base.cpp:262
-#, fuzzy
 msgid "Initial Pad Number:"
-msgstr "Numer pola:"
+msgstr "Początkowy numer pola:"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:125
 msgid "Continuous (1, 2, 3...)"
@@ -17127,9 +17195,8 @@ msgid "Coordinate (A1, A2, ... B1, ...)"
 msgstr "Według osi szyku (A1, A2, ... B1, ...)"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:127
-#, fuzzy
 msgid "Pad Numbering Scheme:"
-msgstr "Schemat numeracji"
+msgstr "Schemat numeracji pól:"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:131
 msgid "Primary axis numbering:"
@@ -17141,7 +17208,7 @@ msgstr "Schemat numeracji drugiej ośi:"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:156
 msgid "Pad numbering start:"
-msgstr ""
+msgstr "Rozpoczęcie numeracji pól od:"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:180
 msgid "Grid Array"
@@ -17205,13 +17272,12 @@ msgstr ""
 "Obróć element i przesuń - elementy z wyboru wielokrotnego będą obracane razem"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:258
-#, fuzzy
 msgid "Pad Numbering Options:"
-msgstr "Opcje wtyczki:"
+msgstr "Opcje numeracji pól:"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:269
 msgid "Pad numbering start value:"
-msgstr ""
+msgstr "Wartość początkowa numeracji pól:"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:286
 msgid "Circular Array"
@@ -17249,6 +17315,8 @@ msgstr "Domyślna klasa połączeń nie może zostać usunięta"
 #, c-format
 msgid " - <b>Track Size</b> (%f %s) &lt; <b>Min Track Size</b> (%f %s)<br>"
 msgstr ""
+" - <b>Szerokośc ścieżki</b> (%f %s) &lt; <b>Min szerokość ścieżki</b> (%f "
+"%s)<br>"
 
 #: pcbnew/dialogs/dialog_design_rules.cpp:1039
 #, c-format
@@ -17256,22 +17324,28 @@ msgid ""
 " - <b>Differential Pair Size</b> (%f %s) &lt; <b>Min Track Size</b> (%f "
 "%s)<br>"
 msgstr ""
+" - <b>Szerokość ścieżek pary różnicowej</b> (%f %s) &lt; <b>Min szerokość "
+"ścieżki</b> (%f %s)<br>"
 
 #: pcbnew/dialogs/dialog_design_rules.cpp:1053
 #, c-format
 msgid ""
 " - <b>Via Diameter</b> (%f %s) &lt; <b>Minimum Via Diameter</b> (%f %s)<br>"
 msgstr ""
+" - <b>Rozmiar przelotki</b> (%f %s) &lt; <b>Min rozmiar przelotki</b> (%f "
+"%s)<br>"
 
 #: pcbnew/dialogs/dialog_design_rules.cpp:1065
 #, c-format
 msgid " - <b>Via Drill</b> (%f %s) &ge; <b>Via Dia</b> (%f %s)<br>"
 msgstr ""
+" - <b>Otwór przelotki</b> (%f %s) &ge; <b>Rozmiar przelotki</b> (%f %s)<br>"
 
 #: pcbnew/dialogs/dialog_design_rules.cpp:1074
 #, c-format
 msgid " - <b>Via Drill</b> (%f %s) &lt; <b>Min Via Drill</b> (%f %s)<br>"
 msgstr ""
+" - <b>Otwór przelotki</b> (%f %s) &lt; <b>Min otwór przelotki</b> (%f %s)<br>"
 
 #: pcbnew/dialogs/dialog_design_rules.cpp:1087
 #, c-format
@@ -17279,22 +17353,28 @@ msgid ""
 " - <b>MicroVia Diameter</b> (%f %s) &lt; <b>MicroVia Min Diameter</b> (%f "
 "%s)<br>"
 msgstr ""
+" - <b>Rozmiar mikroprzelotki</b> (%f %s) &lt; <b>Min rozmiar mikroprzelotki</"
+"b> (%f %s)<br>"
 
 #: pcbnew/dialogs/dialog_design_rules.cpp:1099
 #, c-format
 msgid " - <b>MicroVia Drill</b> (%f %s) &ge; <b>MicroVia Dia</b> (%f %s)<br>"
 msgstr ""
+" - <b>Otwór mikroprzelotki</b> (%f %s) &ge; <b>Rozmiar mikroprzelotki</b> "
+"(%f %s)<br>"
 
 #: pcbnew/dialogs/dialog_design_rules.cpp:1108
 #, c-format
 msgid ""
 " - <b>MicroVia Drill</b> (%f %s) &lt; <b>MicroVia Min Drill</b> (%f %s)<br>"
 msgstr ""
+" - <b>Otwór mikroprzelotki</b> (%f %s) &lt; <b>Min otwór mikroprzelotki</b> "
+"(%f %s)<br>"
 
 #: pcbnew/dialogs/dialog_design_rules.cpp:1117
 #, c-format
 msgid "Netclass: <b>%s</b><br>"
-msgstr "Klasy sieci: <b>%s</b><br>"
+msgstr "Klasa sieci: <b>%s</b><br>"
 
 #: pcbnew/dialogs/dialog_design_rules.cpp:1137
 #, c-format
@@ -17340,7 +17420,7 @@ msgstr "<b>Rozmiar %d dodatkowej przelotki </b>%s &gt; <b>1 cal!</b><br>"
 
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:27
 msgid "Net Classes:"
-msgstr "Klasy połączeń:"
+msgstr "Klasy sieci:"
 
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:48
 msgid "Clearance"
@@ -17356,20 +17436,20 @@ msgstr "Otwór przelotki"
 
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:52
 msgid "uVia Dia"
-msgstr "Średnica mikroprzelotki"
+msgstr "Średnica uVia"
 
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:53
 #: pcbnew/dialogs/dialog_global_edit_tracks_and_vias_base.cpp:90
 msgid "uVia Drill"
-msgstr "Otwór mikroprzelotki"
+msgstr "Otwór uVia"
 
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:54
 msgid "Diff Pair Width"
-msgstr "Szerokość par różnicowych"
+msgstr "Szerokość pary różnicowej"
 
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:55
 msgid "Diff Pair Gap"
-msgstr "Prześwit par różnicowych"
+msgstr "Odległość pary różnicowej"
 
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:68
 msgid "Net Class parameters"
@@ -17392,9 +17472,8 @@ msgid "Move the currently selected Net Class up one row"
 msgstr "Przesuń zaznaczoną klasę sieci o jedną pozycję w górę"
 
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:97
-#, fuzzy
 msgid "Net Class Membership:"
-msgstr "Sieci klas połączeń"
+msgstr "Przynależność do klas sieci:"
 
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:112
 msgid "Select all nets in the left list"
@@ -17421,25 +17500,21 @@ msgid "Net Classes Editor"
 msgstr "Edytor klas połączeń"
 
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:183
-#, fuzzy
 msgid "Routing Options:"
-msgstr "Opcje trasowania"
+msgstr "Opcje trasowania:"
 
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:191
 #: pcbnew/dialogs/dialog_drc_base.cpp:60
-#, fuzzy
 msgid "Minimum track width:"
-msgstr "Minimalna szerokość ścieżki"
+msgstr "Miminalna szerokość ścieżki:"
 
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:202
-#, fuzzy
 msgid "Minimum via diameter:"
-msgstr "Minimalna średnica przelotki"
+msgstr "Minimalny rozmiar przelotki:"
 
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:213
-#, fuzzy
 msgid "Minimum via drill:"
-msgstr "Minimalny otwór przelotki"
+msgstr "Minimalny rozmiar otworu przelotki:"
 
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:227
 msgid "Allow blind/buried vias"
@@ -17447,17 +17522,15 @@ msgstr "Ślepe/zagrzebane przelotki dozwolone"
 
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:236
 msgid "Allow micro vias (uVias)"
-msgstr "Zezwalaj na mikro przelotki"
+msgstr "Zezwalaj na mikroprzelotki (uVia)"
 
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:242
-#, fuzzy
 msgid "Minimum uVia diameter:"
-msgstr "Minimalna średnica mikroprzelotki"
+msgstr "Minimalny rozmiar mikroprzelotki:"
 
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:255
-#, fuzzy
 msgid "Minimum uVia drill:"
-msgstr "Minimalny otwórz mikroprzelotki"
+msgstr "Minimalny rozmiar otworu mikroprzelotki:"
 
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:277
 msgid ""
@@ -17465,9 +17538,9 @@ msgid ""
 "default Netclass values on demand,\n"
 "for arbitrary vias or track segments."
 msgstr ""
-"Specyficzne rozmiary przelotek i szerokości ścieżek, które mogą być użyte do "
-"zastąpienia domyślnych wartości klas połączeń na żądanie,\n"
-"dla dowolnych przelotek lub segmentów ścieżek."
+"Określa rozmiar przelotek oraz szerokość ścieżek, które mogą zostać użyte "
+"przy zamianie domyślnych\n"
+"wartości z klas sieci, dla poszczególnych przelotek lub ścieżek."
 
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:285
 msgid "Custom Via Sizes:"
@@ -17527,7 +17600,7 @@ msgstr "Przelotka 12"
 
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:335
 msgid "Custom Track Widths:"
-msgstr "Własna szerkość ścieżek:"
+msgstr "Własne szerokości ścieżek:"
 
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:360
 msgid "Track 1"
@@ -17586,23 +17659,20 @@ msgid "Design Rules Editor"
 msgstr "Edytor reguł projektowych"
 
 #: pcbnew/dialogs/dialog_dimension_editor_base.cpp:58
-#, fuzzy
 msgid "Text position X:"
-msgstr "Pozycja tekstu X"
+msgstr "Pozycja X tekstu:"
 
 #: pcbnew/dialogs/dialog_dimension_editor_base.cpp:65
-#, fuzzy
 msgid "Text position Y:"
-msgstr "Pozycja tekstu Y"
+msgstr "Pozycja Y tekstu:"
 
 #: pcbnew/dialogs/dialog_dimension_editor_base.h:69
 msgid "Dimension Properties"
 msgstr "Właściwości wymiarowań"
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:31
-#, fuzzy
 msgid "Annotations:"
-msgstr "Adnotacje"
+msgstr "Numeracje:"
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:33
 msgid "Do not show"
@@ -17626,20 +17696,19 @@ msgstr "Pokaż nazwy sieci:"
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:37
 msgid "Show or hide net names on pads and/or tracks."
-msgstr ""
+msgstr "Pokaż lub ukryj nazwy sieci na polach lutowniczych i/lub ścieżkach."
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:41
 msgid "Show pad numbers"
-msgstr "Pokaż numery pól lutowniczych"
+msgstr "Pokaż numery pola"
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:45
 msgid "Show pad no net connection indicator"
 msgstr "Pokaż znacznik dla pól niepołączonych"
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:53
-#, fuzzy
 msgid "Clearance Outlines:"
-msgstr "Zamknij obrys strefy"
+msgstr "Obrysy prześwitu:"
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:55
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:182
@@ -17674,6 +17743,9 @@ msgid ""
 "Show or hide the track and via clearance area. If \"New track\" is selected, "
 "track clearance area is shown only when creating the track."
 msgstr ""
+"Pokazuje lub ukrywa zarys prześwitu na ścieżkach i przelotkach. Jeśli "
+"wybrano \"Tylko nowa ścieżka\", prześwit jest pokazywany tylko podczas "
+"trasowania ścieżki."
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:63
 msgid "Show pad clearance"
@@ -17682,7 +17754,7 @@ msgstr "Pokaż prześwit pola lutowniczego"
 #: pcbnew/dialogs/dialog_drc.cpp:248 pcbnew/dialogs/dialog_drc.cpp:320
 #, c-format
 msgid "Report file \"%s\" created"
-msgstr "Utworzono plik raportu \"%s\""
+msgstr "Plik raportu \"%s\" został utworzony"
 
 #: pcbnew/dialogs/dialog_drc.cpp:250 pcbnew/dialogs/dialog_drc.cpp:321
 msgid "Disk File Report Completed"
@@ -17691,7 +17763,7 @@ msgstr "Zakończono raportowanie do pliku"
 #: pcbnew/dialogs/dialog_drc.cpp:255 pcbnew/dialogs/dialog_drc.cpp:326
 #, c-format
 msgid "Unable to create report file \"%s\""
-msgstr ""
+msgstr "Nie można utworzyć pliku raportu \"%s\""
 
 #: pcbnew/dialogs/dialog_drc.cpp:346
 msgid "Save DRC Report File"
@@ -17706,18 +17778,16 @@ msgid "Enter the minimum acceptable value for a track width"
 msgstr "Wpisz dozwolony minimalny rozmiar ścieżki"
 
 #: pcbnew/dialogs/dialog_drc_base.cpp:75
-#, fuzzy
 msgid "Minimum via size:"
-msgstr "Minimalny rozmiar przelotki"
+msgstr "Minimalny rozmiar przelotki:"
 
 #: pcbnew/dialogs/dialog_drc_base.cpp:77 pcbnew/dialogs/dialog_drc_base.cpp:86
 msgid "Enter the minimum acceptable diameter for a standard via"
 msgstr "Wpisz dozwolony minimalny rozmiar przelotki"
 
 #: pcbnew/dialogs/dialog_drc_base.cpp:90
-#, fuzzy
 msgid "Minimum uVia size:"
-msgstr "Minimalny rozmiar mikroprzelotki"
+msgstr "Minimalny rozmiar mikroprzelotki:"
 
 #: pcbnew/dialogs/dialog_drc_base.cpp:92 pcbnew/dialogs/dialog_drc_base.cpp:101
 msgid "Enter the minimum acceptable diameter for a micro via"
@@ -17725,11 +17795,11 @@ msgstr "Wpisz dozwolony minimalny rozmiar mikroprzelotki"
 
 #: pcbnew/dialogs/dialog_drc_base.cpp:108
 msgid "Refill all zones before performing DRC"
-msgstr "Wypełnij wszystkie strefy przed uruchomieniem DRC"
+msgstr "Wypełnij wszystkie strefy przed przeprowadzeniem kontroli DRC"
 
 #: pcbnew/dialogs/dialog_drc_base.cpp:111
 msgid "Report all errors for tracks (slower)"
-msgstr ""
+msgstr "Raportuj wszystkie błędy ścieżek (wolne)"
 
 #: pcbnew/dialogs/dialog_drc_base.cpp:112
 msgid ""
@@ -17739,19 +17809,23 @@ msgid ""
 "If unselected, only the first DRC violation will be reported for each track "
 "connection."
 msgstr ""
+"Jeśli zaznaczone, raportowane będą wszystkie naruszenia DRC dla ścieżek.  Ta "
+"procedura będzie wolna przy skomplikowanych projektach.\n"
+"\n"
+"Jeśli niezaznaczone, raportowane będzie tylko pierwsze naruszenie DRC dla "
+"poszczególnych połączeń."
 
 #: pcbnew/dialogs/dialog_drc_base.cpp:116
 msgid "Check footprint courtyard overlap"
-msgstr ""
+msgstr "Sprawdza czy pola zajętości footprintu nie nachodzą na siebie"
 
 #: pcbnew/dialogs/dialog_drc_base.cpp:119
 msgid "Check courtyard missing in footprints"
-msgstr ""
+msgstr "Sprawdza czy footprinty posiadają określone pole zajętości"
 
 #: pcbnew/dialogs/dialog_drc_base.cpp:131
-#, fuzzy
 msgid "Create Report File:"
-msgstr "Utwórz plik raportu"
+msgstr "Utwórz plik raportu:"
 
 #: pcbnew/dialogs/dialog_drc_base.cpp:150
 msgid "Enable writing report to this file"
@@ -17799,18 +17873,18 @@ msgstr "Błędy:"
 
 #: pcbnew/dialogs/dialog_drc_base.cpp:223
 msgid "Marker count:"
-msgstr ""
+msgstr "Ilość markerów:"
 
 #: pcbnew/dialogs/dialog_drc_base.cpp:234
 msgid "Unconnected count:"
-msgstr ""
+msgstr "Ilość niepołączonych:"
 
 #: pcbnew/dialogs/dialog_drc_base.cpp:251
 msgid ""
 "MARKERs, double click any to go there in PCB, right click for popup menu"
 msgstr ""
 "ZNACZNIKI na płytce. Kliknij dwukrotnie na dowolnym ZNACZNIKU, aby do niego "
-"przejść. Prawy przycisk myszy dla menu podręcznego."
+"przejść. Prawy przycisk myszy dla menu podręcznego"
 
 #: pcbnew/dialogs/dialog_drc_base.cpp:260
 msgid "Problems / Markers"
@@ -17819,7 +17893,7 @@ msgstr "Problemy / Znaczniki"
 #: pcbnew/dialogs/dialog_drc_base.cpp:266
 msgid "A list of unconnected pads, right click for popup menu"
 msgstr ""
-"Lista niepołączonych pól. Prawy przycisk myszy uruchamia menu podręczne."
+"Lista niepołączonych pól. Prawy przycisk myszy uruchamia menu podręczne"
 
 #: pcbnew/dialogs/dialog_drc_base.cpp:274
 msgid "Unconnected"
@@ -17834,6 +17908,8 @@ msgid ""
 "Use this attribute for most non SMD footprints\n"
 "Footprints with this option are not put in the footprint position list file"
 msgstr ""
+"Użyj tego atrybutu dla większości elementów nie będących typu SMD\n"
+"Footprinty z tą opcją nie są umieszczane w pliku z listą położeń footprintów"
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_BoardEditor.cpp:348
 #: pcbnew/dialogs/dialog_edit_footprint_for_fp_editor.cpp:193
@@ -17841,12 +17917,17 @@ msgid ""
 "Use this attribute for SMD footprints.\n"
 "Only footprints with this option are put in the footprint position list file"
 msgstr ""
+"Użyj tego atrybutu dla większości elementów typu SMD\n"
+"Footprinty z tą opcją są umieszczane w pliku z listą położeń footprintów"
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_BoardEditor.cpp:351
 msgid ""
 "Use this attribute for \"virtual\" footprints drawn on board\n"
 "such as an edge connector (old ISA PC bus for instance)"
 msgstr ""
+"Użyj tego atrybutu dla elementów wirtualnych, które są integralną częścią "
+"obwodu drukowanego,\n"
+"na przykład złącze krawędziowe, punkt testowy, otwór mechaniczny."
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_BoardEditor.cpp:382
 msgid ""
@@ -17873,38 +17954,38 @@ msgstr ""
 #: pcbnew/dialogs/dialog_edit_footprint_for_BoardEditor.cpp:513
 #: pcbnew/dialogs/dialog_edit_footprint_for_fp_editor.cpp:386
 msgid "Invalid filename: "
-msgstr "Błędna nazwa pliku:"
+msgstr "Nieprawidłowa nazwa pliku: "
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_BoardEditor.cpp:515
 #: pcbnew/dialogs/dialog_edit_footprint_for_fp_editor.cpp:388
 msgid "Edit 3D file name"
-msgstr "Edycja nazwy pliku 3D"
+msgstr "Edycja nazwy pliku modelu 3D"
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_BoardEditor.cpp:613
 msgid "Error: invalid footprint parameter"
-msgstr ""
+msgstr "Błąd: niepoprawny parametr footprintu"
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_BoardEditor.cpp:619
 msgid "Error: invalid 3D parameter"
-msgstr ""
+msgstr "Błąd: niepoprawny parametr 3D"
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_BoardEditor.cpp:639
 msgid "Error: invalid or missing footprint parameter"
-msgstr ""
+msgstr "Błąd: niepoprawny lub nieistniejący parametr footprintu"
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_BoardEditor.cpp:645
 msgid "Error: invalid or missing 3D parameter"
-msgstr ""
+msgstr "Błąd: niepoprawny lub nieistniejący paramter 3D"
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_BoardEditor.cpp:654
 #: pcbnew/dialogs/dialog_edit_footprint_for_fp_editor.cpp:505
 msgid "Error: footprint local net clearance is < 0"
-msgstr ""
+msgstr "Błąd: lokalny prześwit dla sieci jest mniejszy od zera"
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_BoardEditor.cpp:777
 #: pcbnew/dialogs/dialog_edit_footprint_for_fp_editor.cpp:597
 msgid "Modify module properties"
-msgstr ""
+msgstr "Modyfikuj właściwości footprintu"
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_BoardEditor_base.cpp:28
 #: pcbnew/dialogs/dialog_edit_footprint_for_fp_editor_base.cpp:28
@@ -17920,9 +18001,8 @@ msgid "Back"
 msgstr "Dolna"
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_BoardEditor_base.cpp:65
-#, fuzzy
 msgid "Board Side:"
-msgstr "Strona płytki"
+msgstr "Strona płytki:"
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_BoardEditor_base.cpp:69
 #: pcbnew/dialogs/dialog_edit_footprint_text_base.cpp:119
@@ -17968,7 +18048,7 @@ msgstr ""
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_BoardEditor_base.cpp:142
 msgid "Update Footprint from Library"
-msgstr "Aktualizacja footprintów z biblioteki"
+msgstr "Uaktualnij footprint z biblioteki"
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_BoardEditor_base.cpp:148
 msgid "Change Footprint"
@@ -17982,18 +18062,17 @@ msgstr "Edytor Footprintów"
 #: pcbnew/dialogs/dialog_edit_footprint_for_BoardEditor_base.cpp:160
 #: pcbnew/dialogs/dialog_edit_footprint_for_fp_editor_base.cpp:105
 msgid "Through hole"
-msgstr "Otwór przelotowy"
+msgstr "Do montażu przewlekanego (THT)"
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_BoardEditor_base.cpp:160
 #: pcbnew/dialogs/dialog_edit_footprint_for_fp_editor_base.cpp:105
 msgid "Surface mount"
-msgstr ""
+msgstr "Do montażu powierzchniowego (SMT)"
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_BoardEditor_base.cpp:162
 #: pcbnew/dialogs/dialog_edit_footprint_for_fp_editor_base.cpp:107
-#, fuzzy
 msgid "Placement Type:"
-msgstr "Ścieżka typu:"
+msgstr "Tryb układania:"
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_BoardEditor_base.cpp:166
 #: pcbnew/dialogs/dialog_edit_footprint_for_fp_editor_base.cpp:111
@@ -18010,31 +18089,28 @@ msgstr "Zablokuj footprint"
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_BoardEditor_base.cpp:168
 #: pcbnew/dialogs/dialog_edit_footprint_for_fp_editor_base.cpp:113
-#, fuzzy
 msgid "Move and Place:"
-msgstr "Przesuwanie i rozmieszczanie"
+msgstr "Przesuwanie i rozmieszczanie:"
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_BoardEditor_base.cpp:176
 #: pcbnew/dialogs/dialog_edit_footprint_for_fp_editor_base.cpp:121
-#, fuzzy
 msgid "Auto Place:"
-msgstr "Automatyczne rozmieszczanie"
+msgstr "Automatyczne rozmieszczanie:"
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_BoardEditor_base.cpp:181
 #: pcbnew/dialogs/dialog_edit_footprint_for_fp_editor_base.cpp:126
 msgid "Allow 90 degree rotation:"
-msgstr ""
+msgstr "Zezwól na obrót o 90 stopni:"
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_BoardEditor_base.cpp:194
 #: pcbnew/dialogs/dialog_edit_footprint_for_fp_editor_base.cpp:139
 msgid "Allow 180 degree rotation:"
-msgstr ""
+msgstr "Zezwól na obrót o 180 stopni:"
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_BoardEditor_base.cpp:208
 #: pcbnew/dialogs/dialog_edit_footprint_for_fp_editor_base.cpp:153
-#, fuzzy
 msgid "Local Settings:"
-msgstr "Właściwości lokalne"
+msgstr "Właściwości lokalne:"
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_BoardEditor_base.cpp:216
 #: pcbnew/dialogs/dialog_edit_footprint_for_fp_editor_base.cpp:160
@@ -18048,21 +18124,24 @@ msgstr "Użyj ustawień ze stref"
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_BoardEditor_base.cpp:232
 #: pcbnew/dialogs/dialog_edit_footprint_for_fp_editor_base.cpp:176
-#, fuzzy
 msgid "Set clearances to 0 to use netclass values."
-msgstr "Ustaw wartość 0 by użyć globalnych ustawień"
+msgstr "Ustaw prześwit na 0 by użyć ustawień z klas połączeń."
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_BoardEditor_base.cpp:238
 #: pcbnew/dialogs/dialog_edit_footprint_for_fp_editor_base.cpp:182
 msgid ""
 "Positive clearance means area bigger than the pad (usual for solder mask)."
 msgstr ""
+"Dodatnia wartość prześwitu oznacza większą niż pole lutownicze (zwykle dla "
+"prześwitu soldermaski)."
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_BoardEditor_base.cpp:244
 #: pcbnew/dialogs/dialog_edit_footprint_for_fp_editor_base.cpp:188
 msgid ""
 "Negative clearance means area smaller than the pad (usual for solder paste)."
 msgstr ""
+"Ujemna wartość prześwitu oznacza mniejszą niż pole lutownicze (zwykle dla "
+"prześwitu pasty)."
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_BoardEditor_base.cpp:253
 #: pcbnew/dialogs/dialog_edit_footprint_for_fp_editor_base.cpp:197
@@ -18102,7 +18181,7 @@ msgstr ""
 "dla danego footprintu.\n"
 "Jeśli wartość wynosi 0, używana jest wartość globalna.\n"
 "Wartość ta może zostać zastąpiona przez lokalne ustawienia dla pól "
-"lutowniczych."
+"lutowniczych"
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_BoardEditor_base.cpp:281
 #: pcbnew/dialogs/dialog_edit_footprint_for_fp_editor_base.cpp:225
@@ -18128,7 +18207,7 @@ msgstr ""
 "lutowniczych.\n"
 "Ostateczny rozmiar prześwitu jest sumą tej wartości i stosunku pomiędzy "
 "prześwitami.\n"
-"Wartość ujemna oznacza mniejszy rozmiar maski niż rozmiar pola lutowniczego."
+"Wartość ujemna oznacza mniejszy rozmiar maski niż rozmiar pola lutowniczego"
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_BoardEditor_base.cpp:294
 #: pcbnew/dialogs/dialog_edit_footprint_for_fp_editor_base.cpp:238
@@ -18165,11 +18244,12 @@ msgstr ""
 msgid ""
 "Note: solder mask and paste values are used only for pads on copper layers."
 msgstr ""
+"Pamiętaj: wartości soldermaski oraz pasty są używane tylko dla pól "
+"lutowniczych na warstwach miedzi."
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_BoardEditor_base.cpp:333
-#, fuzzy
 msgid "3D Shape Name:"
-msgstr "Nazwa obiektu 3D"
+msgstr "Nazwa obiektu 3D:"
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_BoardEditor_base.cpp:353
 #: pcbnew/dialogs/dialog_edit_footprint_for_fp_editor_base.cpp:298
@@ -18199,12 +18279,17 @@ msgstr "Właściwości footprintu"
 #: pcbnew/dialogs/dialog_edit_footprint_for_fp_editor.cpp:191
 msgid "Use this attribute for most non SMD footprints"
 msgstr ""
+"Użyj tego atrybutu dla większości footprintów nie przeznaczonych pod "
+"elementy typu SMD"
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_fp_editor.cpp:196
 msgid ""
 "Use this attribute for \"virtual\" footprints drawn on board\n"
 "like an edge connector (old ISA PC bus for instance)"
 msgstr ""
+"Użyj tego atrybutu dla footprintów elementów wirtualnych, które są "
+"integralną częścią obwodu drukowanego,\n"
+"na przykład złącze krawędziowe, punkt testowy, otwór mechaniczny."
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_fp_editor.cpp:220
 msgid "Enable hotkey move commands and Auto Placement"
@@ -18215,14 +18300,12 @@ msgid "Disable hotkey move commands and Auto Placement"
 msgstr "Wyłącz przesuwanie i autorozmieszczanie klawiszami skrótów"
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_fp_editor.cpp:371
-#, fuzzy
 msgid "Filepath:"
-msgstr "Plik:"
+msgstr "Ścieżka pliku:"
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_fp_editor.cpp:371
-#, fuzzy
 msgid "Edit 3D Shape Name"
-msgstr "Nazwa obiektu 3D"
+msgstr "Edytuj nazwę obiektu 3D"
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_fp_editor.cpp:489
 #, c-format
@@ -18231,21 +18314,21 @@ msgid ""
 "one of invalid chars \"%s\" found\n"
 "in \"%s\""
 msgstr ""
+"Błąd:\n"
+"znaleziono jeden z niedopuszczalnych znaków \"%s\"\n"
+"w \"%s\""
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_fp_editor_base.cpp:63
-#, fuzzy
 msgid "Document link:"
-msgstr "Link dokumentacji"
+msgstr "Łącze do dokumentacji:"
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_fp_editor_base.cpp:80
-#, fuzzy
 msgid "Footprint name in library:"
-msgstr "Nazwa footprintu w bibliotece"
+msgstr "Nazwa footprintu w bibliotece:"
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_fp_editor_base.cpp:87
-#, fuzzy
 msgid "Library nickname:"
-msgstr "Pliki bibliotek:"
+msgstr "Skrócona nazwa biblioteki:"
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_fp_editor_base.cpp:111
 #: pcbnew/dialogs/dialog_track_via_properties_base.cpp:31
@@ -18253,9 +18336,8 @@ msgid "Locked"
 msgstr "Zablokowany"
 
 #: pcbnew/dialogs/dialog_edit_footprint_for_fp_editor_base.cpp:278
-#, fuzzy
 msgid "3D Shape Names:"
-msgstr "Nazwy kształtów 3D"
+msgstr "Nazwy kształtów 3D:"
 
 #: pcbnew/dialogs/dialog_edit_footprint_text.cpp:204
 msgid ""
@@ -18263,7 +18345,7 @@ msgid ""
 "Now, forced on the front silk screen layer. Please, fix it"
 msgstr ""
 "Ten element posiada niepoprawny identyfikator warstwy.\n"
-"Obecnie został przeniesiony na górną warstwę opisową. Proszę to poprawić."
+"Obecnie został przeniesiony na górną warstwę opisową. Proszę to poprawić"
 
 #: pcbnew/dialogs/dialog_edit_footprint_text.cpp:266
 #: pcbnew/dialogs/dialog_pcb_text_properties.cpp:308
@@ -18274,7 +18356,7 @@ msgstr ""
 
 #: pcbnew/dialogs/dialog_edit_footprint_text.cpp:348
 msgid "Modify module text"
-msgstr ""
+msgstr "Modyfikuj tekst footprintu"
 
 #: pcbnew/dialogs/dialog_edit_footprint_text_base.cpp:25
 #, c-format
@@ -18291,17 +18373,19 @@ msgstr "Przesunięcie Y:"
 
 #: pcbnew/dialogs/dialog_edit_footprint_text_base.cpp:125
 msgid "Rotation (-180.0 to 180.0)"
-msgstr "Obrót (-180.0 do 180.0)"
+msgstr "Obrót (-180.0 do 180)"
 
 #: pcbnew/dialogs/dialog_edit_footprint_text_base.cpp:132
 msgid "Unlock text orientation"
-msgstr "Odblokuj orientację teksu"
+msgstr "Odblokuj orientację tekstu"
 
 #: pcbnew/dialogs/dialog_edit_footprint_text_base.cpp:133
 msgid ""
 "If orientation is locked, the text will always face near the bottom or right "
 "edge of the board."
 msgstr ""
+"Jeśli orientacja jest zablokowana, tekst jest zawsze umieszczany blisko "
+"dolnej lub prawej krawędzi płytki."
 
 #: pcbnew/dialogs/dialog_edit_footprint_text_base.h:78
 msgid "Footprint Text Properties"
@@ -18321,11 +18405,11 @@ msgstr "Pierwszy numer pola:"
 
 #: pcbnew/dialogs/dialog_enum_pads_base.h:51
 msgid "Pad Enumeration Settings"
-msgstr ""
+msgstr "Ustawienia numeracji pól lutowniczych"
 
 #: pcbnew/dialogs/dialog_exchange_footprints.cpp:96
 msgid "Update Footprints from Library"
-msgstr "Aktualizacja footprintów z biblioteki"
+msgstr "Uaktualnij footprinty z biblioteki"
 
 #: pcbnew/dialogs/dialog_exchange_footprints.cpp:96
 msgid "Change Footprints"
@@ -18339,21 +18423,21 @@ msgstr "Uaktualniona"
 #: pcbnew/dialogs/dialog_exchange_footprints.cpp:345
 #, c-format
 msgid "File \"%s\" created\n"
-msgstr "Plik \"%s\" został utworzony\n"
+msgstr "Plik \"%s\" utworzony\n"
 
 #: pcbnew/dialogs/dialog_exchange_footprints.cpp:350
 #, c-format
 msgid "** Could not create file \"%s\" ***\n"
-msgstr "** Nie mogę utworzyć pliku \"%s\" ***\n"
+msgstr "** Nie można utworzyć pliku \"%s\" ***\n"
 
 #: pcbnew/dialogs/dialog_exchange_footprints.cpp:434
 #, c-format
 msgid "Change footprint \"%s\" (from \"%s\") to \"%s\""
-msgstr ""
+msgstr "Zmiana footprintu \"%s\" (z \"%s\") na \"%s\""
 
 #: pcbnew/dialogs/dialog_exchange_footprints.cpp:443
 msgid "footprint not found"
-msgstr "Nie znaleziono footprintu"
+msgstr "footprintu nie znaleziono"
 
 #: pcbnew/dialogs/dialog_exchange_footprints.cpp:534
 msgid "No footprints!"
@@ -18366,12 +18450,12 @@ msgstr "Zapisz plik z przypisaniami footprintów do komponentów"
 #: pcbnew/dialogs/dialog_exchange_footprints.cpp:556
 #, c-format
 msgid "Could not create file \"%s\""
-msgstr "Nie mogę utworzyć pliku \"%s\""
+msgstr "Nie można było utworzyć pliku \"%s\""
 
 #: pcbnew/dialogs/dialog_exchange_footprints_base.cpp:24
 #, c-format
 msgid "%s all footprints on board"
-msgstr "%s wszystkie footprinty na płytce"
+msgstr "%s wszystkich footprintów na płytce"
 
 #: pcbnew/dialogs/dialog_exchange_footprints_base.cpp:27
 #, c-format
@@ -18381,30 +18465,30 @@ msgstr "%s bieżący footprint (%s)"
 #: pcbnew/dialogs/dialog_exchange_footprints_base.cpp:30
 #, c-format
 msgid "%s footprint with reference:"
-msgstr ""
+msgstr "%s footprintów z odnośnikiem:"
 
 #: pcbnew/dialogs/dialog_exchange_footprints_base.cpp:36
 #, c-format
 msgid "%s footprints with matching value (%s)"
-msgstr ""
+msgstr "%s footprintów z pasującą wartością (%s)"
 
 #: pcbnew/dialogs/dialog_exchange_footprints_base.cpp:39
 #, c-format
 msgid "%s footprints with value:"
-msgstr ""
+msgstr "%s footprintów z wartością:"
 
 #: pcbnew/dialogs/dialog_exchange_footprints_base.cpp:45
 #, c-format
 msgid "%s footprints with identifier:"
-msgstr ""
+msgstr "%s footprintów z identyfikatorem:"
 
 #: pcbnew/dialogs/dialog_exchange_footprints_base.cpp:77
 msgid "New footprint identifier:"
-msgstr ""
+msgstr "Nowy identyfikator footprintu:"
 
 #: pcbnew/dialogs/dialog_exchange_footprints_base.cpp:113
 msgid "Export Footprint Associations"
-msgstr ""
+msgstr "Eksportuj plik z przypisaniami footprintów"
 
 #: pcbnew/dialogs/dialog_exchange_footprints_base.cpp:127
 msgid "Apply"
@@ -18418,7 +18502,7 @@ msgstr "%s"
 #: pcbnew/dialogs/dialog_export_idf.cpp:169
 #: pcbnew/dialogs/dialog_export_vrml.cpp:177
 msgid "Are you sure you want to overwrite the existing file?"
-msgstr ""
+msgstr "Jesteś pewien, że chcesz nadpisać istniejący plik?"
 
 #: pcbnew/dialogs/dialog_export_idf.cpp:223
 #: pcbnew/exporters/export_d356.cpp:376
@@ -18438,7 +18522,7 @@ msgstr "Wybierz nazwę pliku dla eksportu IDF"
 #: pcbnew/dialogs/dialog_export_idf_base.cpp:34
 #: pcbnew/dialogs/dialog_export_vrml_base.cpp:49
 msgid "Grid reference point:"
-msgstr ""
+msgstr "Punkt odniesienia siatki:"
 
 #: pcbnew/dialogs/dialog_export_idf_base.cpp:38
 msgid "Adjust automatically"
@@ -18456,12 +18540,12 @@ msgstr "Pozycja Y:"
 
 #: pcbnew/dialogs/dialog_export_idf_base.cpp:102
 msgid "Mils"
-msgstr "milsy"
+msgstr "Milsy"
 
 #: pcbnew/dialogs/dialog_export_idf_base.cpp:104
 #: pcbnew/dialogs/dialog_export_vrml_base.cpp:113
 msgid "Output Units:"
-msgstr "Jednostki"
+msgstr "Jednostki wyjściowe:"
 
 #: pcbnew/dialogs/dialog_export_idf_base.h:62
 msgid "Export IDFv3"
@@ -18470,66 +18554,66 @@ msgstr "Eksport IDFv3"
 #: pcbnew/dialogs/dialog_export_step.cpp:192
 msgid "STEP export failed!  Please save the PCB and try again"
 msgstr ""
+"Eksport STEP nie powiódł się! Proszę zapisać PCB oraz spróbować ponownie"
 
 #: pcbnew/dialogs/dialog_export_step.cpp:241
-#, fuzzy, c-format
+#, c-format
 msgid "File '%s' already exists. Do you want overwrite this file?"
-msgstr ""
-"Plik '%s' już istnieje.\n"
-"\n"
-"Czy chcesz go zastąpić?"
+msgstr "Plik '%s' już istnieje. Czy chcesz go zastąpić?"
 
 #: pcbnew/dialogs/dialog_export_step.cpp:244
 msgid "STEP Export"
 msgstr "Eksport STEP"
 
 #: pcbnew/dialogs/dialog_export_step.cpp:326
-#, fuzzy, c-format
+#, c-format
 msgid "Executing '%s'"
-msgstr "Spodziewano się '%s'"
+msgstr "Wykonuję '%s'"
 
 #: pcbnew/dialogs/dialog_export_step.cpp:351
 msgid ""
 "Unable to create STEP file.  Check that the board has a valid outline and "
 "models."
 msgstr ""
+"Nie można utworzyć pliku STEP. Sprawdź czy obwód drukowany posiada poprawny "
+"obrys oraz modele 3D."
 
 #: pcbnew/dialogs/dialog_export_step.cpp:356
 msgid "STEP file has been created, but there are warnings."
-msgstr ""
+msgstr "Plik STEP został utworzony, ale wystąpiły ostrzeżenia."
 
 #: pcbnew/dialogs/dialog_export_step.cpp:362
 msgid "STEP file has been created successfully."
-msgstr ""
+msgstr "Plik STEP został poprawnie utworzony."
 
 #: pcbnew/dialogs/dialog_export_step_base.cpp:26
 msgid "Select a STEP export filename"
-msgstr ""
+msgstr "Wybierz nazwę pliku eksportu STEP"
 
 #: pcbnew/dialogs/dialog_export_step_base.cpp:38
 msgid "Coordinate origin options:"
-msgstr ""
+msgstr "Opcje położenia punktu centralnego:"
 
 #: pcbnew/dialogs/dialog_export_step_base.cpp:44
 msgid "Drill and plot origin"
-msgstr ""
+msgstr "Punkt bazowy dla plików Gerber i wierceń"
 
 #: pcbnew/dialogs/dialog_export_step_base.cpp:47
 #: pcbnew/dialogs/dialog_move_exact_base.cpp:77
 msgid "Grid origin"
-msgstr ""
+msgstr "Punkt bazowy siatki"
 
 #: pcbnew/dialogs/dialog_export_step_base.cpp:50
 msgid "User defined origin"
-msgstr ""
+msgstr "Zdefiniowany przez użytkownika"
 
 #: pcbnew/dialogs/dialog_export_step_base.cpp:53
 msgid "Board center origin"
-msgstr ""
+msgstr "Punkt centralny w centrum płytki"
 
 #: pcbnew/dialogs/dialog_export_step_base.cpp:62
 msgid "User defined origin:"
-msgstr ""
+msgstr "Punkt bazowy użytkownika:"
 
 #: pcbnew/dialogs/dialog_export_step_base.cpp:131
 msgid "Other options:"
@@ -18537,11 +18621,11 @@ msgstr "Pozostałe opcje:"
 
 #: pcbnew/dialogs/dialog_export_step_base.cpp:145
 msgid "Ignore virtual components"
-msgstr "Ignoruj wirtualne komponenty"
+msgstr "Ignoruj komponenty wirtualne"
 
 #: pcbnew/dialogs/dialog_export_step_base.h:79
 msgid "Export STEP"
-msgstr "Eksport STEP"
+msgstr "Eksportuj w formacie STEP"
 
 #: pcbnew/dialogs/dialog_export_vrml_base.cpp:26
 msgid "Save VRML Board File"
@@ -18579,7 +18663,7 @@ msgstr "0.1 cala"
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:559
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:570
 msgid "Inch"
-msgstr "cale"
+msgstr "Cale"
 
 #: pcbnew/dialogs/dialog_export_vrml_base.cpp:126
 msgid "Copy 3D model files to 3D model path"
@@ -18605,12 +18689,12 @@ msgstr "Opcje eksportu VRML"
 #: pcbnew/dialogs/dialog_find.cpp:132
 #, c-format
 msgid "\"%s\" found"
-msgstr "\"%s\" znaleziono"
+msgstr "\"%s\" odlaleziono"
 
 #: pcbnew/dialogs/dialog_find.cpp:138
 #, c-format
 msgid "\"%s\" not found"
-msgstr "\"%s\" nie znaleziono"
+msgstr "\"%s\" nieodnaleziono"
 
 #: pcbnew/dialogs/dialog_find.cpp:169
 msgid "Marker found"
@@ -18634,19 +18718,19 @@ msgstr "Znajdź znacznik"
 
 #: pcbnew/dialogs/dialog_footprint_wizard_list.cpp:146
 msgid "All footprint generator scripts were loaded"
-msgstr ""
+msgstr "Wszystkie skrypty generatorów footprintów zostały załadowane"
 
 #: pcbnew/dialogs/dialog_footprint_wizard_list_base.cpp:65
 msgid "Available Footprint Generators"
-msgstr ""
+msgstr "Dostępne kreatory footprintów"
 
 #: pcbnew/dialogs/dialog_footprint_wizard_list_base.cpp:70
 msgid "Search paths:"
-msgstr "Ścieżki wyszukiwania:"
+msgstr "Ścieżki przeszukiwań:"
 
 #: pcbnew/dialogs/dialog_footprint_wizard_list_base.cpp:77
 msgid "Not loadable python scripts:"
-msgstr ""
+msgstr "Skrypty, których nie można wczytać:"
 
 #: pcbnew/dialogs/dialog_footprint_wizard_list_base.cpp:84
 msgid "Show Trace"
@@ -18654,7 +18738,7 @@ msgstr "Pokaż ścieżkę"
 
 #: pcbnew/dialogs/dialog_footprint_wizard_list_base.cpp:98
 msgid "Update Python Modules"
-msgstr ""
+msgstr "Uaktualnij moduły Python"
 
 #: pcbnew/dialogs/dialog_footprint_wizard_list_base.h:66
 msgid "Footprint Generators"
@@ -18662,7 +18746,7 @@ msgstr "Generatory Footprintów"
 
 #: pcbnew/dialogs/dialog_footprint_wizard_list_base.h:85
 msgid "Traceback of Python Script Errors"
-msgstr ""
+msgstr "Śledzenie błędów skryptów Python"
 
 #: pcbnew/dialogs/dialog_fp_lib_table.cpp:74
 msgid "All supported library formats|"
@@ -18674,7 +18758,7 @@ msgstr "Dodaje wpis o bibliotece PCB do tej tabeli"
 
 #: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:142
 msgid "Remove a PCB library from this library table"
-msgstr "Usuwa bibliotekę PCB z tej tabeli"
+msgstr "Usuwa bibliotekę PCB z tej tabeli bibliotek"
 
 #: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:156
 msgid "Options Editor"
@@ -18685,7 +18769,6 @@ msgid "Zoom into the options table for current row"
 msgstr "Wchodzi do opcji tableli dla bieżącego rzędu"
 
 #: pcbnew/dialogs/dialog_fp_lib_table_base.h:81
-#, fuzzy
 msgid "Footprint Libraries"
 msgstr "Biblioteki footprintów"
 
@@ -18700,7 +18783,7 @@ msgstr ""
 #: pcbnew/dialogs/dialog_fp_plugin_options.cpp:64
 #, c-format
 msgid "Options for Library \"%s\""
-msgstr "Opcje dla biblioteki \"%s\""
+msgstr "Opcje biblioteki \"%s\""
 
 #: pcbnew/dialogs/dialog_fp_plugin_options_base.cpp:23
 msgid "Plugin Options:"
@@ -18767,7 +18850,7 @@ msgstr "Błąd Pcbnew"
 #: pcbnew/dialogs/dialog_freeroute_exchange.cpp:199
 #: pcbnew/specctra_import_export/specctra_export.cpp:95
 msgid "Specctra DSN File"
-msgstr "Plik DSN Spectra "
+msgstr "Plik Specctra DSN"
 
 #: pcbnew/dialogs/dialog_freeroute_exchange_base.cpp:25
 msgid "Export/Import to/from FreeRoute:"
@@ -18823,7 +18906,7 @@ msgstr "Jednen plik na warstwę"
 
 #: pcbnew/dialogs/dialog_gen_footprint_position_file_base.cpp:75
 msgid "Single file for board"
-msgstr "Pojedynczy plik dla płytki"
+msgstr "Jednen plik na płytkę"
 
 #: pcbnew/dialogs/dialog_gen_footprint_position_file_base.cpp:77
 msgid "Files:"
@@ -18867,28 +18950,30 @@ msgstr "Generuj plik"
 
 #: pcbnew/dialogs/dialog_gen_footprint_position_file_base.h:64
 msgid "Generate Footprint Position Files"
-msgstr ""
+msgstr "Generowanie plików położeń footprintów"
 
 #: pcbnew/dialogs/dialog_gencad_export_options.cpp:39
 msgid "Export to GenCAD settings"
-msgstr "Ustawienia eksportu do GenCAD"
+msgstr "Eksportuj ustawienia do GenCAD"
 
 #: pcbnew/dialogs/dialog_gencad_export_options.cpp:124
 #, c-format
 msgid "File %s already exists. Overwrite?"
-msgstr "Plik %s istnieje. Nadpisać?"
+msgstr "Plik %s już istnieje. Nadpisać?"
 
 #: pcbnew/dialogs/dialog_gencad_export_options.cpp:134
 msgid "Flip bottom footprint padstacks"
-msgstr ""
+msgstr "Obróć dolny padstack footprintu"
 
 #: pcbnew/dialogs/dialog_gencad_export_options.cpp:135
 msgid "Generate unique pin names"
-msgstr ""
+msgstr "Generuj unikalne nazwy pinów"
 
 #: pcbnew/dialogs/dialog_gencad_export_options.cpp:136
 msgid "Generate a new shape for each footprint instance (do not reuse shapes)"
 msgstr ""
+"Utwórz nowy kształt dla każdego wystąpienia footprintu (nie używaj już "
+"użytych kształtów)"
 
 #: pcbnew/dialogs/dialog_gencad_export_options.cpp:137
 #: pcbnew/dialogs/dialog_plot_base.cpp:122
@@ -18897,7 +18982,7 @@ msgstr "Użyj osi pomocniczej jako puntu początkowego"
 
 #: pcbnew/dialogs/dialog_gencad_export_options.cpp:138
 msgid "Save the origin coordinates in the file"
-msgstr ""
+msgstr "Zapisz współrzędne początkowe w pliku"
 
 #: pcbnew/dialogs/dialog_gencad_export_options.cpp:152
 msgid "Save GenCAD Board File"
@@ -18906,12 +18991,12 @@ msgstr "Zapisz plik płytki GenCAD"
 #: pcbnew/dialogs/dialog_gendrill.cpp:139
 #: pcbnew/dialogs/dialog_gendrill.cpp:140
 msgid "Use Netclass values"
-msgstr "Użyj wartości z klas połączeń"
+msgstr "Użyj wartości z klas sieci"
 
 #: pcbnew/dialogs/dialog_gendrill.cpp:397
 #, c-format
 msgid "Could not write drill and/or map files to folder \"%s\"."
-msgstr ""
+msgstr "Nie można zapisać pliku owiertu/lub mapy owiertów w folderze \"%s\"."
 
 #: pcbnew/dialogs/dialog_gendrill.cpp:444
 msgid "Save Drill Report File"
@@ -18932,7 +19017,7 @@ msgstr "Plik raportu %s został utworzony\n"
 
 #: pcbnew/dialogs/dialog_gendrill_base.cpp:22
 msgid "Output Directory:"
-msgstr ""
+msgstr "Folder wyjściowy:"
 
 #: pcbnew/dialogs/dialog_gendrill_base.cpp:43
 msgid "Excellon"
@@ -18967,18 +19052,16 @@ msgid "Keep zeros"
 msgstr "Zachowaj zera"
 
 #: pcbnew/dialogs/dialog_gendrill_base.cpp:57
-#, fuzzy
 msgid "Zeros Format:"
-msgstr "Format zer"
+msgstr "Format zer:"
 
 #: pcbnew/dialogs/dialog_gendrill_base.cpp:59
 msgid "Choose EXCELLON numbers notation"
 msgstr "Wybierz format liczb EXCELLON"
 
 #: pcbnew/dialogs/dialog_gendrill_base.cpp:69
-#, fuzzy
 msgid "Precision:"
-msgstr "Precyzja"
+msgstr "Precyzja:"
 
 #: pcbnew/dialogs/dialog_gendrill_base.cpp:73
 msgid "Precision"
@@ -18986,7 +19069,7 @@ msgstr "Precyzja"
 
 #: pcbnew/dialogs/dialog_gendrill_base.cpp:86
 msgid "PostScript"
-msgstr "Postscript"
+msgstr "PostScript"
 
 #: pcbnew/dialogs/dialog_gendrill_base.cpp:86
 #: pcbnew/dialogs/dialog_plot_base.cpp:30
@@ -19003,7 +19086,7 @@ msgstr "Tworzy mapę wierceń w formacie PS, HPGL lub innym"
 
 #: pcbnew/dialogs/dialog_gendrill_base.cpp:95
 msgid "Excellon Drill File Options:"
-msgstr ""
+msgstr "Opcje pliku Excellon z owiertem:"
 
 #: pcbnew/dialogs/dialog_gendrill_base.cpp:97
 msgid "Mirror Y axis"
@@ -19014,6 +19097,8 @@ msgid ""
 "Not recommended.\n"
 "Used mostly by users who make the boards themselves."
 msgstr ""
+"Opcja nie zalecana.\n"
+"Używana często przez użytkowników samodzielnie tworzących płytki."
 
 #: pcbnew/dialogs/dialog_gendrill_base.cpp:102
 msgid "Minimal header"
@@ -19024,10 +19109,13 @@ msgid ""
 "Not recommended.\n"
 "Only use it for board houses which do not accept fully featured headers."
 msgstr ""
+"Nie zalecane.\n"
+"Używaj wyłącznie przy współpracy z producentem, który akceptuje pełne "
+"informacje nagłówkowe."
 
 #: pcbnew/dialogs/dialog_gendrill_base.cpp:107
 msgid "PTH and NPTH holes in single file"
-msgstr ""
+msgstr "Połącz otwory PTH i NPTH w jednym pliku"
 
 #: pcbnew/dialogs/dialog_gendrill_base.cpp:108
 msgid ""
@@ -19035,6 +19123,9 @@ msgid ""
 "Only use for board houses which ask for merged PTH and NPTH into a single "
 "file."
 msgstr ""
+"Opcja nie zalecana.\n"
+"Użyj tylko gdy wytwórca płytek zażąda by otwory PTH i NPTH znajdowały się w "
+"jednym pliku."
 
 #: pcbnew/dialogs/dialog_gendrill_base.cpp:115
 msgid "Auxiliary axis"
@@ -19053,7 +19144,7 @@ msgstr ""
 
 #: pcbnew/dialogs/dialog_gendrill_base.cpp:129
 msgid "Default Via Drill:"
-msgstr "Domyślny otwór przelotki:"
+msgstr "Domyślny rozmiar wiercenia przelotki:"
 
 #: pcbnew/dialogs/dialog_gendrill_base.cpp:131
 msgid "Via Drill Value"
@@ -19065,7 +19156,7 @@ msgstr "Otwór mikroprzelotek:"
 
 #: pcbnew/dialogs/dialog_gendrill_base.cpp:140
 msgid "Micro via drill size"
-msgstr "Wielkość otworu mikroprzelotki"
+msgstr "Rozmiar wiercenia mikroprzelotki"
 
 #: pcbnew/dialogs/dialog_gendrill_base.cpp:148
 msgid "Holes Count:"
@@ -19073,23 +19164,23 @@ msgstr "Liczba otworów:"
 
 #: pcbnew/dialogs/dialog_gendrill_base.cpp:155
 msgid "Plated pads:"
-msgstr ""
+msgstr "Pola metalizowane:"
 
 #: pcbnew/dialogs/dialog_gendrill_base.cpp:163
 msgid "Non-plated pads:"
-msgstr ""
+msgstr "Pola niemetalizowane:"
 
 #: pcbnew/dialogs/dialog_gendrill_base.cpp:171
 msgid "Through vias:"
-msgstr "Przelotki na wylot:"
+msgstr "Przelotek na wylot:"
 
 #: pcbnew/dialogs/dialog_gendrill_base.cpp:179
 msgid "Micro vias:"
-msgstr "Mikro przelotki: "
+msgstr "Mikroprzelotek:"
 
 #: pcbnew/dialogs/dialog_gendrill_base.cpp:187
 msgid "Buried vias:"
-msgstr "Przelotki zagrzebane:"
+msgstr "Przelotek zagrzebanych:"
 
 #: pcbnew/dialogs/dialog_gendrill_base.cpp:210
 msgid "Generate Drill File"
@@ -19097,7 +19188,7 @@ msgstr "Generuj plik wierceń"
 
 #: pcbnew/dialogs/dialog_gendrill_base.cpp:214
 msgid "Generate Map File"
-msgstr ""
+msgstr "Generuj mapę wierceń"
 
 #: pcbnew/dialogs/dialog_gendrill_base.cpp:217
 msgid "Generate Report File"
@@ -19105,7 +19196,7 @@ msgstr "Utwórz plik raportu"
 
 #: pcbnew/dialogs/dialog_gendrill_base.h:91
 msgid "Generate Drill Files"
-msgstr "Generuj plik wierceń"
+msgstr "Generowanie pliku wierceń"
 
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:31
 msgid "&Auto save (minutes):"
@@ -19116,6 +19207,8 @@ msgid ""
 "Delay after the first change to create a backup file of the board on disk. "
 "If set to 0, auto backup is disabled."
 msgstr ""
+"Opóźnienie w tworzeniu pliku zapasowego po pierwszej zmianie w projekcie. "
+"Jeśli czas wynosi 0, automatyczne kopie zapasowe są wyłączone."
 
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:75
 msgid "Show icons in menus"
@@ -19131,11 +19224,15 @@ msgid ""
 "Set display of relative (dx/dy) coordinates to Cartesian (rectangular) or "
 "polar (angle/distance)."
 msgstr ""
+"Wybiera sposób wyświetlania koordynatów względnych (dx/dy) jako "
+"kartezjańskie (prostokątne) lub polarne (kąt/odległość)."
 
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:120
 #: pcbnew/dialogs/dialog_modedit_options_base.cpp:101
 msgid "Set units used to display dimensions and positions."
 msgstr ""
+"Wybiera jednostki jakie będą wyświetlane podczas wyświetlania wymiarów lub "
+"pozycji."
 
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:127
 msgid "&Show ratsnest"
@@ -19143,7 +19240,7 @@ msgstr "Pokaż połączenia wspomagające"
 
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:129
 msgid "Show the full ratsnest."
-msgstr ""
+msgstr "Pokazuje wszystkie linie prowadzące."
 
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:133
 msgid "Show page limits"
@@ -19160,21 +19257,26 @@ msgid ""
 "Force line segment directions to H, V or 45 degrees when drawing on "
 "technical layers."
 msgstr ""
+"Wymusza rysowanie linii graficznych tylko pod kątem prostym lub 45 stopni na "
+"warstwach technicznych."
 
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:145
 msgid "Edit action changes track width"
-msgstr ""
+msgstr "Polecenie Edytuj zmienia szerokość ścieżki"
 
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:146
 msgid ""
 "When active, hitting Edit hotkey or double-clicking on a track or via "
 "changes its width/diameter to the one selected in the main toolbar. "
 msgstr ""
+"Gdy opcja jest aktywna, skrót klawiszowy polecenia edycji lub podwójne "
+"kliknięcie na ścieżce lub przelotce zmienia ich rozmiar do wartości "
+"określonej na głównym pasku narzędziowym. "
 
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:150
 #: pcbnew/dialogs/dialog_modedit_options_base.cpp:183
 msgid "Prefer selection to dragging"
-msgstr ""
+msgstr "Preferuj tryb wyboru by przesunąć"
 
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:151
 #: pcbnew/dialogs/dialog_modedit_options_base.cpp:184
@@ -19183,6 +19285,9 @@ msgid ""
 "box, even if there are items under the cursor that could be immediately "
 "dragged."
 msgstr ""
+"Gdy jest włączony i nic nie jest zaznaczone, przeciąganie myszą będzie "
+"rysować zaznaczenie, nawet jeśli są dostępne elementy w miejscu kursora, "
+"które mogłyby być natychmiast przeciągnięte."
 
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:161
 msgid "&Rotation angle:"
@@ -19191,6 +19296,8 @@ msgstr "Kąt obrotu:"
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:166
 msgid "Set increment (in degrees) for context menu and hotkey rotation."
 msgstr ""
+"Wybiera jednostkowy kąt rotacji elementu dla poleceń z menu i skrótów "
+"klawiszowych."
 
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:182
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:190
@@ -19198,27 +19305,27 @@ msgid "When creating tracks"
 msgstr "W trakcie tworzenia ścieżek"
 
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:184
-#, fuzzy
 msgid "Magnetic Pads:"
-msgstr "Przyciągaj do padów"
+msgstr "Przyciągaj do padów:"
 
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:186
 msgid "Control capture of the cursor when the mouse enters a pad area."
 msgstr ""
+"Kontroluje sposób przechwytywania kursora gdy wchodzi on w strefę pola "
+"lutowniczego."
 
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:192
-#, fuzzy
 msgid "Magnetic Tracks:"
-msgstr "Przyciągaj do ścieżek"
+msgstr "Przyciągaj do ścieżek:"
 
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:194
 msgid "Control capture of the cursor when the mouse approaches a track."
 msgstr ""
+"Kontroluje sposób przechwytywania kursora gdy wchodzi on w strefę ścieżki."
 
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:199
-#, fuzzy
 msgid "Legacy Routing Options:"
-msgstr "Starsze opcje routingu"
+msgstr "Opcje trasowania kanwy Legacy:"
 
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:201
 msgid "&Enforce design rules when routing"
@@ -19229,15 +19336,18 @@ msgid ""
 "Enable DRC control. When DRC control is disabled, all connections are "
 "allowed."
 msgstr ""
+"Włącza kontrolę DRC. Jeśli kontrola DRC jest wyłączona, możliwe są wszelkie "
+"połączenia, również te błędne."
 
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:207
-#, fuzzy
 msgid "Auto-delete old tracks"
-msgstr "Włącz automatyczne usuwanie starych ścieżek"
+msgstr "Automatyczne usuwanie starych ścieżek"
 
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:209
 msgid "Enable automatic track deletion when redrawing a track."
 msgstr ""
+"Włącza funkcję automatycznego usuwania starych tras ścieżek przy "
+"przerysowywaniu ścieżki."
 
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:213
 msgid "&Limit tracks to 45 degrees"
@@ -19245,7 +19355,7 @@ msgstr "Ścieżki tylko pod kątem 45 stopni"
 
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:215
 msgid "Force track directions to H, V or 45 degrees when drawing a track."
-msgstr ""
+msgstr "Wymusza rysowanie ścieżek tylko pod kątem prostym lub 45 stopni."
 
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:219
 msgid "&Use double segmented tracks"
@@ -19256,6 +19366,8 @@ msgid ""
 "Use two track segments, with 45 degrees angle between them, when drawing a "
 "new track "
 msgstr ""
+"Używa dwóch segmentów pod kątem 45 stopni przy łamaniu ścieżki, podczas "
+"trasowania nowej ścieżki "
 
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.h:95
 msgid "General Settings"
@@ -19278,13 +19390,12 @@ msgid "Select by Browser"
 msgstr "Wybierz przez przeglądarkę"
 
 #: pcbnew/dialogs/dialog_get_footprint_base.h:62
-#, fuzzy
 msgid "Choose Footprint"
-msgstr "Zamień footprint"
+msgstr "Wybierz footprint"
 
 #: pcbnew/dialogs/dialog_get_footprint_by_name_base.cpp:34
 msgid "Available:"
-msgstr "Dostępny:"
+msgstr "Dostępne:"
 
 #: pcbnew/dialogs/dialog_get_footprint_by_name_base.h:55 pcbnew/hotkeys.cpp:145
 #: pcbnew/tools/selection_tool.cpp:127
@@ -19300,9 +19411,8 @@ msgid "Are you sure you want to delete the selected items?"
 msgstr "Czy usunąć wybrane elementy?"
 
 #: pcbnew/dialogs/dialog_global_deletion_base.cpp:23
-#, fuzzy
 msgid "Items to Delete:"
-msgstr "Elementy do usunięcia"
+msgstr "Elementy do usunięcia:"
 
 #: pcbnew/dialogs/dialog_global_deletion_base.cpp:25
 #: pcbnew/onrightclick.cpp:662 pcbnew/tools/pcb_editor_control.cpp:158
@@ -19335,9 +19445,8 @@ msgid "Clear board"
 msgstr "Wyczyść płytkę"
 
 #: pcbnew/dialogs/dialog_global_deletion_base.cpp:55
-#, fuzzy
 msgid "Filter Settings:"
-msgstr "Parametry filtrowania"
+msgstr "Parametry filtrowania:"
 
 #: pcbnew/dialogs/dialog_global_deletion_base.cpp:57
 msgid "Automatically routed tracks"
@@ -19368,9 +19477,8 @@ msgid "Current layer only"
 msgstr "Tylko bieżąca warstwa"
 
 #: pcbnew/dialogs/dialog_global_deletion_base.cpp:84
-#, fuzzy
 msgid "Layer Filter:"
-msgstr "Filtr warstw"
+msgstr "Filtr warstw:"
 
 #: pcbnew/dialogs/dialog_global_deletion_base.cpp:100
 msgid "Current layer:"
@@ -19426,7 +19534,7 @@ msgstr "Bieżąca klasa połączeń:"
 
 #: pcbnew/dialogs/dialog_global_edit_tracks_and_vias_base.cpp:59
 msgid "unknown"
-msgstr "Nieznany"
+msgstr "nieznany"
 
 #: pcbnew/dialogs/dialog_global_edit_tracks_and_vias_base.cpp:86
 msgid "Track size"
@@ -19442,7 +19550,7 @@ msgstr "Otwór przelotki"
 
 #: pcbnew/dialogs/dialog_global_edit_tracks_and_vias_base.cpp:89
 msgid "uVia size"
-msgstr "Rozmiar mikroprzelotki"
+msgstr "Rozmiar uVia"
 
 #: pcbnew/dialogs/dialog_global_edit_tracks_and_vias_base.cpp:97
 msgid "Netclass value"
@@ -19460,6 +19568,8 @@ msgstr "Opcje edycyjne ogólne:"
 msgid ""
 "Set tracks and vias of the current Net to the current selected user value"
 msgstr ""
+"Ustaw ścieżki i przelotki bieżącej sieci to bieżących wartości wybranych "
+"przez użytkownika"
 
 #: pcbnew/dialogs/dialog_global_edit_tracks_and_vias_base.cpp:145
 msgid "Set tracks and vias of the current Net to the Netclass value"
@@ -19485,9 +19595,8 @@ msgid "Global Edition of Tracks and Vias"
 msgstr "Edytuj rozmiary wszystkich ścieżek i przelotek"
 
 #: pcbnew/dialogs/dialog_global_footprints_fields_edition_base.cpp:26
-#, fuzzy
 msgid "Footprint Fields:"
-msgstr "Pola footprintu"
+msgstr "Pola footprintu:"
 
 #: pcbnew/dialogs/dialog_global_footprints_fields_edition_base.cpp:28
 msgid "Reference designator"
@@ -19513,9 +19622,8 @@ msgstr ""
 "Treścią filtra może być na przykład SM* (wielkość liter dowolna)"
 
 #: pcbnew/dialogs/dialog_global_footprints_fields_edition_base.cpp:56
-#, fuzzy
 msgid "Current Text Dimensions:"
-msgstr "Bieżacy rozmiar tekstu"
+msgstr "Bieżący rozmiar tekstu:"
 
 #: pcbnew/dialogs/dialog_global_footprints_fields_edition_base.h:61
 msgid "Set Text Size"
@@ -19551,7 +19659,7 @@ msgstr "Zamień pola lut. w tych samych footprintach"
 
 #: pcbnew/dialogs/dialog_global_pads_edition_base.h:56
 msgid "Push Pad Properties"
-msgstr ""
+msgstr "Wymuś właściwości pola lutowniczego"
 
 #: pcbnew/dialogs/dialog_graphic_item_properties.cpp:156
 #: pcbnew/dialogs/dialog_graphic_item_properties_for_fp_editor.cpp:168
@@ -19590,7 +19698,7 @@ msgstr "Pozycja początkowa Y:"
 #: pcbnew/dialogs/dialog_graphic_item_properties.cpp:176
 #: pcbnew/dialogs/dialog_graphic_item_properties_for_fp_editor.cpp:188
 msgid "Polygon Properties"
-msgstr "Właściwości wypełnienia"
+msgstr "Właściwości stref wypełnień"
 
 #: pcbnew/dialogs/dialog_graphic_item_properties.cpp:181
 #: pcbnew/dialogs/dialog_graphic_item_properties_for_fp_editor.cpp:193
@@ -19598,24 +19706,25 @@ msgid "Line Segment Properties"
 msgstr "Właściwości Segmentów"
 
 #: pcbnew/dialogs/dialog_graphic_item_properties.cpp:221
-#, fuzzy
 msgid ""
 "This item was on a not allowed or non existing layer.\n"
 "It has been moved to the first allowed layer.\n"
 "\n"
 "Please fix it."
 msgstr ""
-"Ten element znajduje się na nieznanej warstwie.\n"
-"Obecnie został przeniesiony na warstwę rysunkową. Proszę to poprawić."
+"Ten element znajduje się na nieodpowiedniej lub nieistniejącej warstwie.\n"
+"Zostanie przeniesiony na najbliższą odpowiednią warstwę.\n"
+"\n"
+"Proszę to poprawić."
 
 #: pcbnew/dialogs/dialog_graphic_item_properties.cpp:296
 msgid "Modify drawing properties"
-msgstr ""
+msgstr "Modyfikuj właściwości rysunków"
 
 #: pcbnew/dialogs/dialog_graphic_item_properties.cpp:333
 #: pcbnew/dialogs/dialog_graphic_item_properties_for_fp_editor.cpp:336
 msgid "The arc angle cannot be zero."
-msgstr ""
+msgstr "Kąt łuku nie może być zerowy."
 
 #: pcbnew/dialogs/dialog_graphic_item_properties.cpp:341
 #: pcbnew/dialogs/dialog_graphic_item_properties_for_fp_editor.cpp:344
@@ -19630,7 +19739,7 @@ msgstr "Punkt początkowy i końcowy nie mogą być takie same."
 #: pcbnew/dialogs/dialog_graphic_item_properties.cpp:367
 #: pcbnew/dialogs/dialog_graphic_item_properties_for_fp_editor.cpp:370
 msgid "The polygon outline thickness must be >= 0."
-msgstr ""
+msgstr "Grubość obrysu strefy musi być większa niż zero."
 
 #: pcbnew/dialogs/dialog_graphic_item_properties.cpp:370
 #: pcbnew/dialogs/dialog_graphic_item_properties_for_fp_editor.cpp:373
@@ -19697,6 +19806,10 @@ msgid ""
 "This is very dangerous because DRC does not handle it.\n"
 "Are you sure?"
 msgstr ""
+"Elementy graficzne będą na warstwie miedzi.\n"
+"Jest to niebezpieczne, gdyż narzędzie DRC nie będzie w stanie sprawdzić tych "
+"elementów.\n"
+"Czy jesteś pewien?"
 
 #: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:25
 msgid "Graphics:"
@@ -19737,40 +19850,35 @@ msgstr "Teksty i rysunki"
 msgid "Tracks, vias, and pads are allowed. The keepout is useless"
 msgstr ""
 "Ścieżki, przelotki i pola lutownicze są dozwolone. Strefa chroniona jest "
-"nieprzydatna."
+"nieprzydatna"
 
 #: pcbnew/dialogs/dialog_keepout_area_properties.cpp:255
 msgid "No layers selected."
 msgstr "Nie wybrano warstw."
 
 #: pcbnew/dialogs/dialog_keepout_area_properties_base.cpp:39
-#, fuzzy
 msgid "Keepout tracks"
-msgstr "Strefa chroniona"
+msgstr "Wyklucz ścieżki"
 
 #: pcbnew/dialogs/dialog_keepout_area_properties_base.cpp:42
-#, fuzzy
 msgid "Keepout vias"
-msgstr "Strefa chroniona"
+msgstr "Wyklucz przelotki"
 
 #: pcbnew/dialogs/dialog_keepout_area_properties_base.cpp:45
-#, fuzzy
 msgid "Keepout copper pours"
-msgstr "Bez stref wypełnień"
+msgstr "Wyklucz strefy miedzi"
 
 #: pcbnew/dialogs/dialog_keepout_area_properties_base.h:63
 msgid "Keepout Area Properties"
 msgstr "Właściwości strefy chronionej"
 
 #: pcbnew/dialogs/dialog_layer_selection_base.cpp:119
-#, fuzzy
 msgid "Top/Front layer:"
-msgstr "Warstwa górna / przednia"
+msgstr "Górna/Frontowa warstwa:"
 
 #: pcbnew/dialogs/dialog_layer_selection_base.cpp:157
-#, fuzzy
 msgid "Bottom/Back layer:"
-msgstr "Warstwa dolna / tylna"
+msgstr "Dolna/Tylna warstwa:"
 
 #: pcbnew/dialogs/dialog_layer_selection_base.h:50
 msgid "Select Layer"
@@ -19787,7 +19895,7 @@ msgstr "Włączony"
 #: pcbnew/dialogs/dialog_layers_setup.cpp:645
 #, c-format
 msgid "Board thickness %s is out of range."
-msgstr ""
+msgstr "Grubość płytki %s jest poza zakresem."
 
 #: pcbnew/dialogs/dialog_layers_setup.cpp:662
 #, c-format
@@ -19797,18 +19905,22 @@ msgid ""
 "These items will be no longer accessible\n"
 "Do you wish to continue?"
 msgstr ""
+"Footprinty posiadają elementy na usuniętych warstwach:\n"
+"%s\n"
+"Te elementy nie będą już dostępne\n"
+"Czy chcesz kontynuować?"
 
 #: pcbnew/dialogs/dialog_layers_setup.cpp:670
 msgid ""
 "Items have been found on removed layers. This operation will delete all "
 "items from removed layers and cannot be undone. Do you wish to continue?"
 msgstr ""
-"Ta operacja usunie wszystkie elementy z usuniętych warstw i nie będzie można "
-"ich przywrócić. Kontynuować?"
+"Na usuwanej warstwie są elementy. Operacja ta spowoduje ich usunięcie razem "
+"z usuwaną warstwą i ta operacja nie może zostać cofnięta. Chcesz kontynuować?"
 
 #: pcbnew/dialogs/dialog_layers_setup.cpp:804
 msgid "Layer name may not be empty."
-msgstr ""
+msgstr "Nazwa warstwy nie może być pusta."
 
 #: pcbnew/dialogs/dialog_layers_setup.cpp:811
 msgid "Layer name has an illegal character, one of: '"
@@ -19816,16 +19928,15 @@ msgstr "Nazwa warstwy posiada niedozwolony znak z grupy: '"
 
 #: pcbnew/dialogs/dialog_layers_setup.cpp:819
 msgid "Layer name 'signal' is reserved."
-msgstr ""
+msgstr "Nazwa 'signal' dla warstwy jest zarezerwowana."
 
 #: pcbnew/dialogs/dialog_layers_setup.cpp:828
 msgid "Duplicate layer names are not permitted."
-msgstr ""
+msgstr "Zduplikowane nazwy warstw nie są dopuszczalne."
 
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:25
-#, fuzzy
 msgid "Preset Layer Groupings:"
-msgstr "Domyślne ustawienia warstw"
+msgstr "Domyślne ustawienia warstw:"
 
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:29
 msgid "Two layers, parts on Front only"
@@ -19849,7 +19960,7 @@ msgstr "Cztery warstwy, elementy po stronie dolnej"
 
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:29
 msgid "All layers on"
-msgstr "Wszystkie warstwy włączone"
+msgstr "Wszystkie warstwy właczone"
 
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:41
 msgid "Copper Layers:"
@@ -19916,9 +20027,8 @@ msgid "32"
 msgstr "32"
 
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:57
-#, fuzzy
 msgid "Board Thickness:"
-msgstr "Grubość płytki"
+msgstr "Grubość płytki:"
 
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:118
 msgid "CrtYd_Front_later"
@@ -20358,7 +20468,7 @@ msgstr "CrtYd_Dolna_Po"
 
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:1568
 msgid "If you want a courtyard layer for the back side of the board"
-msgstr ""
+msgstr "Jeśli potrzebujesz warstwy Courtyard na dolnej stronie płytki"
 
 #: pcbnew/dialogs/dialog_layers_setup_base.cpp:1582
 msgid "PCB_Edges_later"
@@ -20416,21 +20526,22 @@ msgid "Layer Setup"
 msgstr "Ustawienia warstwy"
 
 #: pcbnew/dialogs/dialog_mask_clearance_base.cpp:27
-#, fuzzy
 msgid ""
 "Note: for clearance values:\n"
 "- a positive value means a mask bigger than a pad.\n"
 "- a negative value means a mask smaller than a pad."
 msgstr ""
-"Uwaga: Dla wartości odstępu:\n"
-"- wartość dodatnia oznacza, że maska będzie większa niż pole lutownicze\n"
-"- wartość ujemna oznacza, że maska będzie mniejsza niż pole lutownicze\n"
+"Pamiętaj: Dla wartości prześwitu:\n"
+"- wartość dodatnia oznacza maskę większą niż pole lutownicze\n"
+"- wartość ujemna oznacza maskę mniejszą niż pole lutownicze."
 
 #: pcbnew/dialogs/dialog_mask_clearance_base.cpp:31
 msgid ""
 "These global values are used only to build the mask shape\n"
 "of pads on copper layers."
 msgstr ""
+"Te wartości globalne są używane tylko przy budowaniu kształtu\n"
+"maski dla pól na warstwach miedzi."
 
 #: pcbnew/dialogs/dialog_mask_clearance_base.cpp:48
 msgid ""
@@ -20492,41 +20603,34 @@ msgid "Pads Mask Clearance"
 msgstr "Prześwit maski"
 
 #: pcbnew/dialogs/dialog_modedit_options_base.cpp:28
-#, fuzzy
 msgid "Default Values for New Graphic Items"
-msgstr "Domyślna ścieżka dla bibliotek"
+msgstr "Domyślne wartości dla nowych elementów graficznych"
 
 #: pcbnew/dialogs/dialog_modedit_options_base.cpp:36
-#, fuzzy
 msgid "&Graphic line width:"
-msgstr "Grubość linii grafiki"
+msgstr "Grubość linii grafiki:"
 
 #: pcbnew/dialogs/dialog_modedit_options_base.cpp:47
-#, fuzzy
 msgid "&Text line width:"
-msgstr "Szerokość linii &tekstu"
+msgstr "Grubość linii tekstu:"
 
 #: pcbnew/dialogs/dialog_modedit_options_base.cpp:58
-#, fuzzy
 msgid "Text &height:"
-msgstr "Wysokość tekstu"
+msgstr "Wysokość tekstu:"
 
 #: pcbnew/dialogs/dialog_modedit_options_base.cpp:69
-#, fuzzy
 msgid "Text &width:"
-msgstr "Szerokość tekstu"
+msgstr "Szerokość tekstu:"
 
 #: pcbnew/dialogs/dialog_modedit_options_base.cpp:91
 msgid "Coordinates"
 msgstr "Współrzędne"
 
 #: pcbnew/dialogs/dialog_modedit_options_base.cpp:109
-#, fuzzy
 msgid "Default Values for New Footprints"
-msgstr "Domyślne wartości przy tworzeniu nowych footprintów:"
+msgstr "Domyślne wartości dla nowych footprintów"
 
 #: pcbnew/dialogs/dialog_modedit_options_base.cpp:117
-#, fuzzy
 msgid "&Reference:"
 msgstr "Oznaczenie:"
 
@@ -20549,9 +20653,8 @@ msgid "Fab. Layer"
 msgstr "Warstwa produkcyjna"
 
 #: pcbnew/dialogs/dialog_modedit_options_base.cpp:138
-#, fuzzy
 msgid "V&alue:"
-msgstr "Wartość"
+msgstr "Wartość:"
 
 #: pcbnew/dialogs/dialog_modedit_options_base.cpp:143
 msgid ""
@@ -20562,23 +20665,20 @@ msgstr ""
 "Pozostaw pusty by została użyta nazwa footprintu"
 
 #: pcbnew/dialogs/dialog_modedit_options_base.cpp:162
-#, fuzzy
 msgid "Leave reference and/or value blank to use footprint name."
 msgstr ""
 "Pozostaw puste pola 'Oznaczenie' i 'Wartość' by użyć dla nich nazwy "
-"footprintu jako tekstu domyślnego"
+"footprintu jako tekstu domyślnego."
 
 #: pcbnew/dialogs/dialog_modedit_options_base.cpp:170
-#, fuzzy
 msgid "Editing Options"
-msgstr "Edycja właściwości linii"
+msgstr "Opcje edycji"
 
 #: pcbnew/dialogs/dialog_modedit_options_base.cpp:172
-#, fuzzy
 msgid "Magnetic pads"
-msgstr "Przyciągaj do padów"
+msgstr "Magnetyczne pola lutownicze"
 
-#: pcbnew/dialogs/dialog_modedit_options_base.h:83
+#: pcbnew/dialogs/dialog_modedit_options_base.h:78
 msgid "Footprint Editor Options"
 msgstr "Opcje edytora footprintów"
 
@@ -20610,31 +20710,31 @@ msgstr "Bieżąca pozycja"
 
 #: pcbnew/dialogs/dialog_move_exact_base.cpp:77
 msgid "User origin"
-msgstr ""
+msgstr "Punkt odniesienia użytkownika"
 
 #: pcbnew/dialogs/dialog_move_exact_base.cpp:77
 msgid "Drill/Place origin"
-msgstr ""
+msgstr "Punkt bazowy dla wstawiania/wiercenia"
 
 #: pcbnew/dialogs/dialog_move_exact_base.cpp:77
 msgid "Sheet origin"
-msgstr ""
+msgstr "Punkt bazowy arkusza"
 
 #: pcbnew/dialogs/dialog_move_exact_base.cpp:79
 msgid "Move Relative To:"
-msgstr "Przenieś w odniesieniu do:"
+msgstr "Przesuń względem:"
 
 #: pcbnew/dialogs/dialog_move_exact_base.cpp:88
 msgid "Override default footprint anchor with:"
-msgstr ""
+msgstr "Zastąp domyślny punkt zaczepienia footprintu przez:"
 
 #: pcbnew/dialogs/dialog_move_exact_base.cpp:91
 msgid "Top left pad"
-msgstr ""
+msgstr "Górne lewe pole lutownicze"
 
 #: pcbnew/dialogs/dialog_move_exact_base.cpp:91
 msgid "Footprint center"
-msgstr ""
+msgstr "Centrum footprinu"
 
 #: pcbnew/dialogs/dialog_netlist.cpp:85
 msgid "The project configuration has changed.  Do you want to save it?"
@@ -20737,7 +20837,6 @@ msgid "Timestamp"
 msgstr "Znacznik czasowy"
 
 #: pcbnew/dialogs/dialog_netlist_base.cpp:35
-#, fuzzy
 msgid "Footprint Selection:"
 msgstr "Wybór footprintów:"
 
@@ -20760,9 +20859,8 @@ msgid "Keep"
 msgstr "Pozostaw"
 
 #: pcbnew/dialogs/dialog_netlist_base.cpp:43
-#, fuzzy
 msgid "Exchange Footprint:"
-msgstr "Zamień footprinty"
+msgstr "Zamień footprinty:"
 
 #: pcbnew/dialogs/dialog_netlist_base.cpp:45
 msgid ""
@@ -20774,16 +20872,17 @@ msgstr ""
 
 #: pcbnew/dialogs/dialog_netlist_base.cpp:57
 msgid "Tracks Joining Multiple Nets:"
-msgstr ""
+msgstr "Ścieżki łączące dwie sieci:"
 
 #: pcbnew/dialogs/dialog_netlist_base.cpp:59
 msgid ""
 "Keep or delete tracks creating a short circuit between two nets after a "
 "netlist change"
 msgstr ""
+"Zachowuje lub usuwa ścieżki, które tworzą zwarcia w obwodzie pomiędzy dwoma "
+"sieciami po zmianie listy sieci"
 
 #: pcbnew/dialogs/dialog_netlist_base.cpp:65
-#, fuzzy
 msgid "Extra Footprints:"
 msgstr "Dodatkowe footprinty:"
 
@@ -20796,7 +20895,6 @@ msgstr ""
 "Uwaga: tylko nie zablokowane footprinty zostaną usunięte"
 
 #: pcbnew/dialogs/dialog_netlist_base.cpp:73
-#, fuzzy
 msgid "Single Pad Nets:"
 msgstr "Nazwy sieci z niepołączonych pól:"
 
@@ -20816,6 +20914,7 @@ msgstr "Testuj footprinty"
 #: pcbnew/dialogs/dialog_netlist_base.cpp:102
 msgid "Read the current netlist file and list missing and extra footprints"
 msgstr ""
+"Wczytuje bieżącą listę sieci i wypisuje brakujące lub dodatkowe footprinty"
 
 #: pcbnew/dialogs/dialog_netlist_base.cpp:106
 msgid "Rebuild Board Connectivity"
@@ -20824,6 +20923,8 @@ msgstr "Odbuduj połączenia płytki"
 #: pcbnew/dialogs/dialog_netlist_base.cpp:107
 msgid "Rebuild the full ratsnest (useful after a manual pad netname edition)"
 msgstr ""
+"Odbudowuje wszystkie połączenia (użyteczne po ręcznej zmianie nazwy sieci "
+"pola lutuowniczego)"
 
 #: pcbnew/dialogs/dialog_netlist_base.cpp:123
 msgid "Dry run. Only report changes in message panel"
@@ -20856,7 +20957,7 @@ msgstr ""
 
 #: pcbnew/dialogs/dialog_netlist_base.cpp:146
 msgid "Netlist file:"
-msgstr "Plik listy połączeń:"
+msgstr "Plik z listą sieci:"
 
 #: pcbnew/dialogs/dialog_non_copper_zones_properties.cpp:197
 msgid ""
@@ -20872,7 +20973,7 @@ msgstr "BŁĄD : musisz wybrać warstwę"
 
 #: pcbnew/dialogs/dialog_non_copper_zones_properties_base.cpp:44
 msgid "Outlines Options:"
-msgstr "Opcje obrysu:"
+msgstr "Opcje krawędzi:"
 
 #: pcbnew/dialogs/dialog_non_copper_zones_properties_base.cpp:46
 msgid "Any"
@@ -20888,7 +20989,7 @@ msgstr "Orientacja krawędzi strefy:"
 
 #: pcbnew/dialogs/dialog_non_copper_zones_properties_base.cpp:52
 msgid "Hatched outline"
-msgstr "Linia kreskowa"
+msgstr "Obrys kreskowany"
 
 #: pcbnew/dialogs/dialog_non_copper_zones_properties_base.cpp:52
 msgid "Full hatched"
@@ -20896,11 +20997,11 @@ msgstr "Pełne kreskowanie"
 
 #: pcbnew/dialogs/dialog_non_copper_zones_properties_base.cpp:54
 msgid "Outline Appearance:"
-msgstr ""
+msgstr "Wygląd obrysów:"
 
 #: pcbnew/dialogs/dialog_non_copper_zones_properties_base.cpp:61
 msgid "Zone min thickness value:"
-msgstr ""
+msgstr "Minimalna wartość szerokości strefy:"
 
 #: pcbnew/dialogs/dialog_non_copper_zones_properties_base.h:64
 msgid "Non Copper Zones Properties"
@@ -20910,7 +21011,7 @@ msgstr "Właściwości obszarów bez warstw miedzi"
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:935
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:1038
 msgid "degree"
-msgstr "Stopnie"
+msgstr "stopni"
 
 #: pcbnew/dialogs/dialog_pad_basicshapes_properties.cpp:106
 msgid "Ring"
@@ -20918,31 +21019,31 @@ msgstr "Pierścień"
 
 #: pcbnew/dialogs/dialog_pad_basicshapes_properties.cpp:131
 msgid "corners count"
-msgstr "Liczba narożników"
+msgstr "ilość narożników"
 
 #: pcbnew/dialogs/dialog_pad_basicshapes_properties.cpp:278
 msgid "Incorrect polygon: less than 3 corners"
-msgstr ""
+msgstr "Niepoprawny kształt strefy: mniej niż 3 narożniki"
 
 #: pcbnew/dialogs/dialog_pad_basicshapes_properties.cpp:298
 msgid "Incorrect polygon: too few corners after simplification"
-msgstr ""
+msgstr "Niepoprawny kształt strefy: za mało narożników po uproszczeniu"
 
 #: pcbnew/dialogs/dialog_pad_basicshapes_properties.cpp:304
 msgid "Incorrect polygon: self intersecting"
-msgstr ""
+msgstr "Niepoprawny kształt strefy: strefy nachodzą na siebie"
 
 #: pcbnew/dialogs/dialog_pad_basicshapes_properties.cpp:309
 msgid "Polygon:"
-msgstr "Wypełnienie\""
+msgstr "Strefa:"
 
 #: pcbnew/dialogs/dialog_pad_basicshapes_properties.cpp:318
 msgid "Polygon: redundant corners removed"
-msgstr ""
+msgstr "Strefa: zbędne narożniki zostały usunięte"
 
 #: pcbnew/dialogs/dialog_pad_basicshapes_properties.cpp:346
 msgid "Select a corner before adding a new corner"
-msgstr ""
+msgstr "Wybierz narożnik przed dodaniem nowego narożnika"
 
 #: pcbnew/dialogs/dialog_pad_properties.cpp:527
 msgid "Back side (footprint is mirrored)"
@@ -20960,23 +21061,23 @@ msgstr "Brak footprintu"
 #: pcbnew/dialogs/dialog_pad_properties.cpp:799
 #, c-format
 msgid "width %s"
-msgstr "szerokość %s"
+msgstr "szerokość %s"
 
 #: pcbnew/dialogs/dialog_pad_properties.cpp:806
 msgid "from "
-msgstr ""
+msgstr "z "
 
 #: pcbnew/dialogs/dialog_pad_properties.cpp:807
 msgid "to "
-msgstr ""
+msgstr "do "
 
 #: pcbnew/dialogs/dialog_pad_properties.cpp:812
 msgid "center "
-msgstr "Wyśrodkuj"
+msgstr "centralnie "
 
 #: pcbnew/dialogs/dialog_pad_properties.cpp:813
 msgid "start "
-msgstr "Start"
+msgstr "start "
 
 #: pcbnew/dialogs/dialog_pad_properties.cpp:814
 #, c-format
@@ -20985,21 +21086,21 @@ msgstr "kąt %s"
 
 #: pcbnew/dialogs/dialog_pad_properties.cpp:819
 msgid "ring"
-msgstr "Pierścień"
+msgstr "obręcz"
 
 #: pcbnew/dialogs/dialog_pad_properties.cpp:821
 msgid "circle"
-msgstr "Okrąg"
+msgstr "okrąg"
 
 #: pcbnew/dialogs/dialog_pad_properties.cpp:824
 #, c-format
 msgid "radius %s"
-msgstr ""
+msgstr "promień %s"
 
 #: pcbnew/dialogs/dialog_pad_properties.cpp:830
 #, c-format
 msgid "corners count %d"
-msgstr "liczba narożników %d"
+msgstr "ilość wierzchołków %d"
 
 #: pcbnew/dialogs/dialog_pad_properties.cpp:1107
 msgid "Pad size must be greater than zero"
@@ -21012,16 +21113,16 @@ msgstr ""
 
 #: pcbnew/dialogs/dialog_pad_properties.cpp:1120
 msgid "Pad local clearance must be zero or greater than zero"
-msgstr ""
+msgstr "Lokalny prześwit pola lutowniczego musi być większy lub równy zero"
 
 #: pcbnew/dialogs/dialog_pad_properties.cpp:1131
 msgid "Pad local solder mask clearance must be zero or greater than zero"
-msgstr ""
+msgstr "Lokalny prześwit soldermaski musi być większy lub równy zero"
 
 #: pcbnew/dialogs/dialog_pad_properties.cpp:1139
 #, c-format
 msgid "Pad local solder mask clearance must be greater than %s"
-msgstr ""
+msgstr "Lokalny prześwit soldermaski musi być większy niż %s"
 
 #: pcbnew/dialogs/dialog_pad_properties.cpp:1154
 msgid "Error: pad has no layer"
@@ -21029,7 +21130,7 @@ msgstr "Błąd: Pole lutownicze nie posiada warstwy"
 
 #: pcbnew/dialogs/dialog_pad_properties.cpp:1161
 msgid "Error: the pad is not on a copper layer and has a hole"
-msgstr "Błąd: Pole lutownicze nie jest na wartwie sygnałowej i posiada otwór."
+msgstr "Błąd: Pole lutownicze nie jest na warstwie sygnałowej i posiada otwór"
 
 #: pcbnew/dialogs/dialog_pad_properties.cpp:1166
 msgid ""
@@ -21037,7 +21138,7 @@ msgid ""
 "pad plotted in gerber files"
 msgstr ""
 "Jeśli nie chcesz by punkt lutowniczy NPTH został umieszczony w plikach "
-"Gerber ustaw jego rozmiar i średnicę owiertu na tą samą wartość."
+"Gerber ustaw jego rozmiar i średnicę owiertu na tą samą wartość"
 
 #: pcbnew/dialogs/dialog_pad_properties.cpp:1186
 msgid "Incorrect value for pad offset"
@@ -21067,19 +21168,21 @@ msgstr ""
 
 #: pcbnew/dialogs/dialog_pad_properties.cpp:1227
 msgid "Incorrect corner size value"
-msgstr ""
+msgstr "Nieprawidłowa wartość rozmiaru narożnika"
 
 #: pcbnew/dialogs/dialog_pad_properties.cpp:1231
 msgid "Incorrect (negative) corner size value"
-msgstr ""
+msgstr "Niepoprawna (ujemna) wartość rozmiaru narożnika"
 
 #: pcbnew/dialogs/dialog_pad_properties.cpp:1233
 msgid "Corner size value must be smaller than 50%"
-msgstr ""
+msgstr "Rozmiar narożnika musi być mniejszy niż 50%"
 
 #: pcbnew/dialogs/dialog_pad_properties.cpp:1241
 msgid "Incorrect pad shape: the shape must be equivalent to only one polygon"
 msgstr ""
+"Niepoprawny kształt pola lutowniczego: kształt musi być odpowiednikiem "
+"pojedynczej strefy"
 
 #: pcbnew/dialogs/dialog_pad_properties.cpp:1247
 msgid "Pad setup errors list"
@@ -21091,7 +21194,7 @@ msgstr "Nieznana nazwa sieci, nie dokonano zmian"
 
 #: pcbnew/dialogs/dialog_pad_properties.cpp:1532
 msgid "Modify pad"
-msgstr "Modyfikowanie pola lutowniczego"
+msgstr "Modyfikuj pole lutownicze"
 
 #: pcbnew/dialogs/dialog_pad_properties.cpp:1873
 #: pcbnew/dialogs/dialog_pad_properties.cpp:2016
@@ -21101,15 +21204,15 @@ msgstr "Nie wybrano kształtu"
 
 #: pcbnew/dialogs/dialog_pad_properties.cpp:1964
 msgid "ring/circle"
-msgstr "Pierścień / okrąg"
+msgstr "pierścień/okrąg"
 
 #: pcbnew/dialogs/dialog_pad_properties.cpp:1964
 msgid "polygon"
-msgstr "Wielokąt"
+msgstr "strefa"
 
 #: pcbnew/dialogs/dialog_pad_properties.cpp:1967
 msgid "Select shape type:"
-msgstr ""
+msgstr "Wybór typu kształtu:"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:40
 msgid "Pad number:"
@@ -21159,11 +21262,11 @@ msgstr "Zaokrąglony prostokąt"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:77
 msgid "Custom (Circ. Anchor)"
-msgstr ""
+msgstr "Kształt użytkownika (Okrągły punkt zaczepienia)"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:77
 msgid "Custom (Rect. Anchor)"
-msgstr ""
+msgstr "Kształt użytkownika (Prostokątny punkt zaczepienia)"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:108
 #: pcbnew/dialogs/dialog_set_grid_base.cpp:74
@@ -21208,7 +21311,7 @@ msgstr "Nachylenie:"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:209
 msgid "Trapezoid axis:"
-msgstr ""
+msgstr "Nachylenie:"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:231
 msgid "Corner size:"
@@ -21220,10 +21323,13 @@ msgid ""
 "The width is the smaller value between size X and size Y.\n"
 "The max value is 50 percent."
 msgstr ""
+"Promień zaokrąglenia w procentach  szerokości pola.\n"
+"Szerokość jest najmniejszą wartością pomiędzy rozmiarem X a Y.\n"
+"Maksymalna wartość to 50 procent."
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:244
 msgid "Corner radius:"
-msgstr ""
+msgstr "Promień narożnika:"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:246
 msgid ""
@@ -21232,6 +21338,10 @@ msgid ""
 "The width is the smaller value between size X and size Y.\n"
 "Note: IPC norm gives a max value = 0.25mm."
 msgstr ""
+"Promień zaokrąglenia.\n"
+"Nie może być większy niż połowa szerokości pola.\n"
+"Szerokość to najmniejsza wartość pomiędzy rozmiarem X a Y.\n"
+"Uwaga: Norma IPC przewiduje maksymalną wartość równą 0.25mm."
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:252
 msgid ""
@@ -21240,6 +21350,10 @@ msgid ""
 "The width is the smaller value between size X and size Y\n"
 "Note: IPC norm gives a max value = 0.25mm"
 msgstr ""
+"Promień zaokrąglenia.\n"
+"Nie może być większy niż połowa szerokości pola lutowniczego.\n"
+"Szerokość jest mniejszą wartością pomiędzy rozmiarem X a rozmiarem Y\n"
+"Informacja: Norma IPC określa maksymalną wartość na 0.25mm"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:275
 msgid "Hole shape:"
@@ -21258,6 +21372,8 @@ msgid ""
 "Parent footprint on board is flipped.\n"
 "Layers will be reversed."
 msgstr ""
+"Footprint nadrzędny na płytce jest obrócony.\n"
+"Warstwy będą odwrócone."
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:334
 msgid "Copper:"
@@ -21312,22 +21428,25 @@ msgid "E.C.O.2"
 msgstr "E.C.O.2"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:404
-#, fuzzy
 msgid "Set values to 0 to use parent footprint or netclass values."
 msgstr ""
-"Ustaw wartość na 0\n"
-"by użyć danych z footprintu lub wart. globalnej"
+"Ustaw wartość na 0 by użyć danych z footprintu nadrzędnego lub wartości z "
+"klasy sieci."
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:410
 msgid ""
 "Positive clearance means area bigger than the pad (usual for mask clearance)."
 msgstr ""
+"Dodatnia wartość prześwitu oznacza większą niż pole lutownicze (zwykle dla "
+"prześwitu soldermaski)."
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:416
 msgid ""
 "Negative clearance means area smaller than the pad (usual for paste "
 "clearance)."
 msgstr ""
+"Ujemna wartość prześwitu oznacza mniejszą niż pole lutownicze (zwykle dla "
+"prześwitu pasty)"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:423
 msgid "Clearances"
@@ -21389,7 +21508,7 @@ msgstr ""
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:531
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:580
 msgid "Connection to Copper Zones"
-msgstr ""
+msgstr "Połączenia ze strefami miedzi"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:539
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:588
@@ -21402,7 +21521,7 @@ msgstr "Z nadrzędnego footprintu"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:552
 msgid "Thermal relief width:"
-msgstr "Szerokość połączenia termicznego"
+msgstr "Szerokość połączenia termicznego:"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:563
 msgid "Thermal relief gap:"
@@ -21410,15 +21529,15 @@ msgstr "Prześwit połączenia termicznego:"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:598
 msgid "Custom pad shape in zone:"
-msgstr ""
+msgstr "Własny kształt pola lutowniczego w strefie:"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:602
 msgid "Use pad shape"
-msgstr ""
+msgstr "Użyj kształtu pola"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:602
 msgid "Use pad convex hull"
-msgstr ""
+msgstr "Użyj otoczenia obrysu pola lutowniczego"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:621
 msgid "Local Clearance and Settings"
@@ -21426,96 +21545,92 @@ msgstr "Lokalny prześwit i ustawienia"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:625
 msgid "Primitives list"
-msgstr ""
+msgstr "Lista prymitywów"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:631
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:1114
 msgid "Coordinates are relative to anchor pad, orientation 0"
-msgstr ""
+msgstr "Współrzędne są relatywne wobec punktu zaczepienia, orientacja zerowa"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:646
 msgid "Delete Primitive"
-msgstr ""
+msgstr "Usuń prymityw"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:649
 msgid "Edit Primitive"
-msgstr ""
+msgstr "Edycja prymitywu"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:652
 msgid "Add Primitive"
-msgstr ""
+msgstr "Dodaj prymityw"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:655
 msgid "Duplicate Primitive"
-msgstr ""
+msgstr "Duplikuj prymityw"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:664
 msgid "Geometry Transform"
-msgstr ""
+msgstr "Transformacja geometryczna"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:667
 msgid "Import Primitives"
-msgstr ""
+msgstr "Importuj prymitywy"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:680
 msgid "Custom Shape Primitives"
-msgstr ""
+msgstr "Elementy składowe własnego kształtu"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:692
 msgid "Parent Footprint Orientation"
-msgstr ""
+msgstr "Orientacja footprintu nadrzędnego"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:729
 msgid "Show pad in outline mode"
-msgstr ""
+msgstr "Pokaż pola lutownicze jako zarys"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:862
 msgid ""
 "Filled circle: set thickness to 0\n"
 "Ring:  set thickness to the width of the ring"
 msgstr ""
+"Wypełniony okrąg: ustaw grubość na zero\n"
+"Okrąg:  ustaw grubość na szerokość obręczy"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:875
-#, fuzzy
 msgid "Start point:"
-msgstr "Punkt początkowy"
+msgstr "Punkt początkowy:"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:897
-#, fuzzy
 msgid "End point:"
-msgstr "Punkt końcowy"
+msgstr "Punkt końcowy:"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:1000
-#, fuzzy
 msgid "Move vector:"
-msgstr "Przenieś wektor"
+msgstr "Przesuń wektor:"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:1042
-#, fuzzy
 msgid "Scaling factor:"
-msgstr "Współczynnik skalowania"
+msgstr "Skalowanie:"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:1049
 msgid "1.0"
 msgstr "1.0"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:1061
-#, fuzzy
 msgid "Duplicate count:"
-msgstr "Powiel footprint"
+msgstr "Ilość powieleń:"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:1120
 msgid "Incorrect polygon"
-msgstr ""
+msgstr "Niepoprawna strefa"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:1194
-#, fuzzy
 msgid "Outline thickness:"
-msgstr "Grubość &linii:"
+msgstr "Szerokość obrysu:"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:1208
 msgid "(Thickness outline is usually set to 0)"
-msgstr ""
+msgstr "(Szerokość obrysu jest zwykle ustalana na 0)"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.h:220
 msgid "Pad Properties"
@@ -21523,11 +21638,11 @@ msgstr "Właściwości pola lutowniczego"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.h:292
 msgid "Pad Custom Shape Geometry Transform"
-msgstr ""
+msgstr "Przekształcenie geometrii własnych kształtów pól"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.h:331
 msgid "Basic Shape Polygon"
-msgstr "Podstawowy kształt wielokąta"
+msgstr "Strefa z podstawowych kształtów"
 
 #: pcbnew/dialogs/dialog_pcb_text_properties.cpp:242
 msgid "No layer selected, Please select the text layer"
@@ -21535,7 +21650,7 @@ msgstr "Warstwa nie została zdefiniowana. Proszę wybrać warstwę opisową"
 
 #: pcbnew/dialogs/dialog_pcb_text_properties.cpp:351
 msgid "Change text properties"
-msgstr ""
+msgstr "Zmień właściwości tekstu"
 
 #: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:30
 msgid "Enter the text placed on selected layer."
@@ -21555,9 +21670,8 @@ msgid "Orientation (deg):"
 msgstr "Orientacja (stopnie):"
 
 #: pcbnew/dialogs/dialog_plot.cpp:59
-#, fuzzy
 msgid "Generate Drill Files..."
-msgstr "Utwórz plik wierceń..."
+msgstr "Generuj pliki wierceń..."
 
 #: pcbnew/dialogs/dialog_plot.cpp:647
 msgid "HPGL pen size constrained."
@@ -21576,22 +21690,22 @@ msgid "Y scale constrained."
 msgstr "Skala Y ograniczona."
 
 #: pcbnew/dialogs/dialog_plot.cpp:705
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "Width correction constrained. The reasonable width correction value must be "
 "in a range of  [%+f; %+f] (%s) for current design rules."
 msgstr ""
 "Korekcja szerokości ograniczona. Prawidłowa wartość korekcji musi zawierać "
-"się w granicach [%+f; %+f] (%s) dla bieżących reguł projektowych."
+"się w granicach  [%+f; %+f] (%s) dla bieżących reguł projektowych."
 
 #: pcbnew/dialogs/dialog_plot.cpp:789
 msgid "No layer selected, Nothing to plot"
-msgstr ""
+msgstr "Nie wybrano warstw, nic nie zostało narysowane"
 
 #: pcbnew/dialogs/dialog_plot.cpp:908
 #, c-format
 msgid "Plot file \"%s\" created."
-msgstr "Plik rysunkowy \"%s\" został utworzony."
+msgstr "Plik z rysunkiem \"%s\" został utworzony."
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:26
 msgid "Plot format:"
@@ -21600,7 +21714,7 @@ msgstr "Format wyjściowy:"
 #: pcbnew/dialogs/dialog_plot_base.cpp:69
 #: pcbnew/dialogs/dialog_print_using_printer_base.cpp:20
 msgid "Included Layers:"
-msgstr "Dołączone warstwy:"
+msgstr "Załączone warstwy:"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:91
 msgid "Plot sheet reference on all layers"
@@ -21640,17 +21754,21 @@ msgstr "Wyłącz warstwę krawędzi PCB z pozostałych warstw"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:113
 msgid "Do not plot the contents of the PCB edge layer on any other layers."
-msgstr ""
+msgstr "Wyłącz zawartość warstwy krawędzi PCB z pozostałych warstw."
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:117
 msgid "Exclude pads from silkscreen"
-msgstr ""
+msgstr "Nie rysuj pól lutowniczych na warstwie opisowej"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:118
 msgid ""
 "Do not plot pads on silkscreen layers, even when they are assigned to them.\n"
 "Uncheck this if you wish to create assembly drawings from silkscreen layers."
 msgstr ""
+"Nie rysuj pól na warstwach opisowych, nawet jeśli są one do nich "
+"przypisane.\n"
+"Odznacz tą opcję jeśli chcesz tworzyć rysunki montażowe na podstawie warstw "
+"opisowych."
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:123
 msgid "Use auxiliary axis as coordinates origin in plot files"
@@ -21667,7 +21785,7 @@ msgstr "Rysuj w negatywie"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:133
 msgid "Check zone fills before plotting"
-msgstr ""
+msgstr "Sprawdzaj wypełnienia stref przed rysowaniem"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:142
 msgid "Drill marks:"
@@ -21706,18 +21824,16 @@ msgid "Plot mode:"
 msgstr "Tryb rysowania:"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:172
-#, fuzzy
 msgid "Line width:"
-msgstr "Szerokość linii"
+msgstr "Szerokość linii:"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:179
 msgid "Line width for, e.g., sheet references."
 msgstr "Szerokość lini dla, przykładowo: odnośników arkusza."
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:192
-#, fuzzy
 msgid "Solder Mask Options:"
-msgstr "Opcje maski lutowniczej"
+msgstr "Opcje soldermaski:"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:201
 msgid "Margin between pads and solder mask"
@@ -21738,9 +21854,8 @@ msgstr ""
 "rysowania"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:225
-#, fuzzy
 msgid "Gerber Options:"
-msgstr "Opcje Gerber"
+msgstr "Opcje Gerber:"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:230
 msgid "Use Protel filename extensions"
@@ -21751,36 +21866,45 @@ msgid ""
 "Use Protel Gerber extensions (.GBL, .GTL, etc...)\n"
 "No longer recommended. The official extension is .gbr"
 msgstr ""
+"Użyj rozszerzeń plików Gerber zaproponowanych przez firmę Protel (.GBL, ."
+"GTL, itd.)\n"
+"Opcja nie zalecana. Oficjalnym rozszerzeniem jest .gbr"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:235
 msgid "Include extended (X2) attributes"
-msgstr ""
+msgstr "Dołącz atrybuty rozszerzone (X2)"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:236
 msgid ""
 "Include extended attributes (X2 Gerber files format) in the Gerber file.\n"
 "Mainly File Format attributes."
 msgstr ""
+"Dołącz atrybuty rozszerzone (format pliku Gerber X2) w plikach Gerber.\n"
+"Głównie atrybuty dotyczące pliku."
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:240
 msgid "Include advanced X2 features"
-msgstr ""
+msgstr "Dołącz zaawansowane funkcje X2"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:241
 msgid ""
 "Only available in X2 Gerber files format.\n"
 "Include netlist metadata and aperture attributes."
 msgstr ""
+"Dostępne tylko w przypadku formatu Gerber X2.\n"
+"Zawiera metadane o listach sieci i atrybuty apertur."
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:245
 msgid "Generate Gerber job file"
-msgstr "Utwórz plik roboczy Gerber"
+msgstr "Utwórz plik zadań dla plików Gerber"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:246
 msgid ""
 "Generate a Gerber job file that contains info about the board,\n"
 "and the list of generated Gerber plot files"
 msgstr ""
+"Tworzy plik zadań dla plików Gerber, który zawiera informacje o płytce\n"
+"i listę plików Gerber podlegających generowaniu"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:250
 msgid "Subtract soldermask from silkscreen"
@@ -21792,11 +21916,11 @@ msgstr "Usuń maskę opisową z pól wokół maski lutowniczej"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:258
 msgid "4.5, unit mm"
-msgstr "4.5 jednostka mm"
+msgstr "4.5, jednostki: mm"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:258
 msgid "4.6, unit mm"
-msgstr "4.6 jednostka mm"
+msgstr "4.6, jednostki: mm"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:260
 msgid "Coordinate Format"
@@ -21811,27 +21935,26 @@ msgstr ""
 "Użyj wyższej precyzji jeśli to możliwe."
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:274
-#, fuzzy
 msgid "Pen size:"
-msgstr "Rozmiar pisaka"
+msgstr "Rozmiar pisaka:"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:287
-#, fuzzy
 msgid "Postscript Options:"
-msgstr "Opcje PostScript"
+msgstr "Opcje PostScript:"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:300
 msgid "Set global X scale adjust for exact scale postscript output."
-msgstr "Ustawia globalną skalę w osi X dla dostrojenia skali rysunku Postscipt"
+msgstr ""
+"Ustawia globalną skalę w osi X dla dostrojenia skali rysunku Postscipt."
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:315
 msgid "Set global Y scale adjust for exact scale postscript output."
-msgstr "Ustawia globalną skalę w osi Y dla dostrojenia skali rysunku Postscipt"
+msgstr ""
+"Ustawia globalną skalę w osi Y dla dostrojenia skali rysunku Postscipt."
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:325
-#, fuzzy
 msgid "Width correction:"
-msgstr "Korekcja szerokości"
+msgstr "Korekcja szerokości:"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:330
 msgid ""
@@ -21854,13 +21977,12 @@ msgid "Force A4 output"
 msgstr "Wymuś format A4"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:346
-#, fuzzy
 msgid "DXF options:"
-msgstr "Opcje DXF"
+msgstr "Opcje DXF:"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:348
 msgid "Plot all layers in outline (polygon) mode"
-msgstr ""
+msgstr "Rysuj wszystkie warstwy w trybie obrusu (za pomocą stref)"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:350
 msgid ""
@@ -21870,16 +21992,25 @@ msgid ""
 "*_User, Edge.Cuts, Margin, *.CrtYd, *.Fab)\n"
 "and plot in polygon mode other layers (*.Cu, *.Adhes, *.Paste, *.Mask)"
 msgstr ""
+"Tylko DXF:\n"
+"Zaznacz by rysować wszystkie warstwy w trybie polygonu.\n"
+"Odznacz rysowanie w trybie uproszczonym warstwy, które nie wspierają "
+"umieszczania na nich stref (*.SilkS, *_User, Edge.Cuts, Margin, *.CrtYd, *."
+"Fab)\n"
+"i rysuj pozostałe warstwy (*.Cu, *.Adhes, *.Paste, *.Mask) w trybie poligonu."
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:354
 msgid "Use Pcbnew font to plot texts"
-msgstr ""
+msgstr "Użyj czcionek Pcbnew do rysowania tekstu"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:355
 msgid ""
 "Check to use Pcbnew stroke font\n"
 "Uncheck to plot oneline ASCII texts as editable text (using DXF font)"
 msgstr ""
+"Zaznacz by użyć czcionek programu Pcbnew\n"
+"Odznacz by rysować teksty ASCII jako tekst dający się edytować (używając "
+"czcionki DXF)"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:381
 msgid "Run DRC..."
@@ -21911,7 +22042,7 @@ msgstr "Przerwa pomiędzy ścieżkami:"
 
 #: pcbnew/dialogs/dialog_pns_diff_pair_dimensions_base.cpp:49
 msgid "Via gap:"
-msgstr "Przerwa pomiędzy przelotkami"
+msgstr "Przerwa pomiędzy przelotkami:"
 
 #: pcbnew/dialogs/dialog_pns_diff_pair_dimensions_base.cpp:69
 msgid "Via gap same as trace gap"
@@ -21936,12 +22067,11 @@ msgstr "Dostrajanie odchyłek par różnicowych"
 
 #: pcbnew/dialogs/dialog_pns_length_tuning_settings.cpp:77
 msgid "Target skew: "
-msgstr "Docelowa odchyłka:"
+msgstr "Docelowa odchyłka: "
 
 #: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:22
-#, fuzzy
 msgid "Length / Skew"
-msgstr "Długość/Odchyłka"
+msgstr "Długość / Odchyłka"
 
 #: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:30
 msgid "Tune from:"
@@ -21957,11 +22087,11 @@ msgstr "Ograniczenie:"
 
 #: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:58
 msgid "From Design Rules"
-msgstr "z Reguł projektowych"
+msgstr "Z reguł projektowych"
 
 #: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:58
 msgid "Manual"
-msgstr "ręcznie"
+msgstr "Ręcznie"
 
 #: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:69
 msgid "Target length:"
@@ -21969,7 +22099,7 @@ msgstr "Docelowa długość:"
 
 #: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:87
 msgid "Meandering"
-msgstr "Meanderowanie"
+msgstr "Meandrowanie"
 
 #: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:98
 msgid "Min amplitude (Amin):"
@@ -21993,7 +22123,7 @@ msgstr "Kąt 45 stopni"
 
 #: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:135
 msgid "arc"
-msgstr "Łukowate"
+msgstr "łukowate"
 
 #: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:144
 msgid "Miter radius (r):"
@@ -22001,7 +22131,7 @@ msgstr "Promień zaokrąglenia (r):"
 
 #: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.h:79
 msgid "Trace Length Tuning"
-msgstr "Strojenie długości ścieżki"
+msgstr "Dostrajanie długości ścieżek"
 
 #: pcbnew/dialogs/dialog_pns_settings.cpp:34
 msgid "DRC violation: highlight obstacles"
@@ -22028,9 +22158,8 @@ msgid "Walk around"
 msgstr "Omijaj przeszkody"
 
 #: pcbnew/dialogs/dialog_pns_settings_base.cpp:21
-#, fuzzy
 msgid "Mode:"
-msgstr "Tryb"
+msgstr "Tryb:"
 
 #: pcbnew/dialogs/dialog_pns_settings_base.cpp:34
 msgid "Mouse drag behavior:"
@@ -22042,7 +22171,7 @@ msgstr "Przesuń element"
 
 #: pcbnew/dialogs/dialog_pns_settings_base.cpp:38
 msgid "Interactive drag"
-msgstr "Interaktywne przeciągnięcie"
+msgstr "Interaktywne przeciąganie"
 
 #: pcbnew/dialogs/dialog_pns_settings_base.cpp:47
 msgid "Free angle mode (no shove/walkaround)"
@@ -22092,7 +22221,7 @@ msgstr ""
 
 #: pcbnew/dialogs/dialog_pns_settings_base.cpp:66
 msgid "Optimize pad connections"
-msgstr ""
+msgstr "Optymalizuj łącza pól lutowniczych"
 
 #: pcbnew/dialogs/dialog_pns_settings_base.cpp:67
 msgid ""
@@ -22131,9 +22260,8 @@ msgid "Suggest track finish"
 msgstr "Proponuj zakończenie ścieżki"
 
 #: pcbnew/dialogs/dialog_pns_settings_base.cpp:92
-#, fuzzy
 msgid "Optimizer effort:"
-msgstr "Głębokość optymalizacji"
+msgstr "Głębokość optymalizacji:"
 
 #: pcbnew/dialogs/dialog_pns_settings_base.cpp:94
 msgid ""
@@ -22149,56 +22277,55 @@ msgstr ""
 
 #: pcbnew/dialogs/dialog_pns_settings_base.cpp:110
 msgid "low"
-msgstr "Niska"
+msgstr "niska"
 
 #: pcbnew/dialogs/dialog_pns_settings_base.cpp:119
 msgid "high"
-msgstr "Wysoka"
+msgstr "wysoka"
 
 #: pcbnew/dialogs/dialog_pns_settings_base.h:70
 msgid "Interactive Router Settings"
 msgstr "Ustawienia interaktywnego routera"
 
 #: pcbnew/dialogs/dialog_position_relative.cpp:144
-#, fuzzy
 msgid "Distance from anchor:"
-msgstr "Dodaj zakotwiczenie"
+msgstr "Odległość od zakotwiczenia:"
 
 #: pcbnew/dialogs/dialog_position_relative.cpp:151
-#, fuzzy
 msgid "Position from anchor X:"
-msgstr "Pozycja X:"
+msgstr "Pozycja X od punktu zaczepienia:"
 
 #: pcbnew/dialogs/dialog_position_relative.cpp:152
-#, fuzzy
 msgid "Position from anchor Y:"
-msgstr "Pozycja Y:"
+msgstr "Pozycja Y od punktu zaczepienia:"
 
 #: pcbnew/dialogs/dialog_position_relative_base.cpp:21
 #: pcbnew/dialogs/dialog_position_relative_base.cpp:82
 msgid "The Anchor position is the origin of coordinates for the transform."
 msgstr ""
+"Pozycja punktu zaczepienia jest punktem bazowym dla współrzędnych przy "
+"transformacji."
 
 #: pcbnew/dialogs/dialog_position_relative_base.cpp:80
-#, fuzzy
 msgid "Anchor position X:"
-msgstr "Ustaw pozycję zakotwiczenia"
+msgstr "Pozycja zakotwiczenia X:"
 
 #: pcbnew/dialogs/dialog_position_relative_base.cpp:105
-#, fuzzy
 msgid "Select Anchor Position"
-msgstr "Ustaw pozycję zakotwiczenia"
+msgstr "Wybierz pozycję zakotwiczenia"
 
 #: pcbnew/dialogs/dialog_position_relative_base.cpp:106
 msgid ""
 "Click and select a board item.\n"
 "The anchor position will be the position of the selected item."
 msgstr ""
+"Kliknij i wybierz element z płytki.\n"
+"Punkt zaczepienia będzie pozycją wybranego elementu."
 
 #: pcbnew/dialogs/dialog_position_relative_base.h:78
 #: pcbnew/tools/position_relative_tool.cpp:152
 msgid "Position Relative"
-msgstr ""
+msgstr "Pozycja względna"
 
 #: pcbnew/dialogs/dialog_print_for_modedit.cpp:98
 msgid "An error occurred initializing the printer information."
@@ -22227,7 +22354,7 @@ msgstr "Skala 16"
 
 #: pcbnew/dialogs/dialog_print_using_printer_base.cpp:56
 msgid "Exclude PCB edge layer"
-msgstr "Wyłącz warstwę krawędzi płytki"
+msgstr "Wyłącz warstwę Edge"
 
 #: pcbnew/dialogs/dialog_print_using_printer_base.cpp:57
 msgid "Exclude contents of Edges_Pcb layer from all other layers"
@@ -22235,20 +22362,19 @@ msgstr "Pomiń zawartość warstwy krawędzi PCB na pozostałych warstwach"
 
 #: pcbnew/dialogs/dialog_print_using_printer_base.cpp:67
 msgid "Approx. scale 1"
-msgstr "Przybliżona skala 1"
+msgstr "Przybliżona skala 1:1"
 
 #: pcbnew/dialogs/dialog_print_using_printer_base.cpp:73
 msgid "X scale adjust:"
-msgstr "Dopasuj skalę w osi X:"
+msgstr "Poprawka skali X:"
 
 #: pcbnew/dialogs/dialog_print_using_printer_base.cpp:82
 msgid "Y scale adjust:"
-msgstr "Dopasuj skalę w osi Y:"
+msgstr "Poprawka skali Y:"
 
 #: pcbnew/dialogs/dialog_print_using_printer_base.cpp:98
-#, fuzzy
 msgid "Generic Options:"
-msgstr "Ogólne ustawienia"
+msgstr "Podstawowe ustawienia:"
 
 #: pcbnew/dialogs/dialog_print_using_printer_base.cpp:109
 msgid "Print frame ref"
@@ -22256,7 +22382,7 @@ msgstr "Drukuj oznaczenia arkusza"
 
 #: pcbnew/dialogs/dialog_print_using_printer_base.cpp:111
 msgid "Print Frame references."
-msgstr ""
+msgstr "Drukuj referencje ramki."
 
 #: pcbnew/dialogs/dialog_print_using_printer_base.cpp:121
 msgid "No drill mark"
@@ -22271,35 +22397,32 @@ msgid "Real drill"
 msgstr "Rzeczywiste otwory"
 
 #: pcbnew/dialogs/dialog_print_using_printer_base.cpp:123
-#, fuzzy
 msgid "Pads Drill Options:"
-msgstr "Ustawienia wiercenia pól lutowniczych"
+msgstr "Opcje wiercenia pól lutowniczych:"
 
 #: pcbnew/dialogs/dialog_print_using_printer_base.cpp:141
 msgid "1 Page per layer"
-msgstr "1 strona na warstwę"
+msgstr "Jedna strona na warstwę"
 
 #: pcbnew/dialogs/dialog_print_using_printer_base.cpp:141
 msgid "Single page"
 msgstr "Pojedyncza strona"
 
 #: pcbnew/dialogs/dialog_print_using_printer_base.cpp:143
-#, fuzzy
 msgid "Page Print:"
-msgstr "Wydruk strony"
+msgstr "Wydruk strony:"
 
 #: pcbnew/dialogs/dialog_select_net_from_list_base.cpp:25
-#, fuzzy
 msgid "Net name filter:"
-msgstr "Filtr nazw sieci połączeń"
+msgstr "Filtrowanie nazw sieci:"
 
 #: pcbnew/dialogs/dialog_select_net_from_list_base.cpp:32
 msgid "Show zero pad nets"
-msgstr ""
+msgstr "Pokaż sieci niepodłączone"
 
 #: pcbnew/dialogs/dialog_select_net_from_list_base.cpp:55
 msgid "Number of pads"
-msgstr ""
+msgstr "Liczba pól"
 
 #: pcbnew/dialogs/dialog_select_pretty_lib_base.cpp:19
 msgid ""
@@ -22318,10 +22441,10 @@ msgid "Select a folder"
 msgstr "Wybierz folder"
 
 #: pcbnew/dialogs/dialog_select_pretty_lib_base.cpp:34
-#, fuzzy
 msgid "Library folder (.pretty will be added to name, if missing):"
 msgstr ""
-"Folder bibliotek (roszerzenie .pretty zostanie dołączone jeśli nie występuje)"
+"Folder bibliotek (rozszerzenie .pretty zostanie dołączone jeśli nie "
+"występuje)"
 
 #: pcbnew/dialogs/dialog_select_pretty_lib_base.h:57
 msgid "Select Footprint Library Folder"
@@ -22342,23 +22465,20 @@ msgstr ""
 "mniejszy lub równy %.3f mm)"
 
 #: pcbnew/dialogs/dialog_set_grid_base.cpp:23
-#, fuzzy
 msgid "Grid Origin:"
-msgstr "Punkt bazowy siatki"
+msgstr "Punkt bazowy siatki:"
 
 #: pcbnew/dialogs/dialog_set_grid_base.cpp:56 pcbnew/hotkeys.cpp:170
 msgid "Reset Grid Origin"
 msgstr "Zresetuj punkt bazowy"
 
 #: pcbnew/dialogs/dialog_set_grid_base.cpp:66
-#, fuzzy
 msgid "User Defined Grid:"
-msgstr "Siatka użytkownika"
+msgstr "Siatka użytkownika:"
 
 #: pcbnew/dialogs/dialog_set_grid_base.cpp:103
-#, fuzzy
 msgid "Fast Switching:"
-msgstr "Szybkie przełączanie: (Alt+1, Alt+2)"
+msgstr "Szybkie przełączanie:"
 
 #: pcbnew/dialogs/dialog_set_grid_base.cpp:111
 msgid "Grid 1:"
@@ -22402,30 +22522,27 @@ msgstr "Rozmiar wiercenia musi być mniejszy niż rozmiar przelotki"
 
 #: pcbnew/dialogs/dialog_track_via_properties.cpp:629
 msgid "Via start layer and end layer cannot be the same"
-msgstr ""
+msgstr "Warstwa początkowa i końcowa przelotki nie może być taka sama"
 
 #: pcbnew/dialogs/dialog_track_via_properties_base.cpp:22
-#, fuzzy
 msgid "Common:"
-msgstr "Wspólne"
+msgstr "Wspólne:"
 
 #: pcbnew/dialogs/dialog_track_via_properties_base.cpp:28
 msgid "Combo!"
-msgstr ""
+msgstr "Kombo!"
 
 #: pcbnew/dialogs/dialog_track_via_properties_base.cpp:37
-#, fuzzy
 msgid "Tracks:"
-msgstr "Ścieżki"
+msgstr "Ścieżki:"
 
 #: pcbnew/dialogs/dialog_track_via_properties_base.cpp:110
 msgid "Use net class width"
 msgstr "Użyj szerokości z klasy sieci"
 
 #: pcbnew/dialogs/dialog_track_via_properties_base.cpp:132
-#, fuzzy
 msgid "Vias:"
-msgstr "Przelotki"
+msgstr "Przelotki:"
 
 #: pcbnew/dialogs/dialog_track_via_properties_base.cpp:161
 msgid "Diameter:"
@@ -22437,7 +22554,7 @@ msgstr "Wiercenie:"
 
 #: pcbnew/dialogs/dialog_track_via_properties_base.cpp:191
 msgid "Design rule vias:"
-msgstr ""
+msgstr "Reguły projektowe przelotek:"
 
 #: pcbnew/dialogs/dialog_track_via_properties_base.cpp:204
 msgid "Via type:"
@@ -22445,23 +22562,23 @@ msgstr "Typ przelotki:"
 
 #: pcbnew/dialogs/dialog_track_via_properties_base.cpp:208
 msgid "Through"
-msgstr ""
+msgstr "Na wylot"
 
 #: pcbnew/dialogs/dialog_track_via_properties_base.cpp:208
 msgid "Micro"
-msgstr "Mikro"
+msgstr "Mikroprzelotka"
 
 #: pcbnew/dialogs/dialog_track_via_properties_base.cpp:208
 msgid "Blind/buried"
-msgstr ""
+msgstr "Ślepa/Zagrzebana"
 
 #: pcbnew/dialogs/dialog_track_via_properties_base.cpp:219
 msgid "Start layer:"
-msgstr ""
+msgstr "Początkowa warstwa:"
 
 #: pcbnew/dialogs/dialog_track_via_properties_base.cpp:229
 msgid "End layer:"
-msgstr ""
+msgstr "Końcowa warstwa:"
 
 #: pcbnew/dialogs/dialog_track_via_properties_base.cpp:242
 msgid "Use net class size"
@@ -22485,33 +22602,36 @@ msgstr "Otwór przelotki:"
 
 #: pcbnew/dialogs/dialog_track_via_size_base.h:57
 msgid "Track Width and Via Size"
-msgstr "Szerokości ścieżek i rozmiar przelotek"
+msgstr "Szerokość ścieżki i rozmiar przelotki"
 
 #: pcbnew/dialogs/dialog_update_pcb.cpp:50
 msgid "Changes to be applied:"
-msgstr ""
+msgstr "Lista zmian do wykonania:"
 
 #: pcbnew/dialogs/dialog_update_pcb.cpp:98
 msgid ""
 "Failed to load one or more footprints. Please add the missing libraries in "
 "PCBNew configuration. The PCB will not update completely."
 msgstr ""
+"Próba załadowania jednego lub więcej footprintów nie powiodła się. Proszę "
+"dodać brakujące biblioteki do właściwych tabel bibliotek. PCB nie zostało w "
+"pełni uaktualnione."
 
 #: pcbnew/dialogs/dialog_update_pcb.cpp:159
 msgid "Update complete"
-msgstr "Aktualizacja kompletna"
+msgstr "Aktualizacja ukończona"
 
 #: pcbnew/dialogs/dialog_update_pcb.cpp:173
 msgid "Changes applied to the PCB:"
-msgstr ""
+msgstr "Zmiany wprowadzone na PCB:"
 
 #: pcbnew/dialogs/dialog_update_pcb_base.cpp:26
 msgid "Match footprints by:"
-msgstr ""
+msgstr "Dopasowuj footprinty za pomocą:"
 
 #: pcbnew/dialogs/dialog_update_pcb_base.cpp:58
 msgid "Update PCB"
-msgstr "Aktualizacja PCB"
+msgstr "Uaktualnij PCB"
 
 #: pcbnew/dialogs/wizard_3DShape_Libs_downloader.cpp:299
 msgid "Choose a folder to save the downloaded libraries"
@@ -22521,7 +22641,7 @@ msgstr "Wybierz folder gdzie skopiować pobrane bibloteki"
 msgid "KISYS3DMOD path not defined , or not existing"
 msgstr ""
 "Ścieżka w zmiennej KISYS3DMOD nie została zdefiniowana, lub zmienna ta nie "
-"istnieje."
+"istnieje"
 
 #: pcbnew/dialogs/wizard_3DShape_Libs_downloader.cpp:360
 msgid "Downloading 3D libraries"
@@ -22599,7 +22719,7 @@ msgid ""
 "Now, forced on the drawings layer. Please, fix it"
 msgstr ""
 "Ten element posiada niepoprawny identyfikator warstwy.\n"
-"Obecnie został przeniesiony na warstwę rysunkową. Proszę to poprawić."
+"Obecnie został przeniesiony na warstwę rysunkową. Proszę to poprawić"
 
 #: pcbnew/dimension.cpp:170
 msgid ""
@@ -22617,7 +22737,7 @@ msgstr ""
 
 #: pcbnew/dimension.cpp:233
 msgid "Modified dimensions properties"
-msgstr ""
+msgstr "Modyfikuj właściwości wymiarowania"
 
 #: pcbnew/drc.cpp:416
 msgid "Aborting\n"
@@ -22633,17 +22753,15 @@ msgstr "Prześwity ścieżek...\n"
 
 #: pcbnew/drc.cpp:451
 msgid "Refilling all zones...\n"
-msgstr "Wypełnij wszystkie strefy...\n"
+msgstr "Wypełnieniam wszystkie strefy...\n"
 
 #: pcbnew/drc.cpp:458
-#, fuzzy
 msgid "Checking zone fills...\n"
-msgstr "Obliczanie wypełnienia strefy ..."
+msgstr "Sprawdzanie wypełnień stref...\n"
 
 #: pcbnew/drc.cpp:466
-#, fuzzy
 msgid "Zone to zone clearances...\n"
-msgstr "Prześwity pól lutowniczych...\n"
+msgstr "Prześwit pomiędzy strefami...\n"
 
 #: pcbnew/drc.cpp:477
 msgid "Unconnected pads...\n"
@@ -22659,75 +22777,82 @@ msgstr "Sprawdzanie tekstów...\n"
 
 #: pcbnew/drc.cpp:510
 msgid "Courtyard areas...\n"
-msgstr ""
+msgstr "Obszary Courtyard...\n"
 
 #: pcbnew/drc.cpp:522
-#, fuzzy
 msgid "Items on disabled layers...\n"
-msgstr "Uwzględnij elementy z niewidocznych warstw"
+msgstr "Elementy z wyłączonych warstw...\n"
 
 #: pcbnew/drc.cpp:573
 #, c-format
 msgid "NETCLASS: \"%s\" has Clearance:%s which is less than global:%s"
 msgstr ""
+"NETCLASS: \"%s\" posiada prześwit: %s który jest mniejszy niż globalny: %s"
 
 #: pcbnew/drc.cpp:587
 #, c-format
 msgid "NETCLASS: \"%s\" has TrackWidth:%s which is less than global:%s"
 msgstr ""
+"NETCLASS: \"%s\" posiada szerokość: %s która jest mniejsza niż globalna: %s"
 
 #: pcbnew/drc.cpp:600
 #, c-format
 msgid "NETCLASS: \"%s\" has Via Dia:%s which is less than global:%s"
 msgstr ""
+"NETCLASS: \"%s\" posiada rozmiar: %s który jest mniejszy niż globalny: %s"
 
 #: pcbnew/drc.cpp:613
 #, c-format
 msgid "NETCLASS: \"%s\" has Via Drill:%s which is less than global:%s"
 msgstr ""
+"NETCLASS: \"%s\" posiada otwór: %s który jest mniejszy niż globalny: %s"
 
 #: pcbnew/drc.cpp:626
 #, c-format
 msgid "NETCLASS: \"%s\" has uVia Dia:%s which is less than global:%s"
 msgstr ""
+"NETCLASS: \"%s\" posiada rozmiar mikroprzelotki: %s który jest mniejszy niż "
+"globalny: %s"
 
 #: pcbnew/drc.cpp:639
 #, c-format
 msgid "NETCLASS: \"%s\" has uVia Drill:%s which is less than global:%s"
 msgstr ""
+"NETCLASS: \"%s\" posiada otwór mikroprzelotki: %s który jest mniejszy niż "
+"globalny: %s"
 
 #: pcbnew/drc.cpp:737
 msgid "Track clearances"
 msgstr "Prześwity ścieżek"
 
 #: pcbnew/drc.cpp:1035
-#, fuzzy, c-format
+#, c-format
 msgid "\"%s\" is on a disabled layer"
-msgstr "%d nie jest prawidłową liczbą warstw"
+msgstr "\"%s\" znajduje się na wyłączonej warstwie"
 
 #: pcbnew/drc.cpp:1261
 #, c-format
 msgid "footprint \"%s\" has malformed courtyard"
-msgstr ""
+msgstr "footprint \"%s\" ma niepoprawny kształt zajmowanego obszaru"
 
 #: pcbnew/drc.cpp:1278
 #, c-format
 msgid "footprint \"%s\" has no courtyard defined"
-msgstr ""
+msgstr "footprint \"%s\" nie ma zdefiniowanego zajmowanego obszaru"
 
 #: pcbnew/drc.cpp:1317
 #, c-format
 msgid "footprints \"%s\" and \"%s\" overlap on front (top) layer"
-msgstr ""
+msgstr "footprinty \"%s\" i \"%s\" nachodzą na siebie na warstwie górnej"
 
 #: pcbnew/drc.cpp:1354
 #, c-format
 msgid "footprints \"%s\" and \"%s\" overlap on back (bottom) layer"
-msgstr ""
+msgstr "footprinty \"%s\" i \"%s\" nachodzą na siebie na warstwie dolnej"
 
 #: pcbnew/drc_item.cpp:43
 msgid "Unconnected items"
-msgstr ""
+msgstr "Niepołączone elementy"
 
 #: pcbnew/drc_item.cpp:45
 msgid "Track near thru-hole"
@@ -22775,16 +22900,15 @@ msgstr "Mikroprzeltoka: nieprawidłowa para warstw (nie przylegają)"
 
 #: pcbnew/drc_item.cpp:75
 msgid "Micro Via: not allowed"
-msgstr "Mikro przelotka: niedozwolona"
+msgstr "Mikroprzelotka: niedozwolona"
 
 #: pcbnew/drc_item.cpp:77
 msgid "Buried Via: not allowed"
-msgstr "Przelotka zagrzebana\" nie dozwolona"
+msgstr "Przelotki zagrzebane: niedozwolone"
 
 #: pcbnew/drc_item.cpp:79
-#, fuzzy
 msgid "Item on a disabled layer"
-msgstr "Uwzględnij elementy z niewidocznych warstw"
+msgstr "Element na wyłączonej warstwie"
 
 #: pcbnew/drc_item.cpp:81
 msgid "Copper area inside copper area"
@@ -22798,7 +22922,7 @@ msgstr "Obszary miedzi przecinają się lub są zbyt blisko"
 msgid "Copper area belongs a net which has no pads. This is strange"
 msgstr ""
 "Strefa miedzi należy do sieci nie mającej pól lutowniczych.\n"
-"Taka sytuacja nie powinna wystąpić."
+"Taka sytuacja nie powinna wystąpić"
 
 #: pcbnew/drc_item.cpp:89
 msgid "Hole near pad"
@@ -22822,11 +22946,11 @@ msgstr "Za mały wymiar mikro przelotki"
 
 #: pcbnew/drc_item.cpp:99
 msgid "Too small via drill"
-msgstr ""
+msgstr "Za mały otwór przelotki"
 
 #: pcbnew/drc_item.cpp:101
 msgid "Too small micro via drill"
-msgstr ""
+msgstr "Za mały otwór mikroprzelotki"
 
 #: pcbnew/drc_item.cpp:105
 msgid "NetClass Track Width &lt; global limit"
@@ -22879,25 +23003,26 @@ msgstr "Pole lutownicze wewnątrz tekstu"
 
 #: pcbnew/drc_item.cpp:136
 msgid "Courtyards overlap"
-msgstr ""
+msgstr "Pola zajętości zachodzą na siebie"
 
 #: pcbnew/drc_item.cpp:139
 msgid "Footprint has no courtyard defined"
-msgstr ""
+msgstr "Footprint nie ma określonego pola zajętości"
 
 #: pcbnew/drc_item.cpp:142
 msgid "Footprint has incorrect courtyard (not a closed shape)"
-msgstr ""
+msgstr "Footprint posiada błędne pole zajętości (nie jest zamkniętym obszarem)"
 
 #: pcbnew/eagle_plugin.cpp:826
 #, c-format
 msgid "<package> name: \"%s\" duplicated in eagle <library>: \"%s\""
 msgstr ""
+"nazwa <package>: \"%s\" zduplikowana w bibliotece EAGLE <library>: \"%s\""
 
 #: pcbnew/eagle_plugin.cpp:898
 #, c-format
 msgid "No \"%s\" package in library \"%s\""
-msgstr ""
+msgstr "Nie ma obudowy \"%s\" w bibliotece \"%s\""
 
 #: pcbnew/eagle_plugin.cpp:1405
 #, c-format
@@ -22905,6 +23030,9 @@ msgid ""
 "Line on copper layer in package %s (%f mm, %f mm) (%f mm, %f mm).\n"
 "Moving to Dwgs.User layer"
 msgstr ""
+"Linia graficzna na warstwie miedzi w obudowie %s (%f mm, %f mm) (%f mm, %f "
+"mm).\n"
+"Przesunięto na warstwę Dwgs.User"
 
 #: pcbnew/eagle_plugin.cpp:1526
 #, c-format
@@ -22912,6 +23040,8 @@ msgid ""
 "Unsupported text on copper layer in package %s.\n"
 "Moving to Dwgs.User layer."
 msgstr ""
+"Nieobsługiwany tekst na warstwie miedzi w obudowie %s.\n"
+"Przesunięto na warstwę Dwgs.User"
 
 #: pcbnew/eagle_plugin.cpp:1640
 #, c-format
@@ -22919,6 +23049,8 @@ msgid ""
 "Unsupported rectangle on copper layer in package %s.\n"
 "Moving to Dwgs.User layer."
 msgstr ""
+"Nieobsługiwany prostokąt na warstwie miedzi w obudowie %s.\n"
+"Przesunięto na warstwę Dwgs.User"
 
 #: pcbnew/eagle_plugin.cpp:1683
 #, c-format
@@ -22926,6 +23058,8 @@ msgid ""
 "Unsupported polygon on copper layer in package %s.\n"
 "Moving to Dwgs.User layer."
 msgstr ""
+"Nieobsługiwane wypełnienie na warstwie miedzi w obudowie %s.\n"
+"Przesunięto na warstwę Dwgs.User"
 
 #: pcbnew/eagle_plugin.cpp:1768
 #, c-format
@@ -22933,11 +23067,15 @@ msgid ""
 "Unsupported circle on copper layer in package %s.\n"
 "Moving to Dwgs.User layer."
 msgstr ""
+"Nieobsługiwany okrąg na warstwie miedzi w obudowie %s.\n"
+"Przesunięto na warstwę Dwgs.User"
 
 #: pcbnew/eagle_plugin.cpp:2225
 #, c-format
 msgid "Unsupported Eagle layer '%s' (%d), converted to Dwgs.User layer"
 msgstr ""
+"Nieobsługiwana warstwa '%s' (%d) programu EAGLE, skonwertowana na warstwę "
+"Dwgs.User"
 
 #: pcbnew/edgemod.cpp:214
 msgid ""
@@ -23054,10 +23192,12 @@ msgid ""
 "Unable to calculate the board outlines; fall back to using the board "
 "boundary box."
 msgstr ""
+"Nie można obliczyć krawędzi płytki; cofnij się do opcji użycia pola "
+"ograniczającego."
 
 #: pcbnew/exporters/export_vrml.cpp:883
 msgid "VRML Export Failed: Could not add holes to contours."
-msgstr "Eksport VRML nie powiódł się: nie można dodać otworów do konturów."
+msgstr "Eksport VRML nie powiódł się: Nie można dodać otworów do konturów."
 
 #: pcbnew/exporters/gen_footprints_placefile.cpp:251
 msgid "No footprint for automated placement."
@@ -23071,12 +23211,12 @@ msgstr "Nie można utworzyć \"%s\"."
 #: pcbnew/exporters/gen_footprints_placefile.cpp:305
 #, c-format
 msgid "Place file: \"%s\"."
-msgstr "Umieść plik: \"%s\"."
+msgstr "Umieszczenie pliku \"%s\"."
 
 #: pcbnew/exporters/gen_footprints_placefile.cpp:307
 #, c-format
 msgid "Front side (top side) place file: \"%s\"."
-msgstr ""
+msgstr "Plik położeń na stronie górnej: \"%s\"."
 
 #: pcbnew/exporters/gen_footprints_placefile.cpp:311
 #: pcbnew/exporters/gen_footprints_placefile.cpp:352
@@ -23087,12 +23227,12 @@ msgstr "Liczba komponentów: %d."
 #: pcbnew/exporters/gen_footprints_placefile.cpp:316
 #: pcbnew/exporters/gen_footprints_placefile.cpp:364
 msgid "Component Placement File generation OK."
-msgstr ""
+msgstr "Plik położeń footprintów został poprawnie wygenerowany."
 
 #: pcbnew/exporters/gen_footprints_placefile.cpp:349
 #, c-format
 msgid "Back side (bottom side) place file: \"%s\"."
-msgstr ""
+msgstr "Plik położeń na stronie dolnej: \"%s\"."
 
 #: pcbnew/exporters/gen_footprints_placefile.cpp:360
 #, c-format
@@ -23105,6 +23245,8 @@ msgid ""
 "Footprint report file created:\n"
 "\"%s\""
 msgstr ""
+"Raport o footprintach został utworzony:\n"
+"\"%s\""
 
 #: pcbnew/exporters/gen_footprints_placefile.cpp:639
 msgid "Footprint Report"
@@ -23120,12 +23262,12 @@ msgstr "Tworzenie pliku %s\n"
 #: pcbnew/exporters/gerber_jobfile_writer.cpp:128
 #, c-format
 msgid "Unable to create job file \"%s\""
-msgstr ""
+msgstr "Nie można utworzyć pliku zadań \"%s\""
 
 #: pcbnew/exporters/gerber_jobfile_writer.cpp:134
 #, c-format
 msgid "Create Gerber job file \"%s\""
-msgstr ""
+msgstr "Tworzenie pliku zadań Gerber \"%s\""
 
 #: pcbnew/files.cpp:143
 msgid "Open Board File"
@@ -23133,7 +23275,7 @@ msgstr "Otwórz plik PCB"
 
 #: pcbnew/files.cpp:143
 msgid "Import Non KiCad Board File"
-msgstr "Import innych plików płytek spoza KiCad"
+msgstr "Importuj płytkę spoza programu KiCad"
 
 #: pcbnew/files.cpp:179
 msgid "Save Board File As"
@@ -23146,12 +23288,12 @@ msgstr "Wydrukuj obwód drukowany"
 #: pcbnew/files.cpp:283
 #, c-format
 msgid "Recovery file \"%s\" not found."
-msgstr "Nie znaleziono pliku odzyskiwania \"%s\"."
+msgstr "Plik odzyskiwania \"%s\" nie został znaleziony."
 
 #: pcbnew/files.cpp:289
 #, c-format
 msgid "OK to load recovery or backup file \"%s\""
-msgstr "Kliknij OK, aby załadować plik odzyskiwania lub kopię zapasową \"%s\""
+msgstr "OK by załadować plik zapasowy lub odzyskiwania \"%s\""
 
 #: pcbnew/files.cpp:351
 msgid "noname"
@@ -23160,7 +23302,7 @@ msgstr "bez_nazwy"
 #: pcbnew/files.cpp:425
 #, c-format
 msgid "PCB file \"%s\" is already open."
-msgstr "Plik PCB \"% s\" jest już otwarty."
+msgstr "Plik PCB \"%s\" jest już otwarty."
 
 #: pcbnew/files.cpp:435
 msgid "The current board has been modified.  Do you wish to save the changes?"
@@ -23169,7 +23311,8 @@ msgstr "Bieżąca płytka została zmieniona. Czy chcesz zapisać dokonane zmian
 #: pcbnew/files.cpp:461
 #, c-format
 msgid "Board \"%s\" does not exist.  Do you wish to create it?"
-msgstr "Płyta \"% s\" nie istnieje. Czy chcesz ją utworzyć?"
+msgstr ""
+"Plik z obwodem drukowanym \"%s\" nie istnieje.  Czy chcesz go teraz utworzyć?"
 
 #: pcbnew/files.cpp:526
 #, c-format
@@ -23177,7 +23320,7 @@ msgid ""
 "Error loading board file:\n"
 "%s"
 msgstr ""
-"Błąd podczas ładowania pliku płytki:\n"
+"Błąd wczytywania pliku obwodu drukowanego:\n"
 "%s"
 
 #: pcbnew/files.cpp:548
@@ -23191,12 +23334,12 @@ msgstr ""
 #: pcbnew/files.cpp:629
 #, c-format
 msgid "Warning: unable to create backup file \"%s\""
-msgstr ""
+msgstr "Ostrzeżenie: nie można utworzyć pliku zapasowego \"%s\""
 
 #: pcbnew/files.cpp:656 pcbnew/files.cpp:749
 #, c-format
 msgid "No access rights to write to file \"%s\""
-msgstr ""
+msgstr "Nie ma uprawnień by zapisywać w pliku \"%s\""
 
 #: pcbnew/files.cpp:695 pcbnew/files.cpp:774
 #, c-format
@@ -23204,11 +23347,13 @@ msgid ""
 "Error saving board file \"%s\".\n"
 "%s"
 msgstr ""
+"Błąd podczas zapisu pliku obwodu drukowanego \"%s\".\n"
+"%s"
 
 #: pcbnew/files.cpp:701
 #, c-format
 msgid "Failed to create \"%s\""
-msgstr "Nie można utworzyć \"%s\""
+msgstr "Niepowodzenie przy tworzeniu \"%s\""
 
 #: pcbnew/files.cpp:727
 #, c-format
@@ -23218,7 +23363,7 @@ msgstr "Plik kopii zapasowej: \"%s\""
 #: pcbnew/files.cpp:729
 #, c-format
 msgid "Wrote board file: \"%s\""
-msgstr "Zapis pliku płytki: \"%s\""
+msgstr "Zapisano plik obwodu drukowanego: \"%s\""
 
 #: pcbnew/files.cpp:783
 #, c-format
@@ -23226,7 +23371,7 @@ msgid ""
 "Board copied to:\n"
 "\"%s\""
 msgstr ""
-"Kopiowanie płytki do:\n"
+"Obwód został skopiowany do:\n"
 "\"%s\""
 
 #: pcbnew/files.cpp:893 pcbnew/footprint_edit_frame.cpp:878
@@ -23242,13 +23387,12 @@ msgstr ""
 "%s"
 
 #: pcbnew/footprint_edit_frame.cpp:528
-#, fuzzy
 msgid "Save changes to footprint before closing?"
 msgstr "Zapisać zmiany w footprincie przed zamknięciem?"
 
 #: pcbnew/footprint_edit_frame.cpp:736
 msgid "no active library"
-msgstr " Brak aktywnej biblioteki"
+msgstr "brak aktywnej biblioteki"
 
 #: pcbnew/footprint_edit_frame.cpp:858 pcbnew/pcbnew_config.cpp:110
 #, c-format
@@ -23263,7 +23407,7 @@ msgstr ""
 
 #: pcbnew/footprint_editor_onclick.cpp:257
 msgid "Duplicate Block (shift + drag mouse)"
-msgstr ""
+msgstr "Duplikuje blok (Shift + Przeciąganie myszą)"
 
 #: pcbnew/footprint_editor_onclick.cpp:260
 msgid "Mirror Block (alt + drag mouse)"
@@ -23309,13 +23453,13 @@ msgstr "Edytuj pole..."
 #: pcbnew/footprint_editor_onclick.cpp:320 pcbnew/onrightclick.cpp:912
 #: pcbnew/tools/pad_tool.cpp:51
 msgid "Copy Pad Properties"
-msgstr "Kopiuj właściwości pola lutowniczego"
+msgstr "Skopiuj właściwości pola lutowniczego"
 
 #: pcbnew/footprint_editor_onclick.cpp:322 pcbnew/onrightclick.cpp:916
 #: pcbnew/tools/pad_tool.cpp:57 pcbnew/tools/pad_tool.cpp:234
 #: pcbnew/tools/pad_tool.cpp:387
 msgid "Apply Pad Properties"
-msgstr ""
+msgstr "Zastosuj właściwości pola lutowniczego"
 
 #: pcbnew/footprint_editor_onclick.cpp:323
 msgid "Delete Pad"
@@ -23327,16 +23471,16 @@ msgstr "Powiel pole lutownicze"
 
 #: pcbnew/footprint_editor_onclick.cpp:329
 msgid "Move Pad Exactly..."
-msgstr "Przesuń pole lutownicze dokładnie..."
+msgstr "Przesuń pole dokładnie..."
 
 #: pcbnew/footprint_editor_onclick.cpp:332
 msgid "Create Pad Array..."
-msgstr "Utwórz szyk pól lutowniczych..."
+msgstr "Utwórz szyk pól..."
 
 #: pcbnew/footprint_editor_onclick.cpp:340 pcbnew/onrightclick.cpp:920
 #: pcbnew/tools/pad_tool.cpp:63
 msgid "Push Pad Properties..."
-msgstr ""
+msgstr "Wymuś właściwości pola lutowniczego..."
 
 #: pcbnew/footprint_editor_onclick.cpp:372
 #: pcbnew/footprint_editor_onclick.cpp:415 pcbnew/onrightclick.cpp:179
@@ -23350,7 +23494,7 @@ msgstr "Zakończ krawędź"
 
 #: pcbnew/footprint_editor_onclick.cpp:420
 msgid "Place Edge"
-msgstr ""
+msgstr "Dodaj krawędź"
 
 #: pcbnew/footprint_editor_onclick.cpp:434
 msgid "Global Changes"
@@ -23362,7 +23506,7 @@ msgstr "Zmień szerokość elementów"
 
 #: pcbnew/footprint_editor_onclick.cpp:438
 msgid "Change Body Items Layer..."
-msgstr ""
+msgstr "Zmień warstwę elementów..."
 
 #: pcbnew/footprint_editor_onclick.cpp:477
 msgid "Set Line Width..."
@@ -23387,7 +23531,7 @@ msgstr ""
 
 #: pcbnew/footprint_editor_utils.cpp:406
 msgid "No board currently open."
-msgstr ""
+msgstr "Żadna płytka nie jest obecnie edytowana."
 
 #: pcbnew/footprint_editor_utils.cpp:431
 msgid "Unable to find the footprint source on the main board"
@@ -23440,7 +23584,7 @@ msgstr "Nie mogę usunąć pola Wartość!"
 
 #: pcbnew/footprint_info_impl.cpp:136
 msgid "Fetching Footprint Libraries"
-msgstr ""
+msgstr "Pobieranie bibliotek footprintów"
 
 #: pcbnew/footprint_info_impl.cpp:157
 msgid "Loading Footprints"
@@ -23449,7 +23593,7 @@ msgstr "Wczytywanie footprintów"
 #: pcbnew/footprint_libraries_utils.cpp:61
 #, c-format
 msgid "Library \"%s\" exists, OK to replace ?"
-msgstr "Biblioteka \"%s\" istnieje. Czy ją zastąpić?"
+msgstr "Biblioteka \"%s\" istnieje, OK by ją zastąpić?"
 
 #: pcbnew/footprint_libraries_utils.cpp:62
 msgid "Create New Library Folder (the .pretty folder is the library)"
@@ -23459,7 +23603,7 @@ msgstr ""
 #: pcbnew/footprint_libraries_utils.cpp:63
 #, c-format
 msgid "OK to delete footprint \"%s\" in library \"%s\""
-msgstr "Kliknij OK aby usunąć footprint \"%s\" w bibliotece \"%s\""
+msgstr "OK by usunąć footprint \"%s\" w bibliotece \"%s\""
 
 #: pcbnew/footprint_libraries_utils.cpp:64
 msgid "Import Footprint"
@@ -23473,22 +23617,26 @@ msgstr "To nie jest plik z footprintem"
 #, c-format
 msgid "Unable to find or load footprint \"%s\" from lib path \"%s\""
 msgstr ""
+"Nie można znaleźć lub załadować footprintu \"%s\" z biblioteki o ścieżce \"%s"
+"\""
 
 #: pcbnew/footprint_libraries_utils.cpp:68
 #, c-format
 msgid "Unable to find or load footprint from path \"%s\""
-msgstr ""
+msgstr "Nie można znaleźć lub załadować footprintu ze ścieżki \"%s\""
 
 #: pcbnew/footprint_libraries_utils.cpp:69
 #, c-format
 msgid ""
 "The footprint library \"%s\" could not be found in any of the search paths."
 msgstr ""
+"Biblioteka footprintów \"%s\" nie może zostać odnaleziona w żadnej z "
+"przeszukiwanych ścieżek."
 
 #: pcbnew/footprint_libraries_utils.cpp:70
 #, c-format
 msgid "Library \"%s\" is read only, not writable"
-msgstr ""
+msgstr "Biblioteka \"%s\" jest tylko do odczytu, nie można zapisać"
 
 #: pcbnew/footprint_libraries_utils.cpp:72
 msgid "Export Footprint"
@@ -23505,12 +23653,12 @@ msgstr "Wpisz nazwę footprintu:"
 #: pcbnew/footprint_libraries_utils.cpp:75
 #, c-format
 msgid "Footprint exported to file \"%s\""
-msgstr ""
+msgstr "Footprint wyeksportowany do pliku \"%s\""
 
 #: pcbnew/footprint_libraries_utils.cpp:76
 #, c-format
 msgid "Footprint \"%s\" deleted from library \"%s\""
-msgstr ""
+msgstr "Footprint \"%s\" skasowany z biblioteki \"%s\""
 
 #: pcbnew/footprint_libraries_utils.cpp:77
 msgid "New Footprint"
@@ -23519,7 +23667,7 @@ msgstr "Nowy footprint"
 #: pcbnew/footprint_libraries_utils.cpp:79
 #, c-format
 msgid "Footprint \"%s\" already exists in library \"%s\""
-msgstr ""
+msgstr "Footprint \"%s\" obecnie istnieje w bibliotece \"%s\""
 
 #: pcbnew/footprint_libraries_utils.cpp:80
 msgid "No footprint name defined."
@@ -23546,27 +23694,32 @@ msgid ""
 "before deleting a footprint"
 msgstr ""
 "Modyfikacja plików bibliotek starszego typu (pliki .mod) nie jest dostępna.\n"
-"Proszę zapisać bieżącą bibliotekę w nowym formacie .pretty oraz\n"
-"zaktualizować swoją tablicę bibliotek przed usunięciem footprintu."
+"Proszę zapisać bieżącą bibliotekę w nowym formacie .Pretty oraz\n"
+"zaktualizować swoją tablicę bibliotek przed usunięciem footprintu"
 
 #: pcbnew/footprint_libraries_utils.cpp:400
 #, c-format
 msgid "Unable to create or write file \"%s\""
-msgstr ""
+msgstr "Nie można utworzyć lub zapisać pliku \"%s\""
 
 #: pcbnew/footprint_libraries_utils.cpp:556 pcbnew/gpcb_plugin.cpp:1008
 #: pcbnew/kicad_plugin.cpp:2090 pcbnew/kicad_plugin.cpp:2158
 #, c-format
 msgid "Library \"%s\" is read only"
-msgstr "Biblioteka \"%s\" jest oznaczona jako tylko do odczytu"
+msgstr "Biblioteka \"%s\" jest tylko do odczytu"
 
 #: pcbnew/footprint_libraries_utils.cpp:602
 msgid "No footprints to archive!"
 msgstr "Brak footprintów do archiwizacji!"
 
+#: pcbnew/footprint_libraries_utils.cpp:713
+#: pcbnew/footprint_libraries_utils.cpp:902
+msgid "Nickname"
+msgstr "Nazwa skrótowa"
+
 #: pcbnew/footprint_libraries_utils.cpp:727
 msgid "Library Filter:"
-msgstr "Filtr bibliotek\""
+msgstr "Filtr bibliotek:"
 
 #: pcbnew/footprint_libraries_utils.cpp:728
 msgid "Save in Library:"
@@ -23579,20 +23732,23 @@ msgstr "Nazwa footprintu:"
 #: pcbnew/footprint_libraries_utils.cpp:764
 msgid "No library specified.  Footprint could not be saved."
 msgstr ""
+"Biblioteka robocza nie została wybrana.  Footprint nie może zostać zapisany."
 
 #: pcbnew/footprint_libraries_utils.cpp:774
 msgid "No footprint name specified.  Footprint could not be saved."
 msgstr ""
+"Biblioteka footprintów nie została wybrana.  Footprint nie może zostać "
+"zapisany."
 
 #: pcbnew/footprint_libraries_utils.cpp:815
 #, c-format
 msgid "Component \"%s\" replaced in \"%s\""
-msgstr ""
+msgstr "Komponent \"%s\" zastąpiony przez \"%s\""
 
 #: pcbnew/footprint_libraries_utils.cpp:816
 #, c-format
 msgid "Component \"%s\" added in  \"%s\""
-msgstr ""
+msgstr "Komponent \"%s\" dodano do   \"%s\""
 
 #: pcbnew/footprint_viewer_frame.cpp:130
 msgid "Footprint Library Browser"
@@ -23631,11 +23787,11 @@ msgstr "Podgląd Footprintów: Przeglądarka 3D [%s]"
 
 #: pcbnew/footprint_wizard_frame.cpp:655
 msgid "Select wizard script to run"
-msgstr ""
+msgstr "Wybierz skrypt kreatora do uruchomienia"
 
 #: pcbnew/footprint_wizard_frame.cpp:661
 msgid "Reset wizard parameters to default"
-msgstr "Zresetuj parametry kreatora"
+msgstr "Zresetuj parametry kreatora do ich wartości domyślnych"
 
 #: pcbnew/footprint_wizard_frame.cpp:667
 msgid "Select previous parameters page"
@@ -23657,11 +23813,11 @@ msgstr "Dopasuj powiększenie"
 
 #: pcbnew/footprint_wizard_frame.cpp:703
 msgid "Export footprint to editor"
-msgstr "Eksportuje footprint do edytora footprintów"
+msgstr "Eksportuj footprint do edytora"
 
 #: pcbnew/footprint_wizard_frame_functions.cpp:108
 msgid "no wizard selected"
-msgstr "Nie wybrano kreatora"
+msgstr "nie wybrano kreatora"
 
 #: pcbnew/footprint_wizard_frame_functions.cpp:162
 msgid "Couldn't reload footprint wizard"
@@ -23673,6 +23829,8 @@ msgid ""
 "malformed URL:\n"
 "\"%s\""
 msgstr ""
+"niepoprawny URL:\n"
+"\"%s\""
 
 #: pcbnew/github/github_getliblist.cpp:234
 #, c-format
@@ -23680,6 +23838,8 @@ msgid ""
 "Error fetching JSON data from URL \"%s\".\n"
 "Reason: \"%s\""
 msgstr ""
+"Błąd podczas pobierania danych JSON z adresu \"%s\".\n"
+"Powód: \"%s\""
 
 #: pcbnew/github/github_plugin.cpp:300
 #, c-format
@@ -23689,6 +23849,10 @@ msgid ""
 "is not in the writable portion of this Github library\n"
 "\"%s\""
 msgstr ""
+"Footprint\n"
+"\"%s\"\n"
+"nie jest w części zapisywalnej tej biblioteki Github\n"
+"\"%s\""
 
 #: pcbnew/github/github_plugin.cpp:361
 msgid ""
@@ -23713,6 +23877,8 @@ msgid ""
 "option \"%s\" for Github library \"%s\" must point to a writable directory "
 "ending with '.pretty'."
 msgstr ""
+"opcja \"%s\" dla biblioteki GitHub \"%s\" musi wskazywać folder '.pretty', "
+"do którego posiada się uprawnienia do zapisu."
 
 #: pcbnew/github/github_plugin.cpp:572
 #, c-format
@@ -23720,7 +23886,7 @@ msgid ""
 "Unable to parse URL:\n"
 "\"%s\""
 msgstr ""
-"Nie mogę rozpoznać adresu URL:\n"
+"Nie można przetworzyć URL:\n"
 "\"%s\""
 
 #: pcbnew/github/github_plugin.cpp:596
@@ -23731,6 +23897,10 @@ msgid ""
 "for library path: \"%s\".\n"
 "Reason: \"%s\""
 msgstr ""
+"%s\n"
+"Nie można pobrać archiwum ZIP: \"%s\"\n"
+"dla ścieżki biblioteki: \"%s\".\n"
+"Powód: \"%s\""
 
 #: pcbnew/github/github_plugin.cpp:613
 #, c-format
@@ -23738,6 +23908,8 @@ msgid ""
 "Cannot download library \"%s\".\n"
 "The library does not exist on the server"
 msgstr ""
+"Nie można pobrać biblioteki \"%s\".\n"
+"Na tym serwerze taka biblioteka nie istnieje"
 
 #: pcbnew/gpcb_plugin.cpp:91
 #, c-format
@@ -23747,12 +23919,12 @@ msgstr "Nie można dokonać konwersji \"%s\" na wartość Integer"
 #: pcbnew/gpcb_plugin.cpp:248 pcbnew/gpcb_plugin.cpp:926
 #, c-format
 msgid "footprint library path \"%s\" does not exist"
-msgstr ""
+msgstr "ścieżka do biblioteki footprintu \"%s\" nie istnieje"
 
 #: pcbnew/gpcb_plugin.cpp:304 pcbnew/kicad_plugin.cpp:329
 #, c-format
 msgid "library \"%s\" has no footprint \"%s\" to delete"
-msgstr ""
+msgstr "biblioteka \"%s\" nie posiada footprintu \"%s\" dającego się usunąć"
 
 #: pcbnew/gpcb_plugin.cpp:400
 #, c-format
@@ -23767,22 +23939,23 @@ msgstr "Token \"Element\" zawiera %d parametrów."
 #: pcbnew/gpcb_plugin.cpp:1027 pcbnew/kicad_plugin.cpp:2206
 #, c-format
 msgid "user does not have permission to delete directory \"%s\""
-msgstr ""
+msgstr "użytkownik nie posiada uprawnień do usunięcia biblioteki \"%s\""
 
 #: pcbnew/gpcb_plugin.cpp:1035 pcbnew/kicad_plugin.cpp:2214
 #, c-format
 msgid "library directory \"%s\" has unexpected sub-directories"
-msgstr ""
+msgstr "folder biblioteki \"%s\" posiada podkatalogi"
 
 #: pcbnew/gpcb_plugin.cpp:1054 pcbnew/kicad_plugin.cpp:2233
 #, c-format
 msgid "unexpected file \"%s\" was found in library path \"%s\""
 msgstr ""
+"niespodziewany plik \"%s\" został odnaleziony w bibliotece o ścieżce \"%s\""
 
 #: pcbnew/gpcb_plugin.cpp:1072 pcbnew/kicad_plugin.cpp:2251
 #, c-format
 msgid "footprint library \"%s\" cannot be deleted"
-msgstr ""
+msgstr "biblioteka footprintu \"%s\" nie może być usunięta"
 
 #: pcbnew/help_common_strings.h:15 pcbnew/tool_footprint_editor.cpp:105
 msgid "Undo last edition"
@@ -23793,21 +23966,20 @@ msgid "Find components and text in current loaded board"
 msgstr "Znajdź komponenty i teksty w bieżącym PCB"
 
 #: pcbnew/help_common_strings.h:21
-#, fuzzy
 msgid "Zoom to fit board or page"
-msgstr "Powiększ, aby dopasować płytkę do ekranu"
+msgstr "Powiększa by widoczna była cała płytka"
 
 #: pcbnew/help_common_strings.h:22
 msgid "Redraw screen"
-msgstr "Odśwież ekran"
+msgstr "Odrysowywuje ekran"
 
 #: pcbnew/help_common_strings.h:26
 msgid ""
 "Show/hide microwave toolbar\n"
 "(Experimental feature)"
 msgstr ""
-"Pokaż / ukryj pasek narzędzi mikrofalowych\n"
-"(Funkcja eksperymentalna)"
+"Pokazuje/ukrywa pasek narzędzi mikrofalowych\n"
+"(Eksperymentalne funkcje)"
 
 #: pcbnew/hotkeys.cpp:72
 msgid "Switch to Copper (B.Cu) layer"
@@ -23851,24 +24023,25 @@ msgstr "Dodaj nowę ścieżkę"
 
 #: pcbnew/hotkeys.cpp:100
 msgid "Route Differential Pair (Modern Toolset only)"
-msgstr ""
+msgstr "Router par różnicowych (Tylko nowoczesny zestaw narzędzi)"
 
 #: pcbnew/hotkeys.cpp:102
 msgid "Tune Single Track (Modern Toolset only)"
-msgstr ""
+msgstr "Dostrój pojedynczą ścieżkę (Tylko nowoczesny zestaw narzędzi)"
 
 #: pcbnew/hotkeys.cpp:104
 msgid "Tune Differential Pair Length (Modern Toolset only)"
 msgstr ""
+"Dostrajanie długości par różnicowych (Tylko nowoczesny zestaw narzędzi)"
 
 #: pcbnew/hotkeys.cpp:106
 msgid "Tune Differential Pair Skew (Modern Toolset only)"
 msgstr ""
+"Dostrajanie odchyleń/fazy par różnicowych (Tylko nowoczesny zestaw narzędzi)"
 
 #: pcbnew/hotkeys.cpp:108
-#, fuzzy
 msgid "Length Tuning Settings (Modern Toolset only)"
-msgstr "Ustawienia dostrajania długości ścieżek"
+msgstr "Ustawienia dostrajania ścieżek (Tylko nowoczesny zestaw narzędzi)"
 
 #: pcbnew/hotkeys.cpp:111 pcbnew/router/length_tuner_tool.cpp:63
 msgid "Increase meander spacing by one step."
@@ -23925,7 +24098,7 @@ msgstr "Przerzuć element"
 
 #: pcbnew/hotkeys.cpp:134
 msgid "Rotate Item Clockwise (Modern Toolset only)"
-msgstr ""
+msgstr "Obróć element w prawo (Tylko nowoczesny zestaw narzędzi)"
 
 #: pcbnew/hotkeys.cpp:137
 msgid "Move Item Exactly"
@@ -23933,7 +24106,7 @@ msgstr "Przesuń dokładnie"
 
 #: pcbnew/hotkeys.cpp:138
 msgid "Position Item Relative"
-msgstr ""
+msgstr "Pozycja elementu relatywna"
 
 #: pcbnew/hotkeys.cpp:139
 msgid "Duplicate Item"
@@ -23965,7 +24138,7 @@ msgstr "Rysuj linię"
 
 #: pcbnew/hotkeys.cpp:152 pcbnew/tools/drawing_tool.cpp:75
 msgid "Draw Graphic Polygon"
-msgstr "Rysuj wielobok graficzny"
+msgstr "Rysuj strefę graficzną"
 
 #: pcbnew/hotkeys.cpp:153 pcbnew/tools/drawing_tool.cpp:79
 msgid "Draw Circle"
@@ -23982,36 +24155,35 @@ msgstr "Dodaj tekst"
 
 #: pcbnew/hotkeys.cpp:156 pcbnew/tools/drawing_tool.cpp:91
 msgid "Add Dimension"
-msgstr "Doda wymiar"
+msgstr "Dodaj wymiar"
 
 #: pcbnew/hotkeys.cpp:157 pcbnew/tools/drawing_tool.cpp:95
 msgid "Add Filled Zone"
-msgstr "Doda wypełnioną strefę"
+msgstr "Dodaj wypełnioną strefę"
 
 #: pcbnew/hotkeys.cpp:158 pcbnew/tools/drawing_tool.cpp:99
 msgid "Add Vias"
-msgstr "Dodaj przelotkę"
+msgstr "Dodaj przelotki"
 
 #: pcbnew/hotkeys.cpp:159 pcbnew/tools/drawing_tool.cpp:103
 msgid "Add Keepout Area"
-msgstr "Dodaje strefę chronioną"
+msgstr "Dodaj obszar chroniony"
 
 #: pcbnew/hotkeys.cpp:160 pcbnew/tools/drawing_tool.cpp:107
 msgid "Add a Zone Cutout"
-msgstr "Dodaj wycięcie strefy"
+msgstr "Dodaj obszar odcięty"
 
 #: pcbnew/hotkeys.cpp:161 pcbnew/tools/drawing_tool.cpp:112
 msgid "Add a Similar Zone"
-msgstr "Dodaj strefę bliźniaczą"
+msgstr "Dodaj podobną strefę"
 
 #: pcbnew/hotkeys.cpp:162
-#, fuzzy
 msgid "Place DXF"
-msgstr "Umieść"
+msgstr "Wstaw plik DXF"
 
 #: pcbnew/hotkeys.cpp:163 pcbnew/tools/drawing_tool.cpp:121
 msgid "Place the Footprint Anchor"
-msgstr ""
+msgstr "Umieść punkt zakotwiczenia footprintu"
 
 #: pcbnew/hotkeys.cpp:165 pcbnew/tools/drawing_tool.cpp:126
 msgid "Increase Line Width"
@@ -24027,8 +24199,7 @@ msgstr "Zresetuj punkt bazowy siatki"
 
 #: pcbnew/hotkeys.cpp:172
 msgid "Switch to Legacy Toolset (not all features will be available"
-msgstr ""
-"Przełącz na starszy zestaw narzędzi (nie wszystkie funkcje będą dostępne)"
+msgstr "Użyj zestawu narzędzi Legacy (nie wszystkie funkcje będą dostępne)"
 
 #: pcbnew/hotkeys.cpp:191 pcbnew/onrightclick.cpp:332
 msgid "Fill or Refill All Zones"
@@ -24072,11 +24243,11 @@ msgstr "Dodaj footprint"
 
 #: pcbnew/hotkeys.cpp:260
 msgid "Increment Layer Transparency (Modern Toolset only)"
-msgstr "Zwiększ przejżystość warstw (tylko nowy zestaw narzędzi)"
+msgstr "Zwiększ przeźroczystość warstwy (Tylko nowoczesny zestaw narzędzi)"
 
 #: pcbnew/hotkeys.cpp:263
 msgid "Decrement Layer Transparency (Modern Toolset only)"
-msgstr "Zmniejsz przejrzystość warstw (tylko nowy zestaw narzędzi)"
+msgstr "Zmniejsz przeźroczystość warstwy (Tylko nowoczesny zestaw narzędzi)"
 
 #: pcbnew/hotkeys.cpp:267
 msgid "Increment High Contrast"
@@ -24088,11 +24259,11 @@ msgstr "Zmniejsz wysokość kontrastu"
 
 #: pcbnew/hotkeys.cpp:270
 msgid "Select Trivial Connection"
-msgstr ""
+msgstr "Zaznacz od węzła do węzła"
 
 #: pcbnew/hotkeys.cpp:272
 msgid "Select Copper Connection"
-msgstr ""
+msgstr "Zaznacz połączenia na war. miedzi"
 
 #: pcbnew/hotkeys.cpp:274
 msgid "Routing Options"
@@ -24113,10 +24284,11 @@ msgstr "Zmniejsz rozmiar przelotki"
 #: pcbnew/hotkeys.cpp:284
 msgid "Toggle Highlight of Selected Net (Modern Toolset only)"
 msgstr ""
+"Przełącz podświetlenie wybranej sieci (Tylko nowoczesny zestaw narzędzi)"
 
 #: pcbnew/hotkeys.cpp:308
 msgid "Toggle Cursor Display (Modern Toolset only)"
-msgstr ""
+msgstr "Przełącz wyświetlanie kursora (Tylko nowoczesny zestaw narzędzi)"
 
 #: pcbnew/hotkeys.cpp:497
 msgid "Board Editor"
@@ -24128,7 +24300,7 @@ msgstr "Otwórz plik"
 
 #: pcbnew/import_dxf/dialog_dxf_import.cpp:259
 msgid "Error: No DXF filename!"
-msgstr "Błąd: brak nazwy pliku DXF!"
+msgstr "Błąd: Nie ma nazwy pliku DXF!"
 
 #: pcbnew/import_dxf/dialog_dxf_import_base.cpp:42
 msgid "Center of page"
@@ -24152,11 +24324,11 @@ msgstr "Pozycja zdefiniowana przez użytkownika"
 
 #: pcbnew/import_dxf/dialog_dxf_import_base.cpp:44
 msgid "Place DXF Origin (0,0) Point:"
-msgstr ""
+msgstr "Umieść punkt odniesienia DXF (0, 0):"
 
 #: pcbnew/import_dxf/dialog_dxf_import_base.cpp:54
 msgid "User defined position:"
-msgstr ""
+msgstr "Pozycja użytkownika:"
 
 #: pcbnew/import_dxf/dialog_dxf_import_base.cpp:80
 msgid "DXF origin on PCB Grid, X Coordinate"
@@ -24172,11 +24344,11 @@ msgstr "Wybór jednostek siatki PCB"
 
 #: pcbnew/import_dxf/dialog_dxf_import_base.cpp:134
 msgid "Import parameters:"
-msgstr "Parametry importu:"
+msgstr "Importuj parametry:"
 
 #: pcbnew/import_dxf/dialog_dxf_import_base.cpp:150
 msgid "Default line width:"
-msgstr ""
+msgstr "Domyślna szerokość linii:"
 
 #: pcbnew/import_dxf/dialog_dxf_import_base.cpp:163
 msgid "Graphic layer:"
@@ -24196,11 +24368,11 @@ msgstr ""
 #: pcbnew/io_mgr.cpp:89
 #, c-format
 msgid "UNKNOWN (%d)"
-msgstr "NIEZNANY (%d)"
+msgstr "NIEZNANA (%d)"
 
 #: pcbnew/kicad_clipboard.cpp:302
 msgid "Clipboard content is not KiCad compatible"
-msgstr ""
+msgstr "Zawartość schowka nie jest kompatybilna z programem KiCad"
 
 #: pcbnew/kicad_netlist_reader.cpp:253
 #, c-format
@@ -24215,26 +24387,31 @@ msgid ""
 "line: %d\n"
 "offset: %d"
 msgstr ""
+"niepoprawny ID footprintu w\n"
+"plik: \"%s\"\n"
+"linia: %d\n"
+"przesunięcie: %d"
 
 #: pcbnew/kicad_plugin.cpp:193
 #, c-format
 msgid "Cannot create footprint library path \"%s\""
-msgstr ""
+msgstr "Nie można utworzyć ścieżki biblioteki footprintu \"%s\""
 
 #: pcbnew/kicad_plugin.cpp:199
 #, c-format
 msgid "Footprint library path \"%s\" is read only"
-msgstr ""
+msgstr "Ścieżka biblioteki footprintu \"%s\" jest tylko do odczytu"
 
 #: pcbnew/kicad_plugin.cpp:238
 #, c-format
 msgid "Cannot rename temporary file \"%s\" to footprint library file \"%s\""
 msgstr ""
+"Nie można zmienić nazwy pliku tymczasowego \"%s\" do pliku biblioteki \"%s\""
 
 #: pcbnew/kicad_plugin.cpp:266
 #, c-format
 msgid "Footprint library path \"%s\" does not exist"
-msgstr ""
+msgstr "Ścieżka do biblioteki footprintu \"%s\" nie istnieje"
 
 #: pcbnew/kicad_plugin.cpp:1294 pcbnew/legacy_plugin.cpp:96
 #, c-format
@@ -24258,48 +24435,51 @@ msgstr "nieznany typ zaokrągleń krawędzi strefy %d"
 
 #: pcbnew/kicad_plugin.cpp:1943
 msgid "this file does not contain a PCB"
-msgstr ""
+msgstr "ten plik z nie zawiera obwodu drukowanego"
 
 #: pcbnew/kicad_plugin.cpp:2076
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "Library \"%s\" does not exist.\n"
 "Would you like to create it?"
-msgstr "Płyta \"% s\" nie istnieje. Czy chcesz ją utworzyć?"
+msgstr ""
+"Biblioteka \"%s\" nie istnieje.\n"
+"Czy chcesz ją teraz utworzyć?"
 
 #: pcbnew/kicad_plugin.cpp:2079
-#, fuzzy, c-format
+#, c-format
 msgid "Create new library \"%s\"?"
-msgstr "Utwórz nową bibliotekę"
+msgstr "Utworzyć nową bibliotekę \"%s\"?"
 
 #: pcbnew/kicad_plugin.cpp:2108
 #, c-format
 msgid "Footprint file name \"%s\" is not valid."
-msgstr ""
+msgstr "Nazwa pliku footprintu \"%s\" nie jest prawidłowa."
 
 #: pcbnew/kicad_plugin.cpp:2114
 #, c-format
 msgid "user does not have write permission to delete file \"%s\" "
-msgstr ""
+msgstr "użytkownik nie ma uprawnień do skasowania pliku \"%s\" "
 
 #: pcbnew/kicad_plugin.cpp:2181
 #, c-format
 msgid "cannot overwrite library path \"%s\""
-msgstr ""
+msgstr "nie można nadpisać ścieżki biblioteki \"%s\""
 
 #: pcbnew/layer_widget.cpp:130
 msgid "Change Layer Color for "
-msgstr "Zmień kolor warstwy dla"
+msgstr "Zmień kolor warstwy dla "
 
 #: pcbnew/layer_widget.cpp:182
 msgid "Change Render Color for "
-msgstr "Zmień kolor renderowania dla"
+msgstr "Zmień kolor renderowania dla "
 
 #: pcbnew/layer_widget.cpp:334
 msgid ""
 "Left double click or middle click for color change, right click for menu"
 msgstr ""
-"Dwukrotnie kliknij lewym lub środkowym klawiszem myszki aby zmienić kolor"
+"Kliknij dwukrotnie lewym lub kliknij środkowym klawiszem by zmienić kolor, "
+"prawym by wywołać menu"
 
 #: pcbnew/layer_widget.cpp:342
 msgid "Enable this for visibility"
@@ -24308,35 +24488,37 @@ msgstr "Włącz by była widoczna"
 #: pcbnew/layer_widget.cpp:408
 msgid "Left double click or middle click for color change"
 msgstr ""
+"Kliknij dwukrotnie lewym lub kliknij środkowym klawiszem myszy by zmienić "
+"kolor"
 
 #: pcbnew/legacy_netlist_reader.cpp:120
 msgid "Cannot parse time stamp in symbol section of netlist."
-msgstr ""
+msgstr "Nie można przetworzyć odcisku czasowego w sekcji symboli listy sieci."
 
 #: pcbnew/legacy_netlist_reader.cpp:130
 msgid "Cannot parse footprint name in symbol section of netlist."
-msgstr ""
+msgstr "Nie można przetworzyć nazwy footprintu w sekcji symboli listy sieci."
 
 #: pcbnew/legacy_netlist_reader.cpp:144
 msgid "Cannot parse reference designator in symbol section of netlist."
-msgstr ""
+msgstr "Nie można przetworzyć odniesienia w sekcji symboli listy sieci."
 
 #: pcbnew/legacy_netlist_reader.cpp:154
 msgid "Cannot parse value in symbol section of netlist."
-msgstr ""
+msgstr "Nie można przetworzyć wartości w sekcji symboli listy sieci."
 
 #: pcbnew/legacy_netlist_reader.cpp:191
 msgid "Cannot parse pin name in symbol net section of netlist."
-msgstr ""
+msgstr "Nie można przetworzyć nazwy pinu w sekcji sieci symbolu listy sieci."
 
 #: pcbnew/legacy_netlist_reader.cpp:200
 msgid "Cannot parse net name in symbol net section of netlist."
-msgstr ""
+msgstr "Nie można przetworzyć nazwy sieci w sekcji sieci symbolu listy sieci."
 
 #: pcbnew/legacy_netlist_reader.cpp:248
 #, c-format
 msgid "Cannot find symbol \"%s\" in footprint filter section of netlist."
-msgstr ""
+msgstr "Nie można znaleźć symbolu \"%s\" w sekcji filtrów listy sieci."
 
 #: pcbnew/legacy_plugin.cpp:94
 #, c-format
@@ -24345,6 +24527,9 @@ msgid ""
 "I only support format version <= %d.\n"
 "Please upgrade Pcbnew to load this file."
 msgstr ""
+"Plik \"%s\" jest w wersji: %d.\n"
+"Ta wersja obsługuje tylko pliki z wersją <= %d.\n"
+"Proszę uaktualnić Pcbnew by załadować ten plik."
 
 #: pcbnew/legacy_plugin.cpp:95
 #, c-format
@@ -24354,42 +24539,42 @@ msgstr "nieznany typ grafiki: %d"
 #: pcbnew/legacy_plugin.cpp:730
 #, c-format
 msgid "Unknown sheet type \"%s\" on line:%d"
-msgstr ""
+msgstr "Nieznany typ arkusza \"%s\" w linii:%d"
 
 #: pcbnew/legacy_plugin.cpp:1374
 #, c-format
 msgid "Missing '$EndMODULE' for MODULE \"%s\""
-msgstr ""
+msgstr "Brak '$EndMODULE' dla MODULE \"%s\""
 
 #: pcbnew/legacy_plugin.cpp:1426
 #, c-format
 msgid "Unknown padshape '%c=0x%02x' on line: %d of footprint: \"%s\""
-msgstr ""
+msgstr "Nieznany kształt pola '%c=0x%02x' w linii: %d footprintu: \"%s\""
 
 #: pcbnew/legacy_plugin.cpp:1632
 #, c-format
 msgid "Unknown EDGE_MODULE type:'%c=0x%02x' on line:%d of footprint:\"%s\""
-msgstr ""
+msgstr "Nieznany typ EDGE_MODULE: '%c=0x%02x' w linii: %d footprintu: \"%s\""
 
 #: pcbnew/legacy_plugin.cpp:2460
 #, c-format
 msgid "duplicate NETCLASS name \"%s\""
-msgstr ""
+msgstr "zduplikowana nazwa NETCLASS \"%s\""
 
 #: pcbnew/legacy_plugin.cpp:2542 pcbnew/legacy_plugin.cpp:2553
 #, c-format
 msgid "Bad ZAux for CZONE_CONTAINER \"%s\""
-msgstr ""
+msgstr "Zły ZAux dla CZONE_CONTAINER \"%s\""
 
 #: pcbnew/legacy_plugin.cpp:2570
 #, c-format
 msgid "Bad ZSmoothing for CZONE_CONTAINER \"%s\""
-msgstr ""
+msgstr "Zły ZSmoothing dla CZONE_CONTAINER \"%s\""
 
 #: pcbnew/legacy_plugin.cpp:2644
 #, c-format
 msgid "Bad ZClearance padoption for CZONE_CONTAINER \"%s\""
-msgstr ""
+msgstr "Zła opcja pola ZClearance dla CZONE_CONTAINER \"%s\""
 
 #: pcbnew/legacy_plugin.cpp:2992 pcbnew/legacy_plugin.cpp:3029
 #, c-format
@@ -24397,6 +24582,8 @@ msgid ""
 "invalid float number in file: \"%s\"\n"
 "line: %d, offset: %d"
 msgstr ""
+"nieprawidłowa liczba w pliku: \"%s\"\n"
+"linia: %d, przesunięcie: %d"
 
 #: pcbnew/legacy_plugin.cpp:3001 pcbnew/legacy_plugin.cpp:3037
 #, c-format
@@ -24404,11 +24591,13 @@ msgid ""
 "missing float number in file: \"%s\"\n"
 "line: %d, offset: %d"
 msgstr ""
+"brak liczby w pliku: \"%s\"\n"
+"linia: %d, przesunięcie: %d"
 
 #: pcbnew/legacy_plugin.cpp:3263
 #, c-format
 msgid "File \"%s\" is empty or is not a legacy library"
-msgstr ""
+msgstr "Plik \"%s\" jest pusty lub nie jest biblioteką Legacy"
 
 #: pcbnew/load_select_footprint.cpp:432
 #, c-format
@@ -24436,7 +24625,7 @@ msgstr "Nie znaleziono footprintów."
 
 #: pcbnew/load_select_footprint.cpp:523
 msgid "Description: "
-msgstr "Opis:"
+msgstr "Opis: "
 
 #: pcbnew/load_select_footprint.cpp:524
 msgid ""
@@ -24444,7 +24633,7 @@ msgid ""
 "Key words: "
 msgstr ""
 "\n"
-"Słowa kluczowe:"
+"Słowa kluczowe: "
 
 #: pcbnew/load_select_footprint.cpp:540
 #, c-format
@@ -24459,11 +24648,11 @@ msgstr "Footprint \"%s\" został zapisany"
 #: pcbnew/load_select_footprint.cpp:620
 #, c-format
 msgid "Footprint library \"%s\" saved as \"%s\"."
-msgstr ""
+msgstr "Biblioteka footprintu \"%s\" zapisana jako \"%s\"."
 
 #: pcbnew/menubar_footprint_editor.cpp:58
 msgid "Set Acti&ve Library..."
-msgstr "Ustaw aktywną bibliotekę..."
+msgstr "Wybierz aktywną bibliotekę..."
 
 #: pcbnew/menubar_footprint_editor.cpp:59 pcbnew/tool_footprint_editor.cpp:51
 msgid "Select active library"
@@ -24471,7 +24660,7 @@ msgstr "Wybierz aktywną bibliotekę"
 
 #: pcbnew/menubar_footprint_editor.cpp:65
 msgid "&New Footprint..."
-msgstr "&Nowy footprint..."
+msgstr "Nowy footprint..."
 
 #: pcbnew/menubar_footprint_editor.cpp:67
 msgid "Create new footprint"
@@ -24479,11 +24668,11 @@ msgstr "Utwórz nowy footprint"
 
 #: pcbnew/menubar_footprint_editor.cpp:70
 msgid "&Open Footprint..."
-msgstr "&Otwórz footprint..."
+msgstr "Otwórz footprint..."
 
 #: pcbnew/menubar_footprint_editor.cpp:72
 msgid "Open a footprint from a library"
-msgstr "Otwórz footprint z biblioteki"
+msgstr "Otwiera footprint z aktywnej biblioteki"
 
 #: pcbnew/menubar_footprint_editor.cpp:80
 msgid "Save footprint"
@@ -24491,31 +24680,31 @@ msgstr "Zapisz footprint"
 
 #: pcbnew/menubar_footprint_editor.cpp:90
 msgid "Footprint from &Current Board..."
-msgstr ""
+msgstr "Footprint z bieżącej płytki..."
 
 #: pcbnew/menubar_footprint_editor.cpp:91
 msgid "Import a footprint from the current board"
-msgstr ""
+msgstr "Wczytaj footprint z bieżącej płytki do edytora"
 
 #: pcbnew/menubar_footprint_editor.cpp:95
 msgid "Footprint from &KiCad File..."
-msgstr ""
+msgstr "Footprint z pliku KiCad..."
 
 #: pcbnew/menubar_footprint_editor.cpp:96
 msgid "Import a footprint from an existing footprint file"
-msgstr ""
+msgstr "Importuj footprint z istniejącego pliku"
 
 #: pcbnew/menubar_footprint_editor.cpp:100
 msgid "Footprint Outlines from &DXF File..."
-msgstr ""
+msgstr "Obrys footprintu z pliku DXF..."
 
 #: pcbnew/menubar_footprint_editor.cpp:101
 msgid "Import 2D Drawing DXF file to Footprint Editor on Drawings layer"
-msgstr ""
+msgstr "Importuj rysunek 2D z pliku DXF do Pcbnew na warstwę rysunków"
 
 #: pcbnew/menubar_footprint_editor.cpp:113
 msgid "&Active Library..."
-msgstr "&Aktywna biblioteka..."
+msgstr "Aktywna biblioteka..."
 
 #: pcbnew/menubar_footprint_editor.cpp:114
 msgid "Export active library"
@@ -24523,7 +24712,7 @@ msgstr "Eksportuj aktywną bibliotekę"
 
 #: pcbnew/menubar_footprint_editor.cpp:118
 msgid "&Footprint..."
-msgstr "&Footprint..."
+msgstr "Footprint..."
 
 #: pcbnew/menubar_footprint_editor.cpp:119
 msgid "Export current footprint to a file"
@@ -24555,7 +24744,7 @@ msgstr "Ponów ostatnio cofniętą operację"
 
 #: pcbnew/menubar_footprint_editor.cpp:174
 msgid "Cu&t"
-msgstr "Wy&tnij"
+msgstr "Wytnij"
 
 #: pcbnew/menubar_footprint_editor.cpp:189 pcbnew/menubar_pcb_editor.cpp:535
 #: pcbnew/tool_pcb_editor.cpp:495
@@ -24564,11 +24753,11 @@ msgstr "Usuń elementy"
 
 #: pcbnew/menubar_footprint_editor.cpp:196 pcbnew/menubar_pcb_editor.cpp:591
 msgid "&Library Browser"
-msgstr "Przeg&lądarka bibliotek"
+msgstr "Przeglądarka bibliotek"
 
 #: pcbnew/menubar_footprint_editor.cpp:197 pcbnew/menubar_pcb_editor.cpp:592
 msgid "Open the Library Browser"
-msgstr "Otwórz przeglądarkę bibliotek"
+msgstr "Otwiera przeglądarkę bibliotek footprintów"
 
 #: pcbnew/menubar_footprint_editor.cpp:200 pcbnew/menubar_pcb_editor.cpp:595
 msgid "&3D Viewer"
@@ -24576,43 +24765,42 @@ msgstr "Przeglądarka 3D"
 
 #: pcbnew/menubar_footprint_editor.cpp:228 pcbnew/tool_footprint_viewer.cpp:93
 #: pcbnew/tool_footprint_viewer.cpp:156
-#, fuzzy
 msgid "Zoom to fit footprint"
-msgstr "Importuj footprint"
+msgstr "Powiększ by zmieścić footprint"
 
 #: pcbnew/menubar_footprint_editor.cpp:246 pcbnew/menubar_pcb_editor.cpp:641
 msgid "Grid &Settings..."
-msgstr "U&stawienia siatki..."
+msgstr "Ustawienia siatki..."
 
 #: pcbnew/menubar_footprint_editor.cpp:246 pcbnew/menubar_pcb_editor.cpp:641
 msgid "Adjust custom user-defined grid dimensions"
-msgstr ""
+msgstr "Ustawia rozmiar siatki zdefiniowanej przez użytkownia"
 
 #: pcbnew/menubar_footprint_editor.cpp:270
 #: pcbnew/menubar_footprint_editor.cpp:275 pcbnew/menubar_pcb_editor.cpp:666
 #: pcbnew/menubar_pcb_editor.cpp:671
 msgid "Full Window Crosshair"
-msgstr "Pełnoekranowy krzyż"
+msgstr "Kursor pełnoekranowy"
 
 #: pcbnew/menubar_footprint_editor.cpp:286 pcbnew/menubar_pcb_editor.cpp:703
 msgid "Sketch &Pads"
-msgstr "Zarys &pól lutowniczych"
+msgstr "Pola jako zarys"
 
 #: pcbnew/menubar_footprint_editor.cpp:290 pcbnew/menubar_pcb_editor.cpp:721
 msgid "Sketch Footprint &Edges"
-msgstr "Zarys krawędzi footprintów"
+msgstr "Zarysy krawędzi footprintów"
 
 #: pcbnew/menubar_footprint_editor.cpp:290 pcbnew/menubar_pcb_editor.cpp:721
 msgid "Show footprint edges in outline mode"
-msgstr ""
+msgstr "Pokaż krawędzie footprintów jako zarys"
 
 #: pcbnew/menubar_footprint_editor.cpp:293 pcbnew/menubar_pcb_editor.cpp:725
 msgid "Sketch Footprint Te&xt"
-msgstr "Zarys tekstu footprintów"
+msgstr "Teksty footprintu jako szkice"
 
 #: pcbnew/menubar_footprint_editor.cpp:293 pcbnew/menubar_pcb_editor.cpp:725
 msgid "Show footprint text in outline mode"
-msgstr ""
+msgstr "Pokazuje tekst footprintu jako zarys"
 
 #: pcbnew/menubar_footprint_editor.cpp:297 pcbnew/menubar_pcb_editor.cpp:729
 msgid "&Drawing Mode"
@@ -24622,7 +24810,7 @@ msgstr "Tryb rysowania"
 #: pcbnew/menubar_footprint_editor.cpp:326 pcbnew/menubar_pcb_editor.cpp:730
 #: pcbnew/menubar_pcb_editor.cpp:758
 msgid "Select how items are displayed"
-msgstr ""
+msgstr "Wybiera sposób wyświetlania elementów"
 
 #: pcbnew/menubar_footprint_editor.cpp:304 pcbnew/menubar_pcb_editor.cpp:736
 msgid "&High Contrast Mode"
@@ -24630,23 +24818,25 @@ msgstr "Tryb wysokiego kontrastu"
 
 #: pcbnew/menubar_footprint_editor.cpp:307 pcbnew/menubar_pcb_editor.cpp:739
 msgid "Use high contrast display mode"
-msgstr ""
+msgstr "Wyświetlaj w trybie wysokiego kontrastu"
 
 #: pcbnew/menubar_footprint_editor.cpp:312 pcbnew/menubar_pcb_editor.cpp:744
 msgid "&Decrease Layer Opacity"
-msgstr "Zmniejsz krycie warstwy"
+msgstr "Zmniejsz przeźroczystość warstw"
 
 #: pcbnew/menubar_footprint_editor.cpp:315 pcbnew/menubar_pcb_editor.cpp:747
 msgid "Make the current layer more transparent"
 msgstr ""
+"Zwiększa przeźroczystość bieżącej warstwy by mniej przesłaniała inne warstwy"
 
 #: pcbnew/menubar_footprint_editor.cpp:318 pcbnew/menubar_pcb_editor.cpp:750
 msgid "&Increase Layer Opacity"
-msgstr "Zwiększ krycie warstwy"
+msgstr "Zwiększ przeźroczystość warstw"
 
 #: pcbnew/menubar_footprint_editor.cpp:321 pcbnew/menubar_pcb_editor.cpp:753
 msgid "Make the current layer less transparent"
 msgstr ""
+"Zmniejsza przeźroczystość bieżącej warstwy by przesłaniała inne warstwy"
 
 #: pcbnew/menubar_footprint_editor.cpp:325 pcbnew/menubar_pcb_editor.cpp:757
 msgid "&Contrast Mode"
@@ -24662,7 +24852,7 @@ msgstr "Zmieniaj szerokość dla tekstów i rysunków"
 
 #: pcbnew/menubar_footprint_editor.cpp:345 pcbnew/menubar_pcb_editor.cpp:180
 msgid "Default &Pad Properties..."
-msgstr "Domyślne właściwości pola lutowniczego..."
+msgstr "Właściwości pola lutowniczego..."
 
 #: pcbnew/menubar_footprint_editor.cpp:346
 msgid "Edit settings for new pads"
@@ -24682,17 +24872,17 @@ msgstr "Dodaj tekst (grafika)"
 
 #: pcbnew/menubar_footprint_editor.cpp:378 pcbnew/menubar_pcb_editor.cpp:382
 msgid "&Line"
-msgstr "&Linia"
+msgstr "Linia"
 
 #: pcbnew/menubar_footprint_editor.cpp:384 pcbnew/menubar_pcb_editor.cpp:386
 msgid "&Polygon"
-msgstr "Wy&pełnienie"
+msgstr "Strefa"
 
 #: pcbnew/menubar_footprint_editor.cpp:386 pcbnew/menubar_pcb_editor.cpp:387
 #: pcbnew/tool_footprint_editor.cpp:178 pcbnew/tool_pcb_editor.cpp:481
 #: pcbnew/tools/drawing_tool.cpp:715
 msgid "Add graphic polygon"
-msgstr "Dodaj graficzne wypełnienie"
+msgstr "Dodaj strefę graficzną"
 
 #: pcbnew/menubar_footprint_editor.cpp:392
 msgid "A&nchor"
@@ -24708,52 +24898,51 @@ msgstr "Punkt bazowy siatki"
 
 #: pcbnew/menubar_footprint_editor.cpp:400 pcbnew/menubar_pcb_editor.cpp:408
 msgid "Set grid origin point"
-msgstr ""
+msgstr "Ustaw punkt bazowy siatki"
 
 #: pcbnew/menubar_footprint_editor.cpp:408 pcbnew/menubar_pcb_editor.cpp:312
 msgid "&Measure"
-msgstr "&Miarka"
+msgstr "Miarka odległości"
 
 #: pcbnew/menubar_footprint_editor.cpp:417
 msgid "&Update Footprint on PCB"
-msgstr ""
+msgstr "Uaktualnij footprint na PCB"
 
 #: pcbnew/menubar_footprint_editor.cpp:418
 msgid "Push updated footprint through to current board"
-msgstr ""
+msgstr "Uaktualnia footprinty na bieżącej płytce"
 
 #: pcbnew/menubar_footprint_editor.cpp:422
 msgid "&Insert Footprint on PCB"
-msgstr "Wstaw footpr&int na płytkę"
+msgstr "Wstaw footprint na płytkę"
 
 #: pcbnew/menubar_footprint_editor.cpp:423
 msgid "Insert footprint onto current board"
-msgstr ""
+msgstr "Wstawia footprint na bieżącą płytkę"
 
 #: pcbnew/menubar_footprint_editor.cpp:429
 msgid "&Delete a Footprint in Active Library"
-msgstr ""
+msgstr "Usuń footprint z aktywnej biblioteki"
 
 #: pcbnew/menubar_footprint_editor.cpp:430
 msgid "Choose and delete a footprint from the active library"
-msgstr "Wybierz i usuń footprint z aktywnej biblioteki"
+msgstr "Wybiera oraz usuwa footprint z aktywnej biblioteki"
 
 #: pcbnew/menubar_footprint_editor.cpp:445 pcbnew/menubar_pcb_editor.cpp:336
-#, fuzzy
 msgid "Manage Footprint Li&braries..."
-msgstr "Menadżer footprintów i bibliotek..."
+msgstr "Zarządzanie bibliotekami footprintów..."
 
 #: pcbnew/menubar_footprint_editor.cpp:445
 msgid "Configure footprint library table"
-msgstr ""
+msgstr "Konfiguruje tabele bibliotek footprintów"
 
 #: pcbnew/menubar_footprint_editor.cpp:450
 msgid "General &Settings..."
-msgstr "Ustawienia &główne..."
+msgstr "Ustawienia główne..."
 
 #: pcbnew/menubar_footprint_editor.cpp:450
 msgid "Change footprint editor settings."
-msgstr ""
+msgstr "Zmienia ustawienia edytora footprintów."
 
 #: pcbnew/menubar_footprint_editor.cpp:456 pcbnew/menubar_pcb_editor.cpp:212
 msgid "&Display Options..."
@@ -24761,11 +24950,11 @@ msgstr "Opcje wyświetlania..."
 
 #: pcbnew/menubar_footprint_editor.cpp:457
 msgid "Graphics acceleration, grid and cursor settings."
-msgstr ""
+msgstr "Akceleracja, siatka oraz ustawienia kursora."
 
 #: pcbnew/menubar_footprint_editor.cpp:472
 msgid "Modern Toolset (&Fallback)"
-msgstr ""
+msgstr "Nowoczesny zestaw narzędzi (Programowy)"
 
 #: pcbnew/menubar_footprint_editor.cpp:492
 msgid "Open the Pcbnew Manual"
@@ -24773,7 +24962,7 @@ msgstr "Otwiera podręcznik programu Pcbnew"
 
 #: pcbnew/menubar_footprint_editor.cpp:524 pcbnew/menubar_pcb_editor.cpp:141
 msgid "&Setup"
-msgstr "U&stawienia"
+msgstr "Ustawienia"
 
 #: pcbnew/menubar_pcb_editor.cpp:143
 msgid "Ro&ute"
@@ -24781,7 +24970,7 @@ msgstr "Trasowanie"
 
 #: pcbnew/menubar_pcb_editor.cpp:163
 msgid "&Layers Setup..."
-msgstr "Ustawienia warstw..."
+msgstr "&Ustawienia warstw..."
 
 #: pcbnew/menubar_pcb_editor.cpp:164
 msgid "Enable and set layer properties"
@@ -24793,7 +24982,7 @@ msgstr "Reguły projektowe..."
 
 #: pcbnew/menubar_pcb_editor.cpp:169
 msgid "Open design rules editor"
-msgstr ""
+msgstr "Otwiera edytor reguł projektowych"
 
 #: pcbnew/menubar_pcb_editor.cpp:181
 msgid "Adjust default pad characteristics"
@@ -24801,11 +24990,11 @@ msgstr "Ustaw domyslne właściwości pól lutowniczych"
 
 #: pcbnew/menubar_pcb_editor.cpp:185
 msgid "Pads to &Mask Clearance..."
-msgstr "Prześwit maski lutowniczej..."
+msgstr "Prześwit masek na polach lutowniczych..."
 
 #: pcbnew/menubar_pcb_editor.cpp:186
 msgid "Adjust global clearance between pads and solder resist mask"
-msgstr ""
+msgstr "Ustala globalną wartość prześwitu pomiędzy polami lut. a soldermaską"
 
 #: pcbnew/menubar_pcb_editor.cpp:190
 msgid "&Differential Pairs..."
@@ -24813,21 +25002,23 @@ msgstr "Pary różnicowe..."
 
 #: pcbnew/menubar_pcb_editor.cpp:191
 msgid "Define global gap/width for differential pairs."
-msgstr ""
+msgstr "Definiuje globalną wartość przerwy/szerokości par różnicowych."
 
 #: pcbnew/menubar_pcb_editor.cpp:206
 msgid "&General Settings"
-msgstr "Ustawienia &główne"
+msgstr "Ustawienia główne"
 
 #: pcbnew/menubar_pcb_editor.cpp:206
 msgid "Select general options for Pcbnew"
-msgstr "Główne ustawienia dla Pcbnew"
+msgstr "Wybiera główne ustawienia dla Pcbnew"
 
 #: pcbnew/menubar_pcb_editor.cpp:213
 msgid ""
 "Graphics acceleration, grid, cursor, annotation and clearance outline "
 "settings."
 msgstr ""
+"Akceleracja, siatka, ustawienia kursora, numeracja oraz ustawienia obrysu "
+"prześwitu."
 
 #: pcbnew/menubar_pcb_editor.cpp:261
 msgid "&Single Track"
@@ -24835,7 +25026,7 @@ msgstr "Pojedyncza ścieżka"
 
 #: pcbnew/menubar_pcb_editor.cpp:264
 msgid "Interactively route single track"
-msgstr ""
+msgstr "Interaktywnie trasuje pojedyncze ścieżki"
 
 #: pcbnew/menubar_pcb_editor.cpp:267
 msgid "&Differential Pair"
@@ -24843,7 +25034,7 @@ msgstr "Pary różnicowe"
 
 #: pcbnew/menubar_pcb_editor.cpp:270
 msgid "Interactively route differential pair"
-msgstr ""
+msgstr "Interaktywnie trasuje ścieżki par różnicowych"
 
 #: pcbnew/menubar_pcb_editor.cpp:275
 msgid "&Tune Track Length"
@@ -24851,7 +25042,7 @@ msgstr "Dostrój długość ścieżki"
 
 #: pcbnew/menubar_pcb_editor.cpp:278
 msgid "Tune length of single track"
-msgstr ""
+msgstr "Dostraja długość pojedynczych ścieżek"
 
 #: pcbnew/menubar_pcb_editor.cpp:281
 msgid "Tune Differential Pair &Length"
@@ -24859,7 +25050,7 @@ msgstr "Dostrajanie długości par różnicowych"
 
 #: pcbnew/menubar_pcb_editor.cpp:284
 msgid "Tune length of differential pair"
-msgstr ""
+msgstr "Dostraja długość ścieżek par różnicowych"
 
 #: pcbnew/menubar_pcb_editor.cpp:287
 msgid "Tune Differential Pair &Skew/Phase"
@@ -24873,11 +25064,11 @@ msgstr ""
 
 #: pcbnew/menubar_pcb_editor.cpp:296
 msgid "&Interactive Router Settings..."
-msgstr "Ustawienia &interaktywnego routera..."
+msgstr "Ustawienia interaktywnego routera..."
 
 #: pcbnew/menubar_pcb_editor.cpp:297
 msgid "Configure interactive router"
-msgstr "Konfiguracja interaktywnego routera"
+msgstr "Konfiguruje router interaktywny"
 
 #: pcbnew/menubar_pcb_editor.cpp:308
 msgid "&List Nets"
@@ -24885,33 +25076,27 @@ msgstr "&Lista Sieci"
 
 #: pcbnew/menubar_pcb_editor.cpp:309
 msgid "View list of nets with names and IDs"
-msgstr ""
+msgstr "Pokazuje listę sieci razem z ich nazwami oraz numerami ID"
 
 #: pcbnew/menubar_pcb_editor.cpp:320
 msgid "&Design Rules Checker"
-msgstr "Kontroler reguł projektowych (DRC)"
+msgstr "Sprawdzenie reguł projektu (DRC)"
 
 #: pcbnew/menubar_pcb_editor.cpp:321 pcbnew/tool_pcb_editor.cpp:305
 msgid "Perform design rules check"
 msgstr "Kontrola reguł projektowych PCB"
 
 #: pcbnew/menubar_pcb_editor.cpp:337
-#, fuzzy
 msgid "Edit the global and project footprint library lists"
-msgstr ""
-"Wystąpił błąd przy próbie zapisu globlalnej tablicy bibliotek footprintów:\n"
-"'%s'\n"
-"%s"
+msgstr "Edycja globalnej oraz projektowej tabeli bibliotek symboli"
 
 #: pcbnew/menubar_pcb_editor.cpp:342
-#, fuzzy
 msgid "Add &3D Shapes Libraries Wizard..."
-msgstr "Kreator pobierania plików modeli 3D"
+msgstr "Dodaj przez Kreatora pobierania modeli 3D..."
 
 #: pcbnew/menubar_pcb_editor.cpp:343
-#, fuzzy
 msgid "Download 3D shape libraries from GitHub"
-msgstr "Pobieranie bibliotek modeli 3D"
+msgstr "Pobieranie bibliotek modeli 3D z platformy GitHub"
 
 #: pcbnew/menubar_pcb_editor.cpp:354
 msgid "&Footprint"
@@ -24931,7 +25116,7 @@ msgstr "Strefa"
 
 #: pcbnew/menubar_pcb_editor.cpp:363
 msgid "Add filled zone"
-msgstr "Dodaj wypełnioną strefę"
+msgstr "Dodaj strefę"
 
 #: pcbnew/menubar_pcb_editor.cpp:366
 msgid "&Keepout Area"
@@ -24939,7 +25124,7 @@ msgstr "Strefa chroniona"
 
 #: pcbnew/menubar_pcb_editor.cpp:367
 msgid "Add keepout area"
-msgstr "Dodaje strefę chronioną"
+msgstr "Dodaj strefę chronioną"
 
 #: pcbnew/menubar_pcb_editor.cpp:370
 msgid "Te&xt"
@@ -24955,7 +25140,7 @@ msgstr "Wymiary"
 
 #: pcbnew/menubar_pcb_editor.cpp:396
 msgid "La&yer Alignment Target"
-msgstr "Punkt w&yrównania warstw"
+msgstr "Znacznik pozycjonowania warstw"
 
 #: pcbnew/menubar_pcb_editor.cpp:402
 msgid "Drill and &Place Offset"
@@ -24963,35 +25148,35 @@ msgstr "Przesunięcie dla wierceń i ustawień elementów"
 
 #: pcbnew/menubar_pcb_editor.cpp:403
 msgid "Place origin point for drill and place files"
-msgstr ""
+msgstr "Umieszcza punkt odniesienia dla wierceń oraz plików położeń"
 
 #: pcbnew/menubar_pcb_editor.cpp:417
 msgid "Load &Netlist..."
-msgstr "Wczytaj listę połączeń..."
+msgstr "Wczytaj listę sieci..."
 
 #: pcbnew/menubar_pcb_editor.cpp:418
 msgid "Read netlist and update board connectivity"
-msgstr ""
+msgstr "Wczytuje listę sieci oraz aktualizuje połączenia na płytce"
 
 #: pcbnew/menubar_pcb_editor.cpp:424
 msgid "Update PCB design with current schematic (forward annotation)"
-msgstr ""
+msgstr "Uaktualnia PCB na podstawie bieżącego schematu"
 
 #: pcbnew/menubar_pcb_editor.cpp:430
 msgid "Update Footprints from Library..."
-msgstr "Aktualizacja footprintów z biblioteki..."
+msgstr "Uaktualnij footprinty z biblioteki..."
 
 #: pcbnew/menubar_pcb_editor.cpp:431
 msgid "Update footprints to include any changes from the library"
-msgstr "Zaktualizuj footprinty aby uwzględnić zmiany w bibliotece"
+msgstr "Uaktualnia footprinty by dołączyć wszystkie zmiany w bibliotece"
 
 #: pcbnew/menubar_pcb_editor.cpp:437
 msgid "Set &Layer Pair..."
-msgstr "Ustaw parę warstw sygnałowych..."
+msgstr "Ustaw parę warstw..."
 
 #: pcbnew/menubar_pcb_editor.cpp:437
 msgid "Change active layer pair"
-msgstr "Zmień aktywną parę warstw sygnałowych"
+msgstr "Ustawia aktywną w danej chwili parę warstw do umieszczania przelotek"
 
 #: pcbnew/menubar_pcb_editor.cpp:442
 msgid "&Scripting Console"
@@ -24999,15 +25184,15 @@ msgstr "Konsola &Skryptów"
 
 #: pcbnew/menubar_pcb_editor.cpp:443
 msgid "Show/Hide the Python scripting console"
-msgstr "Włącza konsolę skryptów Python"
+msgstr "Pokzuje/Ukrywa konsolę skryptów Python"
 
 #: pcbnew/menubar_pcb_editor.cpp:453
 msgid "&External Plugins..."
-msgstr "Zewnętrzna wtyczka..."
+msgstr "Zewnętrzne wtyczki..."
 
 #: pcbnew/menubar_pcb_editor.cpp:454
 msgid "Execute or reload python action plugins"
-msgstr ""
+msgstr "Uruchamia lub przeładowuje aktywne skrypty Python"
 
 #: pcbnew/menubar_pcb_editor.cpp:458
 msgid "&Refresh Plugins"
@@ -25015,23 +25200,24 @@ msgstr "Odśwież wtyczki"
 
 #: pcbnew/menubar_pcb_editor.cpp:459
 msgid "Reload all python plugins and refresh plugin menus"
-msgstr ""
+msgstr "Przeładowuje wszystkie wtyczki Python oraz odświeża menu wytczek"
 
 #: pcbnew/menubar_pcb_editor.cpp:484
 msgid "Display current hotkeys list and corresponding commands"
 msgstr ""
+"Wyświetla bieżącą tabelę skrótów klawiszowych oraz przypisane im polecenia"
 
 #: pcbnew/menubar_pcb_editor.cpp:545 pcbnew/onrightclick.cpp:610
 msgid "Edit All Tracks and Vias..."
-msgstr "Edytuj wszystkie ścieżki i przelotki..."
+msgstr "Edycja rozmiarów wszystkich ścieżek i przelotek..."
 
 #: pcbnew/menubar_pcb_editor.cpp:548
 msgid "Set Footp&rint Field Sizes..."
-msgstr "Ustaw rozmiar pól wszystkich footprintów..."
+msgstr "Ustaw domyślny &rozmiar pól footprintów..."
 
 #: pcbnew/menubar_pcb_editor.cpp:549
 msgid "Set text size and width of footprint fields"
-msgstr ""
+msgstr "Ustawia rozmiar tekstu oraz szerokość linii dla pól footprintów"
 
 #: pcbnew/menubar_pcb_editor.cpp:553
 msgid "Change Footprints..."
@@ -25039,35 +25225,33 @@ msgstr "Zamień footprinty..."
 
 #: pcbnew/menubar_pcb_editor.cpp:554
 msgid "Assign different footprints from the library"
-msgstr ""
+msgstr "Przypisuje inne footprinty z biblioteki"
 
 #: pcbnew/menubar_pcb_editor.cpp:558
-#, fuzzy
 msgid "&Move and Swap Layers..."
-msgstr "Zamień war&stwy..."
+msgstr "&Przemieść i zamień warstwy..."
 
 #: pcbnew/menubar_pcb_editor.cpp:559
-#, fuzzy
 msgid "Move tracks or drawings from a layer to another layer"
-msgstr "Zamień ścieżki na warstwach ścieżek lub rysunki na innych warstwach"
+msgstr "Przemieszcza ścieżki lub rysunki z jednej warstwy na inną"
 
 #: pcbnew/menubar_pcb_editor.cpp:564
 msgid "&Global Deletions..."
-msgstr "&Globalne usuwanie..."
+msgstr "Usuwanie &globalne..."
 
 #: pcbnew/menubar_pcb_editor.cpp:565
-#, fuzzy
 msgid "Delete tracks, footprints and graphic items from board"
-msgstr "Usuwa ścieżki, footprinty i teksty na płytce"
+msgstr "Usuwa ścieżki, footprinty oraz elementy graficzne z płytki"
 
 #: pcbnew/menubar_pcb_editor.cpp:569
 msgid "&Cleanup Tracks and Vias..."
-msgstr "Wyczyść nadmiarowe ścieżki i przelotki..."
+msgstr "O&czyść ścieżki i przelotki..."
 
 #: pcbnew/menubar_pcb_editor.cpp:570
 msgid "Clean stubs, vias, delete break points or unconnected tracks"
 msgstr ""
-"Wyczyść odcinki, przelotki, usuń przerwane punkty lub niepołączone ścieżki"
+"Przeprowadza czyszczenie niepodłączonych zalążków ścieżek, przelotek, "
+"niepotrzebnych przełamań ścieżek"
 
 #: pcbnew/menubar_pcb_editor.cpp:581
 msgid "Show La&yers Manager"
@@ -25092,11 +25276,11 @@ msgstr "Pokaż połączenia wspomagające płytki"
 
 #: pcbnew/menubar_pcb_editor.cpp:689
 msgid "&Fill Zones"
-msgstr "Strefy wypełnień"
+msgstr "Wypełnij strefy"
 
 #: pcbnew/menubar_pcb_editor.cpp:693
 msgid "&Wireframe Zones"
-msgstr "Zarys stref"
+msgstr "Strefy jako obszary kreskowane"
 
 #: pcbnew/menubar_pcb_editor.cpp:693 pcbnew/tool_pcb_editor.cpp:389
 msgid "Show outlines of filled areas only in zones"
@@ -25130,11 +25314,11 @@ msgstr "Pokaż ścieżki jako zarys"
 
 #: pcbnew/menubar_pcb_editor.cpp:717
 msgid "Sketch &Graphic Items"
-msgstr "Zarys obiektów graficznych"
+msgstr "Graficzne elementy jako szkice"
 
 #: pcbnew/menubar_pcb_editor.cpp:717
 msgid "Show graphic items in outline mode"
-msgstr ""
+msgstr "Pokaż tylko zarys elementów graficznych"
 
 #: pcbnew/menubar_pcb_editor.cpp:762
 msgid "Flip &Board View"
@@ -25142,11 +25326,11 @@ msgstr "Odwróć widok płytki"
 
 #: pcbnew/menubar_pcb_editor.cpp:763
 msgid "Flip (mirror) the board view"
-msgstr "Odwraca (odbicie lustrzane) widok płytki"
+msgstr "Odwraca (lustrzanie) widok płytki"
 
 #: pcbnew/menubar_pcb_editor.cpp:799
 msgid "Create new board"
-msgstr "Utwórz nową płytkę"
+msgstr "Utwórz nowy obwód drukowany"
 
 #: pcbnew/menubar_pcb_editor.cpp:804 pcbnew/tool_pcb_editor.cpp:249
 msgid "Open existing board"
@@ -25154,7 +25338,7 @@ msgstr "Otwórz istniejącą płytkę"
 
 #: pcbnew/menubar_pcb_editor.cpp:809
 msgid "Open recently opened board"
-msgstr "Otwórz ostatnio otwieraną płytkę"
+msgstr "Otwórz ostatnio otwierany obwód drukowany"
 
 #: pcbnew/menubar_pcb_editor.cpp:817
 msgid "Save current board"
@@ -25166,15 +25350,15 @@ msgstr "Zapisz jako..."
 
 #: pcbnew/menubar_pcb_editor.cpp:829
 msgid "Save current board with new name"
-msgstr "Zapisz bieżącą płytką z nową nazwą"
+msgstr "Zapisuje bieżący projekt PCB z nową nazwą"
 
 #: pcbnew/menubar_pcb_editor.cpp:836
 msgid "Sa&ve Copy As..."
-msgstr "Zapisz jako..."
+msgstr "Zapisz kopię jako..."
 
 #: pcbnew/menubar_pcb_editor.cpp:838
 msgid "Save copy of the current board"
-msgstr "Zapisz kopię aktualnej płytki"
+msgstr "Zapisuje kopię bieżącego projektu PCB"
 
 #: pcbnew/menubar_pcb_editor.cpp:845
 msgid "Resc&ue"
@@ -25188,23 +25372,23 @@ msgstr ""
 
 #: pcbnew/menubar_pcb_editor.cpp:852
 msgid "&Append Board..."
-msgstr "Dołącz płytkę..."
+msgstr "&Dołącz płytkę..."
 
 #: pcbnew/menubar_pcb_editor.cpp:853
 msgid "Append another board to currently loaded board"
-msgstr "Dodaje kolejną płytkę do aktualnie wczytanej płytki"
+msgstr "Dołącza inny projekt płytki do bieżąco załadowanej płytki"
 
 #: pcbnew/menubar_pcb_editor.cpp:857
 msgid "Import Non-KiCad Board File..."
-msgstr "Importuje inne pliki schematów niż KiCad"
+msgstr "Importuj obwód drukowany spoza programu KiCad..."
 
 #: pcbnew/menubar_pcb_editor.cpp:858
 msgid "Import board file from other applications"
-msgstr "Importuje pliki płytek z innych aplikacji"
+msgstr "Importuje plik z obwodem drukowanym z innych aplikacji"
 
 #: pcbnew/menubar_pcb_editor.cpp:863
 msgid "Revert to Las&t Backup"
-msgstr "Przywróć z os&tatniej kopii zapasowej"
+msgstr "Przywróć do stanu z ostatniej kopii zapasowej"
 
 #: pcbnew/menubar_pcb_editor.cpp:864
 msgid "Clear board and get previous backup version of board"
@@ -25212,19 +25396,19 @@ msgstr "Czyści obszar roboczy i pobiera dane z danych zapasowych"
 
 #: pcbnew/menubar_pcb_editor.cpp:873
 msgid "&Specctra Session..."
-msgstr "&Sesja Spectra..."
+msgstr "Sesja &Specctra..."
 
 #: pcbnew/menubar_pcb_editor.cpp:874
 msgid "Import routed \"Specctra Session\" (*.ses) file"
-msgstr "Importuje plik trasowań \"Spectra Session\" (*.ses)"
+msgstr "Importuje plik \"Spectra Session\" (*.ses)"
 
 #: pcbnew/menubar_pcb_editor.cpp:878
 msgid "&DXF File..."
-msgstr "Plik &DXF..."
+msgstr "Plik DXF..."
 
 #: pcbnew/menubar_pcb_editor.cpp:879
 msgid "Import 2D Drawing DXF file to Pcbnew on Drawings layer"
-msgstr "Importuje pliki rysunków 2D w Pcbnew na warstwę rysunkową"
+msgstr "Importuj rysunek 2D z pliku DXF do Pcbnew na warstwę rysunków"
 
 #: pcbnew/menubar_pcb_editor.cpp:893
 msgid "Export board"
@@ -25232,7 +25416,7 @@ msgstr "Eksportuj płytkę"
 
 #: pcbnew/menubar_pcb_editor.cpp:899
 msgid "Footprint &Position (.pos) File..."
-msgstr ""
+msgstr "Plik położeń footprintów (.pos)..."
 
 #: pcbnew/menubar_pcb_editor.cpp:900
 msgid "Generate footprint position file for pick and place"
@@ -25240,7 +25424,7 @@ msgstr "Generuj plik położeń footprintów dla automatów montujących"
 
 #: pcbnew/menubar_pcb_editor.cpp:904
 msgid "&Drill (.drl) File..."
-msgstr "Plik wierceń (.drl)"
+msgstr "Plik &wierceń (.drl)..."
 
 #: pcbnew/menubar_pcb_editor.cpp:905
 msgid "Generate excellon2 drill file"
@@ -25248,11 +25432,11 @@ msgstr "Generuj plik wierceń EXCELLON2"
 
 #: pcbnew/menubar_pcb_editor.cpp:909
 msgid "&Footprint (.rpt) Report..."
-msgstr ""
+msgstr "Raport ilościowy footprintów (.rpt)..."
 
 #: pcbnew/menubar_pcb_editor.cpp:910
 msgid "Create report of all footprints from current board"
-msgstr ""
+msgstr "Tworzy raport wszystkich footprintów użytych na bieżącej płytce"
 
 #: pcbnew/menubar_pcb_editor.cpp:914
 msgid "IPC-D-356 Netlist File..."
@@ -25264,11 +25448,11 @@ msgstr "Generuj listę sieci formatu IPC-D-356"
 
 #: pcbnew/menubar_pcb_editor.cpp:919
 msgid "&BOM File..."
-msgstr "Plik &BOM..."
+msgstr "Plik materiałowy..."
 
 #: pcbnew/menubar_pcb_editor.cpp:920
 msgid "Create bill of materials from current schematic"
-msgstr "Tworzy plik listy materiałów z bieżącego schematu"
+msgstr "Tworzy listę materiałową dla bieżącego schematu"
 
 #: pcbnew/menubar_pcb_editor.cpp:924
 msgid "&Fabrication Outputs"
@@ -25288,7 +25472,7 @@ msgstr "Rysuj PCB (Format HPGL, PostScript lub Gerber RS-274X)"
 
 #: pcbnew/menubar_pcb_editor.cpp:951
 msgid "&Archive Footprints in Existing Library..."
-msgstr "&Archiwizuje footprinty w istniejącej bibliotece..."
+msgstr "Archiwizuj footprinty w bibliotece projektu..."
 
 #: pcbnew/menubar_pcb_editor.cpp:952
 msgid ""
@@ -25296,19 +25480,19 @@ msgid ""
 "remove other footprints in this library)"
 msgstr ""
 "Archiwizuje wszystkie footprinty w istniejącej bibliotece w tabeli bibliotek "
-"(nie usuwa innych footprintów w tej bibliotece)"
+"(nie usuwa pozostałych footprintów z tej biblioteki)"
 
 #: pcbnew/menubar_pcb_editor.cpp:957
 msgid "&Create New Library and Archive Footprints..."
-msgstr "Utwórz nową bibliotekę i archiwizuj footprinty..."
+msgstr "Utwórz nową bibliotekę oraz zarchiwizuj w niej footprinty..."
 
 #: pcbnew/menubar_pcb_editor.cpp:958
 msgid ""
 "Archive all footprints in new library\n"
 "(if the library already exists it will be deleted)"
 msgstr ""
-"Archiwizuje wszystkie footprinty w nowej bibliotece (jeśli biblioteka już "
-"istnieje, zostanie usunięta)"
+"Archiwizuje footprinty w nowej bibliotece\n"
+"(Jeśli biblioteka nie była pusta, usuwa pozostałe footprinty z biblioteki)"
 
 #: pcbnew/menubar_pcb_editor.cpp:964
 msgid "Arc&hive Footprints"
@@ -25324,11 +25508,11 @@ msgstr "Zamknij Pcbnew"
 
 #: pcbnew/menubar_pcb_editor.cpp:977
 msgid "S&pecctra DSN..."
-msgstr "S&pecctra DSN..."
+msgstr "&Specctra DSN..."
 
 #: pcbnew/menubar_pcb_editor.cpp:978
 msgid "Export current board to \"Specctra DSN\" file"
-msgstr "Eksportuj bieżącą płytkę do pliku \"Spectra DSN\""
+msgstr "Eksportuje bieżącą płytkę do pliku \"Specctra DSN\""
 
 #: pcbnew/menubar_pcb_editor.cpp:982
 msgid "&GenCAD..."
@@ -25340,27 +25524,27 @@ msgstr "Eksportuj w formacie GenCAD"
 
 #: pcbnew/menubar_pcb_editor.cpp:986
 msgid "&VRML..."
-msgstr "&GenCAD..."
+msgstr "&VRML..."
 
 #: pcbnew/menubar_pcb_editor.cpp:987
 msgid "Export VRML board representation"
-msgstr ""
+msgstr "Eksportuje obraz płytki w formacie VRML"
 
 #: pcbnew/menubar_pcb_editor.cpp:991
 msgid "I&DFv3..."
-msgstr "I&DFv3..."
+msgstr "IDFv3..."
 
 #: pcbnew/menubar_pcb_editor.cpp:991
 msgid "IDFv3 board and symbol export"
-msgstr "Eksportuje kształt płytki do pliku w formacie IDFv3"
+msgstr "Eksport obwodu i symbolu IDFv3"
 
 #: pcbnew/menubar_pcb_editor.cpp:995
 msgid "S&TEP..."
-msgstr "S&TEP..."
+msgstr "STEP..."
 
 #: pcbnew/menubar_pcb_editor.cpp:995
 msgid "STEP export"
-msgstr "Eksportuje do pliku  STEP"
+msgstr "Eksportowanie w formacie STEP"
 
 #: pcbnew/menubar_pcb_editor.cpp:999
 msgid "&SVG..."
@@ -25368,27 +25552,27 @@ msgstr "&SVG..."
 
 #: pcbnew/menubar_pcb_editor.cpp:1000
 msgid "Export board file in Scalable Vector Graphics format"
-msgstr ""
+msgstr "Eksportuje płytkę w formacie Scalable Vector Graphics (SVG)"
 
 #: pcbnew/menubar_pcb_editor.cpp:1004
 msgid "&Footprint Association (.cmp) File..."
-msgstr ""
+msgstr "Plik przypisań footprintów (.cmp)..."
 
 #: pcbnew/menubar_pcb_editor.cpp:1005
 msgid "Export footprint association file (*.cmp) for schematic back annotation"
-msgstr ""
+msgstr "Eksportuj plik przypisań footprintów (*.cmp) dla numeracji wstecznej"
 
 #: pcbnew/microwave.cpp:246
 msgid "Gap Size:"
-msgstr "Rozmiar przerwy:"
+msgstr "Rozmiar odstępu:"
 
 #: pcbnew/microwave.cpp:252
 msgid "Stub Size:"
-msgstr ""
+msgstr "Rozmiar czopu:"
 
 #: pcbnew/microwave.cpp:259
 msgid "Arc Stub Radius Value:"
-msgstr ""
+msgstr "Promień łuku czopu:"
 
 #: pcbnew/microwave.cpp:270 pcbnew/microwave.cpp:288
 msgid "Create microwave module"
@@ -25444,7 +25628,7 @@ msgstr "Tylko jedno pole lutownicze dla tego footprintu"
 
 #: pcbnew/microwave.cpp:725
 msgid "Gap:"
-msgstr "Odstęp"
+msgstr "Odstęp:"
 
 #: pcbnew/microwave.cpp:725
 msgid "Create Microwave Gap"
@@ -25533,7 +25717,7 @@ msgstr "Komponenty"
 #: pcbnew/netlist.cpp:254
 #, c-format
 msgid "No footprint defined for symbol \"%s\".\n"
-msgstr ""
+msgstr "Nie ma zdefiniowanego footprintu dla symbolu \"%s\".\n"
 
 #: pcbnew/netlist.cpp:276
 #, c-format
@@ -25541,11 +25725,14 @@ msgid ""
 "Footprint of symbol \"%s\" changed: board footprint \"%s\", netlist "
 "footprint \"%s\"\n"
 msgstr ""
+"Footprint symbolu \"%s\" zmieniony: footprint na płytce \"%s\", lista sieci "
+"\"%s\"\n"
 
 #: pcbnew/netlist.cpp:306
 #, c-format
 msgid "Component \"%s\" footprint ID \"%s\" is not valid.\n"
 msgstr ""
+"Komponent \"%s\", identyfikator footprintu \"%s\" jest nieprawidłowy.\n"
 
 #: pcbnew/netlist.cpp:327
 #, c-format
@@ -25553,6 +25740,8 @@ msgid ""
 "Component \"%s\" footprint \"%s\" was not found in any libraries in the "
 "footprint library table.\n"
 msgstr ""
+"Komponent \"%s\", footprint \"%s\" nie został znaleziony w żadnej z "
+"bibliotek znajdującej się w tabeli bibliotek.\n"
 
 #: pcbnew/netlist_reader.cpp:181
 #, c-format
@@ -25561,6 +25750,9 @@ msgid ""
 "file: \"%s\"\n"
 "line: %d"
 msgstr ""
+"nieznany ID footprintu w\n"
+"plik: \"%s\"\n"
+"linia: %d"
 
 #: pcbnew/onleftclick.cpp:262
 msgid "Graphic not allowed on Copper layers"
@@ -25568,7 +25760,7 @@ msgstr "Grafika nie może być umieszczona na warstwie ścieżek"
 
 #: pcbnew/onleftclick.cpp:286 pcbnew/router/router_tool.cpp:651
 msgid "Tracks on Copper layers only"
-msgstr ""
+msgstr "Tylko ścieżki na warstwach miedzi"
 
 #: pcbnew/onleftclick.cpp:345
 msgid "Texts not allowed on Edge Cut layer"
@@ -25582,11 +25774,11 @@ msgstr ""
 
 #: pcbnew/onleftclick.cpp:450
 msgid "Via Tool not available in Legacy Toolset"
-msgstr ""
+msgstr "Narzędzie do stawiania przelotek nie jest dostępne w zestawie Legacy"
 
 #: pcbnew/onleftclick.cpp:455
 msgid "Measurement Tool not available in Legacy Toolset"
-msgstr ""
+msgstr "Narzędzie do pomiaru odległości nie jest dostępne w zestawie Legacy"
 
 #: pcbnew/onrightclick.cpp:194
 msgid "Delete All Drawings on Layer"
@@ -25606,13 +25798,13 @@ msgstr "Usuń ostatni narożnik"
 
 #: pcbnew/onrightclick.cpp:319
 msgid "Get and Move Footprint..."
-msgstr ""
+msgstr "Uchwyć element i przesuń..."
 
 #: pcbnew/onrightclick.cpp:344 pcbnew/onrightclick.cpp:350
 #: pcbnew/onrightclick.cpp:368 pcbnew/onrightclick.cpp:381
 #: pcbnew/onrightclick.cpp:418 pcbnew/onrightclick.cpp:512
 msgid "Select Working Layer..."
-msgstr ""
+msgstr "Wybierz warstwę roboczą..."
 
 #: pcbnew/onrightclick.cpp:358 pcbnew/onrightclick.cpp:410
 #: pcbnew/onrightclick.cpp:459
@@ -25626,7 +25818,7 @@ msgstr "Wybierz szerokość ścieżki"
 
 #: pcbnew/onrightclick.cpp:370
 msgid "Select Layer Pair for Vias..."
-msgstr ""
+msgstr "Wybierz parę warstw dla przelotek..."
 
 #: pcbnew/onrightclick.cpp:389
 msgid "Footprint Documentation"
@@ -25672,7 +25864,7 @@ msgstr "Przeciągnij segment"
 
 #: pcbnew/onrightclick.cpp:501
 msgid "Create Track Array..."
-msgstr ""
+msgstr "Utwórz szyk ścieżek..."
 
 #: pcbnew/onrightclick.cpp:507 pcbnew/router/router_tool.cpp:122
 msgid "Break Track"
@@ -25693,7 +25885,7 @@ msgstr "Wstaw przelotkę na wylot"
 
 #: pcbnew/onrightclick.cpp:531 pcbnew/router/router_tool.cpp:171
 msgid "Select Layer and Place Through Via..."
-msgstr ""
+msgstr "Wybierz warstwę i wstaw przelotkę na wylot..."
 
 #: pcbnew/onrightclick.cpp:538 pcbnew/router/router_tool.cpp:157
 msgid "Place Blind/Buried Via"
@@ -25701,7 +25893,7 @@ msgstr "Wstaw przelotkę ślepą/zagrzebaną"
 
 #: pcbnew/onrightclick.cpp:542 pcbnew/router/router_tool.cpp:179
 msgid "Select Layer and Place Blind/Buried Via..."
-msgstr ""
+msgstr "Wybierz warstwę i wstaw przelotkę ślepą/zagrzebaną..."
 
 #: pcbnew/onrightclick.cpp:556
 msgid "Place Micro Via"
@@ -25790,7 +25982,7 @@ msgstr "Przeciągnij segment obrysu"
 # sprawdzić
 #: pcbnew/onrightclick.cpp:684
 msgid "Add Similar Zone"
-msgstr "Dodaj strefę \"bliźniaczą\""
+msgstr "Dodaj strefę bliźniaczą"
 
 #: pcbnew/onrightclick.cpp:687
 msgid "Add Cutout Area"
@@ -25798,7 +25990,7 @@ msgstr "Dodaj obszar odcięty"
 
 #: pcbnew/onrightclick.cpp:690 pcbnew/tools/pcb_editor_control.cpp:100
 msgid "Duplicate Zone onto Layer..."
-msgstr ""
+msgstr "Klonuj strefę na inną warstwę..."
 
 #: pcbnew/onrightclick.cpp:695 pcbnew/tools/zone_filler_tool.cpp:93
 msgid "Fill Zone"
@@ -25814,7 +26006,7 @@ msgstr "Przesuń strefę"
 
 #: pcbnew/onrightclick.cpp:707
 msgid "Move Zone Exactly..."
-msgstr ""
+msgstr "Przesuń strefę dokładnie..."
 
 #: pcbnew/onrightclick.cpp:712
 msgid "Edit Zone Properties..."
@@ -25830,11 +26022,11 @@ msgstr "Usuń obrys strefy"
 
 #: pcbnew/onrightclick.cpp:765
 msgid "Edit Parameters..."
-msgstr "Edytuj parametry..."
+msgstr "Edycja parametrów..."
 
 #: pcbnew/onrightclick.cpp:800 pcbnew/tools/edit_tool.cpp:157
 msgid "Update Footprint..."
-msgstr "Aktualizuj footprint"
+msgstr "Uaktualnij footprint..."
 
 #: pcbnew/onrightclick.cpp:803 pcbnew/tools/edit_tool.cpp:162
 msgid "Change Footprint..."
@@ -25861,6 +26053,8 @@ msgid ""
 "Copy this pad's properties to all pads in this footprint (or similar "
 "footprints)"
 msgstr ""
+"Kopiuje właściwości tego pola lut. do wszystkich pól lut. tego footprintu "
+"(lub podobnych fooprintów)"
 
 #: pcbnew/onrightclick.cpp:999
 msgid "Auto Width"
@@ -25872,7 +26066,7 @@ msgid ""
 "width"
 msgstr ""
 "Użyj szerokości ścieżki gdy zaczynasz na ścieżce. W przeciwnym wypadku użyj "
-"bieżącej szerokości ścieżki."
+"bieżącej szerokości ścieżki"
 
 #: pcbnew/onrightclick.cpp:1010
 msgid "Use Netclass Values"
@@ -25908,7 +26102,7 @@ msgstr "Usunąć pole lut. (footprint %s %s) ?"
 
 #: pcbnew/pcb_base_frame.cpp:192
 msgid "Error loading project footprint libraries"
-msgstr ""
+msgstr "Błąd podczas wczytywania bibliotek footprintów projektu"
 
 #: pcbnew/pcb_base_frame.cpp:613
 msgid "Display rectangular coordinates"
@@ -25923,23 +26117,21 @@ msgid "Zoom "
 msgstr "Powiększenie "
 
 #: pcbnew/pcb_edit_frame.cpp:403
-#, fuzzy
 msgid "Layers Manager"
-msgstr "Ukryj menadżera warstw"
+msgstr "Menadżer warstw"
 
 #: pcbnew/pcb_edit_frame.cpp:709
 #, c-format
 msgid "The auto save file \"%s\" could not be removed!"
-msgstr "Plik automatycznej kopii zapasowej \"%s\" nie może zostać usunięty!"
+msgstr "Plik autozapisu \"%s\" nie może zostać usunięty!"
 
 #: pcbnew/pcb_edit_frame.cpp:1112
 msgid " [new file]"
 msgstr " [nowy plik]"
 
 #: pcbnew/pcb_edit_frame.cpp:1116
-#, fuzzy
 msgid "Pcbnew"
-msgstr "Uruchom Pcbnew"
+msgstr "Pcbnew"
 
 #: pcbnew/pcb_edit_frame.cpp:1227
 msgid ""
@@ -25947,6 +26139,9 @@ msgid ""
 "order to create or update PCBs from schematics, you need to launch the KiCad "
 "project manager and create a PCB project."
 msgstr ""
+"Nie można uaktualnić PCB ponieważ Pcbnew jest uruchomiony jako samodzielna "
+"aplikacja. By utworzyć lub uaktualnić PCB na podstawie schematu należy "
+"uruchomić Menedżer programu KiCad oraz utworzyć projekt."
 
 #: pcbnew/pcb_layer_box_selector.cpp:97
 msgid "(not activated)"
@@ -25970,7 +26165,7 @@ msgstr "Pokaż footprinty umieszczone na warstwie dolnej"
 
 #: pcbnew/pcb_layer_widget.cpp:70
 msgid "Show footprint values"
-msgstr "Pokaż wartości footprintów"
+msgstr "Pokaż wartości dla footprintów"
 
 #: pcbnew/pcb_layer_widget.cpp:71
 msgid "References"
@@ -25982,7 +26177,7 @@ msgstr "Pokaż oznaczenia footprintów"
 
 #: pcbnew/pcb_layer_widget.cpp:72
 msgid "Footprint Text Front"
-msgstr "Footprint tekst górny"
+msgstr "Tekst footprintu na górnej warstwie"
 
 #: pcbnew/pcb_layer_widget.cpp:72
 msgid "Show footprint text on board's front"
@@ -25990,7 +26185,7 @@ msgstr "Pokaż opisy footprintu na warstwie górnej"
 
 #: pcbnew/pcb_layer_widget.cpp:73
 msgid "Footprint Text Back"
-msgstr "Footprint tekst dolny"
+msgstr "Tekst footprintu na dolnej warstwie"
 
 #: pcbnew/pcb_layer_widget.cpp:73
 msgid "Show footprint text on board's back"
@@ -26022,11 +26217,11 @@ msgstr "Pokaż pola lutownicze footprintu na warstwie dolnej"
 
 #: pcbnew/pcb_layer_widget.cpp:77
 msgid "Through Hole Pads"
-msgstr "Pola przelotowych otworów"
+msgstr "Pola lutownicza z otworem na wylot"
 
 #: pcbnew/pcb_layer_widget.cpp:77
 msgid "Show through hole pads in specific color"
-msgstr "Pokaż otwory przelotowe w określonym kolorze"
+msgstr "Wskaż pola z otworem na wylot wybranym kolorem"
 
 #: pcbnew/pcb_layer_widget.cpp:79
 msgid "Show tracks"
@@ -26050,11 +26245,11 @@ msgstr "Pokaź mikroprzelotki"
 
 #: pcbnew/pcb_layer_widget.cpp:83
 msgid "Non Plated Holes"
-msgstr "Nieplaterowane otwory"
+msgstr "Otwory niepowlekane"
 
 #: pcbnew/pcb_layer_widget.cpp:83
 msgid "Show non plated holes in specific color"
-msgstr "Pokazuje nieplaterowane otwory w określonym kolorze"
+msgstr "Pokazuje niepowlekane otwory w wybranym kolorze"
 
 #: pcbnew/pcb_layer_widget.cpp:85
 msgid "Ratsnest"
@@ -26082,11 +26277,11 @@ msgstr "Pokaż punkty bazowe footprintu i opisy w postaci krzyżyka"
 
 #: pcbnew/pcb_layer_widget.cpp:88
 msgid "Worksheet"
-msgstr "Arkusz roboczy"
+msgstr "Arkusz"
 
 #: pcbnew/pcb_layer_widget.cpp:88
 msgid "Show worksheet"
-msgstr "Pokaż arkusz roboczy"
+msgstr "Pokazuje arkusz"
 
 #: pcbnew/pcb_layer_widget.cpp:89
 msgid "Cursor"
@@ -26098,11 +26293,11 @@ msgstr "Kursor PCB"
 
 #: pcbnew/pcb_layer_widget.cpp:90
 msgid "Aux items"
-msgstr "Elementy pomocnicze"
+msgstr "Elementy zewnętrzne"
 
 #: pcbnew/pcb_layer_widget.cpp:90
 msgid "Auxiliary items (rulers, assistants, axes, etc.)"
-msgstr "Elementy pomocnicze (linijki, asystenci, osie itp.)"
+msgstr "Zewnętrzne elementy (miarki, asystenci, osie, itp.)"
 
 #: pcbnew/pcb_layer_widget.cpp:92
 msgid "Background"
@@ -26130,11 +26325,11 @@ msgstr "Ukryj wszystkie warstwy sygnałowe"
 
 #: pcbnew/pcb_layer_widget.cpp:187
 msgid "Show All Non Copper Layers"
-msgstr "Pokaż wszystkie warstwy bez miedzi"
+msgstr "Pokaż wszystkie warstwy niesygnałowe"
 
 #: pcbnew/pcb_layer_widget.cpp:190
 msgid "Hide All Non Copper Layers"
-msgstr "Ukryj wszystkie warstwy bez miedzi"
+msgstr "Ukryj wszystkie warstwy niesygnałowe"
 
 #: pcbnew/pcb_layer_widget.cpp:202
 msgid "Show All Front Layers"
@@ -26232,6 +26427,10 @@ msgid ""
 "line: %d\n"
 "offset: %d"
 msgstr ""
+"Nieprawidłowa liczba w\n"
+"plik: \"%s\"\n"
+"linia: %d\n"
+"przesunięcie: %d"
 
 #: pcbnew/pcb_parser.cpp:144
 #, c-format
@@ -26241,26 +26440,31 @@ msgid ""
 "line: %d\n"
 "offset: %d"
 msgstr ""
+"Brak liczby w\n"
+"plik: \"%s\"\n"
+"linia: %d\n"
+"przesunięcie: %d"
 
 #: pcbnew/pcb_parser.cpp:197
 #, c-format
 msgid "Cannot interpret date code %d"
-msgstr ""
+msgstr "Nie można zinterpretować kodu daty %d"
 
 #: pcbnew/pcb_parser.cpp:473 pcbnew/pcb_parser.cpp:578
 #, c-format
 msgid "Unknown token \"%s\""
-msgstr ""
+msgstr "Nieznany token \"%s\""
 
 #: pcbnew/pcb_parser.cpp:684
 #, c-format
 msgid "Page type \"%s\" is not valid "
-msgstr ""
+msgstr "Typ strony \"%s\" nie jest poprawny "
 
 #: pcbnew/pcb_parser.cpp:916
 #, c-format
 msgid "Layer \"%s\" in file \"%s\" at line %d, is not in fixed layer hash"
 msgstr ""
+"Warstwa \"%s\" w pliku \"%s\" w linii %d, nie znajduje się na liście warstw"
 
 #: pcbnew/pcb_parser.cpp:949
 #, c-format
@@ -26275,11 +26479,16 @@ msgid ""
 "at line %d, position %d\n"
 "was not defined in the layers section"
 msgstr ""
+"Warstwa \"%s\" w pliku\n"
+"\"%s\"\n"
+"w linii %d, pozycja %d\n"
+"nie została zdefiniowana w sekcji warstw"
 
 #: pcbnew/pcb_parser.cpp:1366
 #, c-format
 msgid "Duplicate NETCLASS name \"%s\" in file \"%s\" at line %d, offset %d"
 msgstr ""
+"Zduplikowana nazwa NETCLASS \"%s\" w pliku \"%s\" w linii %d, przesunięcie %d"
 
 #: pcbnew/pcb_parser.cpp:1802
 #, c-format
@@ -26289,11 +26498,15 @@ msgid ""
 "line: %d\n"
 "offset: %d"
 msgstr ""
+"Niepoprawny ID footprintu w\n"
+"plik: \"%s\"\n"
+"linia: %d\n"
+"przesunięcie: %d"
 
 #: pcbnew/pcb_parser.cpp:2053
 #, c-format
 msgid "Cannot handle footprint text type %s"
-msgstr ""
+msgstr "Nie mogę obsłużyć tekstu footprintu typu %s"
 
 #: pcbnew/pcb_parser.cpp:2478 pcbnew/pcb_parser.cpp:2484
 #: pcbnew/pcb_parser.cpp:2713 pcbnew/pcb_parser.cpp:2795
@@ -26305,6 +26518,10 @@ msgid ""
 "line: %d\n"
 "offset: %d"
 msgstr ""
+"Nieprawidłowy ID w\n"
+"plik: \"%s\"\n"
+"linia: %d\n"
+"przesunięcie: %d"
 
 #: pcbnew/pcb_parser.cpp:3185
 #, c-format
@@ -26328,12 +26545,22 @@ msgid ""
 "See the \"Footprint Library Table\" section of the CvPcb or Pcbnew "
 "documentation for more information."
 msgstr ""
+"Uruchomiłeś Pcbnew po raz pierwszy, używając nowej metody dostępu do "
+"bibliotek przez tabele bibliotek.\n"
+"Pcbnew skopiował domyślną tabelę lub utworzył pustą tabelę w folderze "
+"konfiguracji programu KiCad.\n"
+"Musisz najpierw skonfigurować tabelę bibliotek, aby uwzględnić wszystkie "
+"biblioteki footpritnów, które będziesz używać.\n"
+"Więcej informacji można znaleźć w sekcji \"Tabele bibliotek footprintów\" w "
+"podręczniku CvPcb lub Pcbnew."
 
 #: pcbnew/pcbnew.cpp:358
 msgid ""
 "An error occurred attempting to load the global footprint library table:\n"
 "Please edit this global footprint library table in Preferences menu"
 msgstr ""
+"Wystąpił błąd przy próbie załadowania globalnej tabeli bibliotek:\n"
+"Proszę dokonać edycji globalnej tabeli w menu Ustawienia"
 
 #: pcbnew/plot_board_layers.cpp:122 pcbnew/plot_board_layers.cpp:317
 #, c-format
@@ -26346,7 +26573,7 @@ msgstr "Włącz logowanie błędów dla funkcji Footprint*() w tej wtyczce."
 
 #: pcbnew/plugin.cpp:140
 msgid "Regular expression <b>footprint name</b> filter."
-msgstr "Filtrowanie z pomocą wyrażeń regularnch dla <b>Nazwy footprintu</b>"
+msgstr "Filtrowanie z pomocą wyrażeń regularnych dla <b>Nazwy footprintu</b>."
 
 #: pcbnew/plugin.cpp:161
 msgid ""
@@ -26356,7 +26583,7 @@ msgstr ""
 
 #: pcbnew/printout_controler.cpp:103
 msgid "Multiple Layers"
-msgstr ""
+msgstr "Wiele warstw"
 
 #: pcbnew/router/length_tuner_tool.cpp:51 pcbnew/router/router_tool.cpp:140
 msgid "New Track"
@@ -26372,7 +26599,7 @@ msgstr "Kończy trasowanie bieżącego meandra."
 
 #: pcbnew/router/length_tuner_tool.cpp:58
 msgid "Length Tuning Settings..."
-msgstr "Ustawienia dostrajania długości..."
+msgstr "Ustawienia dostrajania długości ścieżek..."
 
 #: pcbnew/router/length_tuner_tool.cpp:58
 msgid "Sets the length tuning parameters for currently routed item."
@@ -26380,11 +26607,11 @@ msgstr "Ustawia parametry dostrajania dla obecnie prowadzonej ścieżki."
 
 #: pcbnew/router/length_tuner_tool.cpp:63
 msgid "Increase Spacing"
-msgstr "Zwiększ odstęp"
+msgstr "Zwiększ prześwit"
 
 #: pcbnew/router/length_tuner_tool.cpp:68
 msgid "Decrease Spacing"
-msgstr "Zmniejsz odstęp"
+msgstr "Zmniejsz prześwit"
 
 #: pcbnew/router/length_tuner_tool.cpp:73
 msgid "Increase Amplitude"
@@ -26392,7 +26619,7 @@ msgstr "Zwiększ amplitudę"
 
 #: pcbnew/router/length_tuner_tool.cpp:78
 msgid "Decrease Amplitude"
-msgstr "Zmniejsz amoplitudę"
+msgstr "Zmniejsz amplitudę"
 
 #: pcbnew/router/length_tuner_tool.cpp:93
 msgid "Length Tuner"
@@ -26411,24 +26638,28 @@ msgid "Tune Diff Pair Skew"
 msgstr "Dostrajanie odchyłek par różnicowych"
 
 #: pcbnew/router/pns_diff_pair_placer.cpp:450
-#, fuzzy
 msgid ""
 "Unable to find complementary differential pair nets. Make sure the names of "
 "the nets belonging to a differential pair end with either _N/_P or +/-."
 msgstr ""
 "Nie można znaleźć komplementarnej ścieżki pary różnicowej. Sprawdź czy nazwy "
-"sieci należących do par różnicowych zawierają _N/_P lub +/-."
+"sieci należących do par różnicowych kończą się na _N/_P lub +/-."
 
 #: pcbnew/router/pns_diff_pair_placer.cpp:471
 msgid ""
 "Can't find a suitable starting point.  If starting from an existing "
 "differential pair make sure you are at the end. "
 msgstr ""
+"Nie można znaleźć odpowiedniego punktu początkowego.  Jeśli rozpoczyna się "
+"trasowanie z istniejącej pary różnicowej, należy sprawdzić czy znajdujemy "
+"się na jej końcu. "
 
 #: pcbnew/router/pns_diff_pair_placer.cpp:524
 #, c-format
 msgid "Can't find a suitable starting point for coupled net \"%s\"."
 msgstr ""
+"Nie można znaleźć odpowiedniego punktu początkowego dla sparowanej sieci \"%s"
+"\"."
 
 #: pcbnew/router/pns_diff_pair_placer.cpp:554
 msgid "Can't start a differential pair  in the middle of nowhere."
@@ -26462,17 +26693,17 @@ msgstr ""
 #: pcbnew/router/pns_dp_meander_placer.cpp:368
 #: pcbnew/router/pns_meander_placer.cpp:243
 msgid "Too long: "
-msgstr "Zbyt długa:"
+msgstr "Zbyt długa: "
 
 #: pcbnew/router/pns_dp_meander_placer.cpp:371
 #: pcbnew/router/pns_meander_placer.cpp:246
 msgid "Too short: "
-msgstr "Zbyt krótka:"
+msgstr "Zbyt krótka: "
 
 #: pcbnew/router/pns_dp_meander_placer.cpp:374
 #: pcbnew/router/pns_meander_placer.cpp:249
 msgid "Tuned: "
-msgstr "Dostrojono:"
+msgstr "Dostrojono: "
 
 #: pcbnew/router/pns_dp_meander_placer.cpp:377
 #: pcbnew/router/pns_meander_placer.cpp:252
@@ -26483,7 +26714,7 @@ msgstr "?"
 #: pcbnew/router/pns_kicad_iface.cpp:797
 #, c-format
 msgid "Malformed keep-out zone at (%d, %d)"
-msgstr ""
+msgstr "Niepoprawnie skonstruowana strefa na pozycji (%d, %d)"
 
 #: pcbnew/router/pns_kicad_iface.cpp:800
 #, c-format
@@ -26492,11 +26723,13 @@ msgid ""
 "This zone cannot be handled by the track layout tool.\n"
 "Please verify it is not a self-intersecting polygon."
 msgstr ""
+"%s\n"
+"Ta strefa nie może być obsłużona przez narzędzie do rysowania ścieżek.\n"
+"Proszę zweryfikować czy nie jest to strefa nachodząca na inną strefę."
 
 #: pcbnew/router/pns_kicad_iface.cpp:1108
-#, fuzzy
 msgid "Added a track"
-msgstr "Dodaj ścieżki"
+msgstr "Dodano ścieżkę"
 
 #: pcbnew/router/pns_meander_skew_placer.cpp:53
 msgid "Please select a differential pair trace you want to tune."
@@ -26527,12 +26760,11 @@ msgstr "Dostrojono: odchyłka "
 #: pcbnew/router/pns_router.cpp:175
 msgid "Cannot start routing inside a keepout area or board outline."
 msgstr ""
-"Nie można rozpocząć trasowania wewnątrz obszaru ochronnego lub konturu "
-"płytki."
+"Nie można rozpocząć trasowania wewnątrz strefy chronionej lub obrysu płytki."
 
 #: pcbnew/router/router_tool.cpp:84
 msgid "Interactive Router (Single Tracks)"
-msgstr "Interaktywny router (pojedyncza ścieżka)"
+msgstr "Router interaktywny (Pojedyncze ścieżki)"
 
 #: pcbnew/router/router_tool.cpp:85
 msgid "Run push & shove router (single tracks)"
@@ -26540,7 +26772,7 @@ msgstr "Uruchom router P&S (pojedyncza ścieżka)"
 
 #: pcbnew/router/router_tool.cpp:89
 msgid "Interactive Router (Differential Pairs)"
-msgstr "Interaktywny router (para różnicowa)"
+msgstr "Router interaktywny (Pary różnicowe)"
 
 #: pcbnew/router/router_tool.cpp:90
 msgid "Run push & shove router (differential pairs)"
@@ -26548,7 +26780,7 @@ msgstr "Uruchom router P&S (pary różnicowe)"
 
 #: pcbnew/router/router_tool.cpp:94
 msgid "Interactive Router Settings..."
-msgstr "Ustawienia interaktywnego routera"
+msgstr "Ustawienia interaktywnego routera..."
 
 #: pcbnew/router/router_tool.cpp:95
 msgid "Open Interactive Router settings"
@@ -26556,7 +26788,7 @@ msgstr "Otwórz ustawienia interaktywnego routera"
 
 #: pcbnew/router/router_tool.cpp:99
 msgid "Differential Pair Dimension Settings..."
-msgstr "Ustawienia wymiarów pary różnicowej..."
+msgstr "Ustawienia rozmiaru par różnicowych..."
 
 #: pcbnew/router/router_tool.cpp:100
 msgid "Open Differential Pair Dimension settings"
@@ -26564,7 +26796,7 @@ msgstr "Otwórz ustawienia rozmiarów par różnicowych"
 
 #: pcbnew/router/router_tool.cpp:105
 msgid "Tune length of a single track"
-msgstr "Dostraja długość pojedynczej ścieżki."
+msgstr "Dostraja długość pojedynczej ścieżki"
 
 #: pcbnew/router/router_tool.cpp:109
 msgid "Tune length of a differential pair"
@@ -26580,29 +26812,35 @@ msgstr "Przeciągnij Ścieżkę/Przelotkę"
 
 #: pcbnew/router/router_tool.cpp:117
 msgid "Drags tracks and vias without breaking connections"
-msgstr ""
+msgstr "Przeciągaj ścieżki i przelotki bez zrywania połączeń"
 
 #: pcbnew/router/router_tool.cpp:123
 msgid ""
 "Splits the track segment into two segments connected at the cursor position."
 msgstr ""
+"Rozdziela segment ścieżki na dwa segmenty złączone na bieżącej pozycji "
+"kursora."
 
 #: pcbnew/router/router_tool.cpp:128
 msgid "Drag (45 degree mode)"
-msgstr "Przeciągnij (tryb 45 stopni)"
+msgstr "Przeciągnij (w trybie 45 stopni)"
 
 #: pcbnew/router/router_tool.cpp:129
 msgid "Drags the track segment while keeping connected tracks at 45 degrees."
 msgstr ""
+"Przeciąga segment ścieżki z zachowaniem połączonych ścieżek pod kątem 45 "
+"stopni."
 
 #: pcbnew/router/router_tool.cpp:134
 msgid "Drag (free angle)"
-msgstr "Przeciągnij (swobodny kąt)"
+msgstr "Przeciągnij (w trybie dowolnym)"
 
 #: pcbnew/router/router_tool.cpp:135
 msgid ""
 "Drags the nearest joint in the track without restricting the track angle."
 msgstr ""
+"Przeciąga najbliższy punkt łączenia na ścieżce bez zachowania kąta "
+"nachylenia."
 
 #: pcbnew/router/router_tool.cpp:143
 msgid "Stops laying the current track."
@@ -26638,16 +26876,20 @@ msgid ""
 "Select a layer, then add a through-hole via at the end of currently routed "
 "track."
 msgstr ""
+"Wybiera warstwę, następnie dodaje przelotkę na wylot na końcu aktualnie "
+"trasowanej ścieżki."
 
 #: pcbnew/router/router_tool.cpp:180
 msgid ""
 "Select a layer, then add a blind or buried via at the end of currently "
 "routed track."
 msgstr ""
+"Wybiera warstwę, następnie dodaje ślepą lub zagrzebaną przelotkę na wylot na "
+"końcu aktualnie trasowanej ścieżki."
 
 #: pcbnew/router/router_tool.cpp:186
 msgid "Custom Track/Via Size..."
-msgstr "Własny rozmiar ścieżki / przelotki..."
+msgstr "Własne rozmiary ścieżek i przelotek..."
 
 #: pcbnew/router/router_tool.cpp:187
 msgid "Shows a dialog for changing the track width and via size."
@@ -26657,7 +26899,7 @@ msgstr ""
 
 #: pcbnew/router/router_tool.cpp:193
 msgid "Switches posture of the currently routed track."
-msgstr ""
+msgstr "Zmienia sposób załamania bieżąco prowadzonej ścieżki."
 
 #: pcbnew/router/router_tool.cpp:208
 msgid "Select Track/Via Width"
@@ -26669,7 +26911,7 @@ msgstr "Rozmiar użytkownika"
 
 #: pcbnew/router/router_tool.cpp:221
 msgid "Use Starting Track Width"
-msgstr ""
+msgstr "Użyj początkowej szerokości ścieżki"
 
 #: pcbnew/router/router_tool.cpp:222
 msgid "Route using the width of the starting track."
@@ -26677,7 +26919,7 @@ msgstr "Prowadź ścieżki używając szerokości ścieżki rozpoczynającej."
 
 #: pcbnew/router/router_tool.cpp:224
 msgid "Use Net Class Values"
-msgstr "Użyj wartości z klas sieci"
+msgstr "Użyj wartości z klas połączeń"
 
 #: pcbnew/router/router_tool.cpp:225
 msgid "Use track and via sizes from the net class"
@@ -26685,7 +26927,7 @@ msgstr "Użyj szerokości ścieżek i rozmiarów przelotek z ich klas połącze�
 
 #: pcbnew/router/router_tool.cpp:307
 msgid "Interactive Router"
-msgstr "Router interaktywny"
+msgstr "Router Interaktywny"
 
 #: pcbnew/router/router_tool.cpp:527
 msgid "Blind/buried vias have to be enabled in the design settings."
@@ -26721,7 +26963,7 @@ msgstr "Router par różnicowych"
 
 #: pcbnew/router/router_tool.cpp:929 pcbnew/router/router_tool.cpp:1078
 msgid "The item is locked. Do you want to continue?"
-msgstr ""
+msgstr "Element jest zablokowany. Czy chcesz kontynuować?"
 
 #: pcbnew/sel_layer.cpp:303
 msgid "Warning: The Top Layer and Bottom Layer are same."
@@ -26733,17 +26975,17 @@ msgstr "Eksport płytki udany."
 
 #: pcbnew/specctra_import_export/specctra_export.cpp:162
 msgid "Unable to export, please fix and try again"
-msgstr ""
+msgstr "Nie można wyeksportować, proszę naprawić i spróbować ponownie"
 
 #: pcbnew/specctra_import_export/specctra_export.cpp:934
 #, c-format
 msgid "Symbol with value of \"%s\" has empty reference id."
-msgstr ""
+msgstr "Symbol z wartością \"%s\" posiada pusty odnośnik."
 
 #: pcbnew/specctra_import_export/specctra_export.cpp:942
 #, c-format
 msgid "Multiple symbols have identical reference IDs of \"%s\"."
-msgstr ""
+msgstr "Wiele symboli posiada identyczny numer ID do \"%s\"."
 
 #: pcbnew/specctra_import_export/specctra_import.cpp:78
 msgid "Merge Specctra Session file:"
@@ -26754,6 +26996,8 @@ msgid ""
 "Board may be corrupted, do not save it.\n"
 "Fix problem and try again"
 msgstr ""
+"Płytka może być uszkodzona, nie zapisuj jej!\n"
+"Napraw problem i spróbuj ponownie"
 
 #: pcbnew/specctra_import_export/specctra_import.cpp:140
 msgid "Session file imported and merged OK."
@@ -26774,7 +27018,7 @@ msgstr "Stos przelotek z sesji nie ma kształtów"
 #: pcbnew/specctra_import_export/specctra_import.cpp:314
 #, c-format
 msgid "Unsupported via shape: %s"
-msgstr "Niewspierany kształt przelotki: \"%s\""
+msgstr "Niewspierany kształt przelotki: %s"
 
 #: pcbnew/specctra_import_export/specctra_import.cpp:370
 msgid "Session file is missing the \"session\" section"
@@ -26791,17 +27035,16 @@ msgstr "Plik sesji nie zawiera sekcji \"library_out\""
 #: pcbnew/specctra_import_export/specctra_import.cpp:407
 #, c-format
 msgid "Session file has 'reference' to non-existent symbol \"%s\""
-msgstr ""
+msgstr "Plik sesji posiada wpis 'reference' do nieistniejącego symbolu \"%s\""
 
 #: pcbnew/specctra_import_export/specctra_import.cpp:546
 #, c-format
 msgid "A wire_via references a missing padstack \"%s\""
-msgstr "wire_via odnosi się do brakującego stosu \"%s\""
+msgstr "Wire_via odnosi się do brakującego stosu \"%s\""
 
 #: pcbnew/swap_layers.cpp:90
-#, fuzzy
 msgid "Move Layers:"
-msgstr "Warstwy ścieżek:"
+msgstr "Przemieszczanie Warstw:"
 
 #: pcbnew/swap_layers.cpp:238 pcbnew/swap_layers.cpp:245
 #: pcbnew/swap_layers.cpp:322
@@ -26818,34 +27061,34 @@ msgstr "&Anuluj"
 
 #: pcbnew/swig/pcbnew_action_plugins.cpp:76
 msgid "Exception on python action plugin code"
-msgstr ""
+msgstr "Wystąpił wyjątek w kodzie aktywnego skryptu Python"
 
 #: pcbnew/swig/pcbnew_action_plugins.cpp:88
 #: pcbnew/swig/pcbnew_footprint_wizards.cpp:82
 #, c-format
 msgid "Method \"%s\" not found, or not callable"
-msgstr ""
+msgstr "Metoda \"%s\" nie została znaleziona lub nie można jej wywołać"
 
 #: pcbnew/swig/pcbnew_action_plugins.cpp:89
 #: pcbnew/swig/pcbnew_footprint_wizards.cpp:83
-#, fuzzy
 msgid "Unknown Method"
-msgstr "Nieznany"
+msgstr "Nieznana Metoda"
 
 #: pcbnew/swig/pcbnew_action_plugins.cpp:304
 #, c-format
 msgid ""
 "(PCB_EDIT_FRAME::OnActionPlugin) needs work: BOARD_ITEM type (%d) not handled"
 msgstr ""
+"(PCB_EDIT_FRAME::OnActionPlugin) wymaga działania: BOARD_ITEM nie "
+"obsługiwanego typu (%d)"
 
 #: pcbnew/swig/pcbnew_footprint_wizards.cpp:69
-#, fuzzy
 msgid "Exception on python footprint wizard code"
-msgstr "Nowy footprint z użyciem kreatora footprintów"
+msgstr "Wystąpił wyjątek w kodzie skryptu Python"
 
 #: pcbnew/target_edit.cpp:155
 msgid "Modified alignment target"
-msgstr ""
+msgstr "Zmodyfikowano wskaźnik pozycjonujący"
 
 #: pcbnew/tool_footprint_editor.cpp:54
 msgid "Save footprint in active library"
@@ -26869,7 +27112,7 @@ msgstr "Nowy footprint"
 
 #: pcbnew/tool_footprint_editor.cpp:74
 msgid "New footprint using footprint wizard"
-msgstr "Nowy footprint za pomocą kreatora"
+msgstr "Nowy footprint z użyciem kreatora"
 
 #: pcbnew/tool_footprint_editor.cpp:80
 msgid "Load footprint from library"
@@ -26881,7 +27124,7 @@ msgstr "Wczytaj footprint z bieżącej płytki do edytora"
 
 #: pcbnew/tool_footprint_editor.cpp:89
 msgid "Update footprint into current board"
-msgstr "Aktualizuj footprinty na bieżącej płytce"
+msgstr "Uaktualnia footprint na bieżącej płytce"
 
 #: pcbnew/tool_footprint_editor.cpp:93
 msgid "Insert footprint into current board"
@@ -26897,7 +27140,7 @@ msgstr "Eksportuj footprint"
 
 #: pcbnew/tool_footprint_editor.cpp:107
 msgid "Redo last undo command"
-msgstr ""
+msgstr "Ponawia ostatnio cofniętą operację"
 
 #: pcbnew/tool_footprint_editor.cpp:112
 msgid "Footprint properties"
@@ -27029,11 +27272,11 @@ msgstr "Dodaj footprinty"
 
 #: pcbnew/tool_pcb_editor.cpp:457
 msgid "Route tracks"
-msgstr "Trasowanie ścieżek"
+msgstr "Trasuje ścieżki"
 
 #: pcbnew/tool_pcb_editor.cpp:460 pcbnew/tools/drawing_tool.cpp:1685
 msgid "Add vias"
-msgstr "Dodaj przelotkę"
+msgstr "Dodaj przelotki"
 
 #: pcbnew/tool_pcb_editor.cpp:463
 msgid "Add filled zones"
@@ -27045,14 +27288,15 @@ msgstr "Dodaje strefy chronione"
 
 #: pcbnew/tool_pcb_editor.cpp:472
 msgid "Add graphic lines"
-msgstr "Dodaj linię graficzną"
+msgstr "Dodaje linie graficzne"
 
 #: pcbnew/tool_pcb_editor.cpp:500
-#, fuzzy
 msgid ""
 "Place the auxiliary axis origin for some plot file formats,\n"
 "and for drill and place files"
-msgstr "Wstaw punkt bazowy dla plików wierceń lub rozkładu elementów"
+msgstr ""
+"Wstaw punkt odniesienia dla niektórych plików wyjściowych,\n"
+"plików wierceń lub plików położeń elementów"
 
 #: pcbnew/tool_pcb_editor.cpp:506
 msgid "Set the origin point for the grid"
@@ -27127,6 +27371,9 @@ msgid ""
 "Toolset.\n"
 "Use Route > Interactive Router Settings... for Modern Toolset."
 msgstr ""
+"Wyłącz sprawdzanie reguł projektowych podczas trasowania/edycji ścieżek na "
+"kanwie Legacy.\n"
+"Użyj Ustawienia -> Router interaktywny... dla nowszej kanwy."
 
 #: pcbnew/toolbars_update_user_interface.cpp:133
 msgid ""
@@ -27134,6 +27381,9 @@ msgid ""
 "Toolset.\n"
 "Use Route > Interactive Router Settings... for Modern Toolset."
 msgstr ""
+"Włącz sprawdzanie reguł projektowych podczas trasowania/edycji ścieżek na "
+"kanwie Legacy.\n"
+"Użyj Ustawienia -> Router interaktywny... dla nowszej kanwy."
 
 #: pcbnew/toolbars_update_user_interface.cpp:141
 msgid "Hide board ratsnest"
@@ -27157,19 +27407,19 @@ msgstr "Wyświetlaj w trybie wysokiego kontrastu"
 
 #: pcbnew/tools/drawing_tool.cpp:71 pcbnew/tools/drawing_tool.cpp:1097
 msgid "Draw a line"
-msgstr "Narysuj linię"
+msgstr "Rysuje linię"
 
 #: pcbnew/tools/drawing_tool.cpp:75
 msgid "Draw a graphic polygon"
-msgstr "Narysuj wielobok graficzny"
+msgstr "Rysuje strefę w formie wypełnienia graficznego"
 
 #: pcbnew/tools/drawing_tool.cpp:79 pcbnew/tools/drawing_tool.cpp:278
 msgid "Draw a circle"
-msgstr "Rysuj okrąg"
+msgstr "Rysuje okrąg"
 
 #: pcbnew/tools/drawing_tool.cpp:83 pcbnew/tools/drawing_tool.cpp:310
 msgid "Draw an arc"
-msgstr "Rysuj łuk"
+msgstr "Rysuje łuk"
 
 #: pcbnew/tools/drawing_tool.cpp:87
 msgid "Add a text"
@@ -27177,39 +27427,39 @@ msgstr "Dodaj tekst"
 
 #: pcbnew/tools/drawing_tool.cpp:91
 msgid "Add a dimension"
-msgstr "Dodaj wymiar"
+msgstr "Dodaje wymiar"
 
 #: pcbnew/tools/drawing_tool.cpp:95
 msgid "Add a filled zone"
-msgstr "Dodaj strefę"
+msgstr "Dodaje wypełnioną strefę"
 
 #: pcbnew/tools/drawing_tool.cpp:99
 msgid "Add free-standing vias"
-msgstr "Dodaj \"wolne\" przelotki"
+msgstr "Dodaj samodzielne przelotki"
 
 #: pcbnew/tools/drawing_tool.cpp:103
 msgid "Add a keepout area"
-msgstr "Dodaje strefę chronioną"
+msgstr "Dodaje obszar chroniony"
 
 #: pcbnew/tools/drawing_tool.cpp:107
 msgid "Add a cutout area of an existing zone"
-msgstr ""
+msgstr "Dodaje obszar odcięty znajdujący się wewnątrz strefy"
 
 #: pcbnew/tools/drawing_tool.cpp:112
 msgid "Add a zone with the same settings as an existing zone"
-msgstr "Dodaj strefę z tymi samymi ustawieniami, co istniejąca strefa"
+msgstr "Dodaje strefę z tymi samymi ustawieniami co istniejąca strefa"
 
 #: pcbnew/tools/drawing_tool.cpp:121 pcbnew/tools/drawing_tool.cpp:921
 msgid "Place the footprint anchor"
-msgstr "Ustaw punkt zakotwiczenia footprintu"
+msgstr "Umieszcza punkt zakotwiczenia footprintu"
 
 #: pcbnew/tools/drawing_tool.cpp:126
 msgid "Increase the line width"
-msgstr "Zwiększ grubość linii"
+msgstr "Zwiększa grubość linii"
 
 #: pcbnew/tools/drawing_tool.cpp:130
 msgid "Decrease the line width"
-msgstr "Zmniejsz grubość linii"
+msgstr "Zmniejsza grubość linii"
 
 #: pcbnew/tools/drawing_tool.cpp:134
 msgid "Switch Arc Posture"
@@ -27217,23 +27467,23 @@ msgstr "Zmień kierunek łuku"
 
 #: pcbnew/tools/drawing_tool.cpp:134
 msgid "Switch the arc posture"
-msgstr "Zmiana kierunku łuku"
+msgstr "Zmienia kierunku łuku"
 
 #: pcbnew/tools/drawing_tool.cpp:142
 msgid "Delete Last Point"
-msgstr "Usuń ostatni narożnik"
+msgstr "Usuń ostatni punkt"
 
 #: pcbnew/tools/drawing_tool.cpp:142
 msgid "Delete the last point added to the current item"
-msgstr ""
+msgstr "Usuwa ostatni punkt dodany do bieżącego elementu"
 
 #: pcbnew/tools/drawing_tool.cpp:147
 msgid "Close the outline of a zone in progress"
-msgstr ""
+msgstr "Zamyka obrys strefy jeśli jest ona w trakcie tworzenia"
 
 #: pcbnew/tools/drawing_tool.cpp:241
 msgid "Draw a line segment"
-msgstr ""
+msgstr "Narysuj segment linii"
 
 #: pcbnew/tools/drawing_tool.cpp:445
 msgid "Place a text"
@@ -27241,27 +27491,27 @@ msgstr "Umieść tekst"
 
 #: pcbnew/tools/drawing_tool.cpp:619
 msgid "Draw a dimension"
-msgstr ""
+msgstr "Narysuj wymiar"
 
 #: pcbnew/tools/drawing_tool.cpp:701
 msgid "Add zone cutout"
-msgstr "Dodaj wycięcie strefy"
+msgstr "Dodaj strefę odciętą"
 
 #: pcbnew/tools/drawing_tool.cpp:725
 msgid "Add similar zone"
-msgstr "Dodaj strefę bliźniaczą"
+msgstr "Dodaj podobną strefę"
 
 #: pcbnew/tools/drawing_tool.cpp:898
 msgid "Place a DXF drawing"
-msgstr ""
+msgstr "Umieść rysunek DXF"
 
 #: pcbnew/tools/drawing_tool.cpp:941
 msgid "Move the footprint reference anchor"
-msgstr ""
+msgstr "Przesuń punkt zaczepienia footprintu"
 
 #: pcbnew/tools/drawing_tool.cpp:1328 pcbnew/tools/point_editor.cpp:237
 msgid "Self-intersecting polygons are not allowed"
-msgstr ""
+msgstr "Strefy nachodzące na siebie nie są dopuszczalne"
 
 #: pcbnew/tools/drawing_tool.cpp:1687
 msgid "Place via"
@@ -27278,33 +27528,37 @@ msgstr "Otwiera wybrany footprint w edytorze footprintów"
 #: pcbnew/tools/edit_tool.cpp:88
 msgid "Copy Pad Properties to Default Pad Properties"
 msgstr ""
+"Kopiuj właściwości tego pola lut. do domyślnych właściwości pól lutowniczych"
 
 #: pcbnew/tools/edit_tool.cpp:89
 msgid ""
 "Copies the properties of the selected pad to the default pad properties."
 msgstr ""
+"Kopiuje ustawienia wybranego pola lutowniczego do domyślnych ustawień pola."
 
 #: pcbnew/tools/edit_tool.cpp:93
 msgid "Copy Default Pad Properties to Pads"
-msgstr ""
+msgstr "Kopiuj domyślne właściwości pól lut. do wszystkich pól lutowniczych"
 
 #: pcbnew/tools/edit_tool.cpp:94
 msgid "Copies the default pad properties to the selected pad(s)."
-msgstr ""
+msgstr "Kopiuje obecne ustawienia pola lutowniczego do wybranego pola/pól."
 
 #: pcbnew/tools/edit_tool.cpp:98
 msgid "Push Pad Settings..."
-msgstr ""
+msgstr "Narzuć ustawienia pola lutowniczego..."
 
 #: pcbnew/tools/edit_tool.cpp:99
 msgid ""
 "Copies the selected pad's properties to all pads in its footprint (or "
 "similar footprints)."
 msgstr ""
+"Kopiuje ustawienia wybranego pola lut. do wszystkich pól lut. tego "
+"footprintu (lub podobnych fooprintów)"
 
 #: pcbnew/tools/edit_tool.cpp:104
 msgid "Edit Activate"
-msgstr ""
+msgstr "Edycja aktywnych"
 
 #: pcbnew/tools/edit_tool.cpp:108
 msgid "Moves the selected item(s)"
@@ -27328,11 +27582,11 @@ msgstr "Utwórz szyk"
 
 #: pcbnew/tools/edit_tool.cpp:129
 msgid "Rotates selected item(s) clockwise"
-msgstr ""
+msgstr "Obraca wybrane elementy w prawo"
 
 #: pcbnew/tools/edit_tool.cpp:134
 msgid "Rotates selected item(s) counterclockwise"
-msgstr ""
+msgstr "Obraca wybrane elementy w lewo"
 
 #: pcbnew/tools/edit_tool.cpp:139
 msgid "Flips selected item(s)"
@@ -27340,7 +27594,7 @@ msgstr "Przerzuca wybrany(e) element(y)"
 
 #: pcbnew/tools/edit_tool.cpp:143
 msgid "Mirrors selected item"
-msgstr "Odbicie zaznaczonego elementu"
+msgstr "Odbij wybrane elementy"
 
 #: pcbnew/tools/edit_tool.cpp:147 pcbnew/tools/edit_tool.cpp:152
 msgid "Deletes selected item(s)"
@@ -27348,15 +27602,15 @@ msgstr "Usuwa wybrany(e) element(y)"
 
 #: pcbnew/tools/edit_tool.cpp:152
 msgid "Delete (Alternative)"
-msgstr "Usuń (alternatywnie)"
+msgstr "Usuń (Alternatywnie)"
 
 #: pcbnew/tools/edit_tool.cpp:157
 msgid "Update the footprint from the library"
-msgstr ""
+msgstr "Uaktualnia footprint z biblioteki"
 
 #: pcbnew/tools/edit_tool.cpp:162
 msgid "Assign a different footprint from the library"
-msgstr ""
+msgstr "Przypisuje inny footprint z biblioteki"
 
 #: pcbnew/tools/edit_tool.cpp:167
 msgid "Properties..."
@@ -27368,23 +27622,23 @@ msgstr "Wyświetla okno z właściwościami"
 
 #: pcbnew/tools/edit_tool.cpp:175
 msgid "Measuring Tool"
-msgstr "Narzędzie pomiarowe"
+msgstr "Miarka"
 
 #: pcbnew/tools/edit_tool.cpp:180
 msgid "Copy selected content to clipboard"
-msgstr "Skopiuj wybraną zawartość do schowka"
+msgstr "Kopiuj wybraną zawartość do schowka"
 
 #: pcbnew/tools/edit_tool.cpp:185
 msgid "Cut selected content to clipboard"
-msgstr ""
+msgstr "Wycina wybraną zawartość i umieszcza w schowku"
 
 #: pcbnew/tools/edit_tool.cpp:635
 msgid "Edit track width/via size"
-msgstr ""
+msgstr "Edycja szerokości ścieżki/rozmiaru przelotki"
 
 #: pcbnew/tools/edit_tool.cpp:662
 msgid "Edit track/via properties"
-msgstr ""
+msgstr "Edytuj właściwości ścieżki/przelotki"
 
 #: pcbnew/tools/edit_tool.cpp:957
 msgid "Move exact"
@@ -27397,7 +27651,7 @@ msgstr "Powielono %d pozycji"
 
 #: pcbnew/tools/edit_tool.cpp:1391
 msgid "Select reference point for the block being copied..."
-msgstr ""
+msgstr "Wybierz punkt odniesienia dla kopiowanego bloku..."
 
 #: pcbnew/tools/footprint_editor_tools.cpp:63
 msgid "Add Pad"
@@ -27405,32 +27659,33 @@ msgstr "Dodaj pole lutownicze"
 
 #: pcbnew/tools/footprint_editor_tools.cpp:63
 msgid "Add a pad"
-msgstr "Dodaj pole lutownicze"
+msgstr "Dodaj pole"
 
 #: pcbnew/tools/footprint_editor_tools.cpp:67
 #: pcbnew/tools/footprint_editor_tools.cpp:472
 msgid "Create Pad from Selected Shapes"
-msgstr ""
+msgstr "Utwórz pole z wybranych kształtów"
 
 #: pcbnew/tools/footprint_editor_tools.cpp:68
 msgid "Creates a custom-shaped pads from a set of selected shapes"
-msgstr ""
+msgstr "Tworzy własne pola lutownicze z wybranych kształtów"
 
 #: pcbnew/tools/footprint_editor_tools.cpp:73
 msgid "Explode Pad to Graphic Shapes"
-msgstr ""
+msgstr "Rozdziel wybrane pole lutownicze na kształty graficzne"
 
 #: pcbnew/tools/footprint_editor_tools.cpp:74
 msgid "Converts a custom-shaped pads to a set of graphical shapes"
 msgstr ""
+"Konwertuje własne kształty pola lutowniczego na zestaw kształtów graficznych"
 
 #: pcbnew/tools/footprint_editor_tools.cpp:79
 msgid "Renumber Pads..."
-msgstr "Przenumeruj pola lutownicze..."
+msgstr "Ponumeruj pola lutownicze..."
 
 #: pcbnew/tools/footprint_editor_tools.cpp:79
 msgid "Renumber pads by clicking on them in the desired order"
-msgstr ""
+msgstr "Ponumeruj pola lutownicze poprzez klikanie w nie w określonym porządku"
 
 #: pcbnew/tools/footprint_editor_tools.cpp:114
 msgid "Add pads"
@@ -27442,21 +27697,23 @@ msgstr "Umieść pole lutownicze"
 
 #: pcbnew/tools/footprint_editor_tools.cpp:152
 msgid "Click on successive pads to renumber them"
-msgstr ""
+msgstr "Kliknij na kolejne pola by je ponumerować"
 
 #: pcbnew/tools/footprint_editor_tools.cpp:238
 msgid "Renumber pads"
-msgstr "Przenumeruj pola lutownicze"
+msgstr "Ponumeruj pola lutownicze"
 
 #: pcbnew/tools/footprint_editor_tools.cpp:313
 msgid "Explode pad to shapes"
-msgstr ""
+msgstr "Rozdziel pole na kształty"
 
 #: pcbnew/tools/footprint_editor_tools.cpp:381
 msgid ""
 "Cannot convert items to a custom-shaped pad:\n"
 "selection contains more than one reference pad."
 msgstr ""
+"Nie można skonwertować elementów na kształt użytkownika:\n"
+"wybór zawiera więcej niż jedno pole referencyjne."
 
 #: pcbnew/tools/footprint_editor_tools.cpp:389
 msgid ""
@@ -27464,6 +27721,9 @@ msgid ""
 "selection contains unsupported items.\n"
 "Only graphical lines, circles, arcs and polygons are allowed."
 msgstr ""
+"Nie można skonwertować elementów na kształt użytkownika:\n"
+"wybór zawiera niewspierane elementy.\n"
+"Tylko linie graficzne, okręgi, łuki oraz strefy są dopuszczalne."
 
 #: pcbnew/tools/footprint_editor_tools.cpp:435
 msgid ""
@@ -27471,69 +27731,75 @@ msgid ""
 "unable to determine the anchor point position.\n"
 "Consider adding a small anchor pad to the selection and try again."
 msgstr ""
+"Nie można skonwertować elementów na kształt użytkownika:\n"
+"nie można określić pozycji punktu zaczepienia.\n"
+"Rozważ dodanie małego pola zaczepienia do zaznaczenia i spróbuj ponownie."
 
 #: pcbnew/tools/footprint_editor_tools.cpp:458
 msgid ""
 "Cannot convert items to a custom-shaped pad:\n"
 "selected items do not form a single solid shape."
 msgstr ""
+"Nie można skonwertować elementów na kształt użytkownika:\n"
+"wybrane elementy nie tworzą pojedynczego, ciągłego kształtu."
 
 #: pcbnew/tools/microwave_tool.cpp:83
 msgid "Create polynomial shape for microwave applications"
-msgstr ""
+msgstr "Tworzy wielokąt dla aplikacji mikrofalowej"
 
 #: pcbnew/tools/microwave_tool.cpp:89
 msgid "Add Microwave Line"
-msgstr "Doda linię mikrofalową"
+msgstr "Dodaj linię mikrofalową"
 
 #: pcbnew/tools/microwave_tool.cpp:160
 msgid "Add Stub (Arc)"
-msgstr "Dodaj wycinek łuku"
+msgstr "Dodaj wycinek (Łuk)"
 
 #: pcbnew/tools/microwave_tool.cpp:229
 msgid "Place microwave feature"
-msgstr ""
+msgstr "Dodaje element mikrofalowy"
 
 #: pcbnew/tools/microwave_tool.cpp:278
 msgid "Add microwave inductor"
-msgstr "Dodaj indukcyjność mikrofalową"
+msgstr "Dodaj cewkę mikrofalową"
 
 #: pcbnew/tools/microwave_tool.cpp:300
 msgid "Add Microwave Inductor"
-msgstr "Dodaj indukcyjność mikrofalową"
+msgstr "Dodaje cewkę mikrofalową"
 
 #: pcbnew/tools/pad_tool.cpp:51
 msgid "Copy current pad's properties to the default pad properties"
 msgstr ""
+"Kopiuje bieżące ustawienia pola lutowniczego do domyślnych ustawień pola"
 
 #: pcbnew/tools/pad_tool.cpp:57
 msgid "Copy the default pad properties to the current pad"
-msgstr ""
+msgstr "Kopiuje domyślne ustawienia pola lutowniczego do bieżącego pola"
 
 #: pcbnew/tools/pad_tool.cpp:63
 msgid "Copy the current pad settings to other pads"
-msgstr ""
+msgstr "Kopiuje bieżące ustawienia pól lutowniczych do innych pól"
 
 #: pcbnew/tools/pcb_editor_control.cpp:96
 msgid "Merge Zones"
-msgstr "Połącz strefy"
+msgstr "Połącz strefy w jedną"
 
 #: pcbnew/tools/pcb_editor_control.cpp:96
 #: pcbnew/tools/pcb_editor_control.cpp:752
 msgid "Merge zones"
-msgstr "Połącz pola miedzi"
+msgstr "Łączy wszystkie strefy w jedną strefę"
 
 #: pcbnew/tools/pcb_editor_control.cpp:100
 msgid "Duplicate zone outline onto a different layer"
-msgstr ""
+msgstr "Klonuje niewypełniony obrys strefy na inną warstwę"
 
 #: pcbnew/tools/pcb_editor_control.cpp:106
 msgid "Add Layer Alignment Target"
-msgstr "Dodaj element pozycjonujący warstwy"
+msgstr "Dodaj znacznik pozycjonowania warstw"
 
 #: pcbnew/tools/pcb_editor_control.cpp:106
 msgid "Add a layer alignment target"
-msgstr "Dodaj element pozycjonujący warstwy"
+msgstr "Dodaje znacznik pozwalający pozycjonować warstwy przy składaniu klisz"
 
 #: pcbnew/tools/pcb_editor_control.cpp:110
 msgid "Add a footprint"
@@ -27541,11 +27807,11 @@ msgstr "Dodaj footprint"
 
 #: pcbnew/tools/pcb_editor_control.cpp:126
 msgid "Lock"
-msgstr "Zablokuj"
+msgstr "Zablokowany"
 
 #: pcbnew/tools/pcb_editor_control.cpp:130
 msgid "Unlock"
-msgstr "Odblokuj"
+msgstr "Odblokowany"
 
 #: pcbnew/tools/pcb_editor_control.cpp:217
 msgid "Locking"
@@ -27553,23 +27819,23 @@ msgstr "Blokowanie"
 
 #: pcbnew/tools/pcb_editor_control.cpp:484
 msgid "Place a module"
-msgstr ""
+msgstr "Umieść footpprint"
 
 #: pcbnew/tools/pcb_editor_control.cpp:636
 msgid "Place a layer alignment target"
-msgstr ""
+msgstr "Umieść znacznik do wyrównywania warstw"
 
 #: pcbnew/tools/pcb_editor_control.cpp:807
 msgid "Duplicate zone"
-msgstr ""
+msgstr "Klonowanie strefy"
 
 #: pcbnew/tools/pcb_editor_control.cpp:1103
 msgid "Pick Components for Local Ratsnest"
-msgstr ""
+msgstr "Zaznacz komponent by wyświetlić lokalne połączenia wspomagające"
 
 #: pcbnew/tools/pcbnew_control.cpp:243
 msgid "Paste content from clipboard"
-msgstr ""
+msgstr "Wkleja zawartość schowka"
 
 #: pcbnew/tools/pcbnew_control.cpp:906
 msgid "Invalid clipboard contents"
@@ -27626,15 +27892,15 @@ msgstr "Wyrównaj do środka"
 
 #: pcbnew/tools/placement_tool.cpp:63
 msgid "Aligns selected items to the vertical center"
-msgstr ""
+msgstr "Wyrównuje wybrane elementy do środka w pionie"
 
 #: pcbnew/tools/placement_tool.cpp:67
 msgid "Align to Center"
-msgstr "Wyrównaj centralnie"
+msgstr "Wyrównaj do środka"
 
 #: pcbnew/tools/placement_tool.cpp:68
 msgid "Aligns selected items to the horizontal center"
-msgstr ""
+msgstr "Wyrównuje wybrane elementy do środka w poziomie"
 
 #: pcbnew/tools/placement_tool.cpp:72
 msgid "Distribute Horizontally"
@@ -27654,7 +27920,7 @@ msgstr "Rozkłada wybrane elementy względem pionowej osi"
 
 #: pcbnew/tools/placement_tool.cpp:106
 msgid "Align/Distribute"
-msgstr "Wyrównywanie / rozkładanie"
+msgstr "Wyrównywanie/rozkładanie"
 
 #: pcbnew/tools/placement_tool.cpp:240 pcbnew/tools/selection_tool.cpp:728
 msgid "Selection contains locked items. Do you want to continue?"
@@ -27683,7 +27949,7 @@ msgstr "Wyrównaj do środka"
 
 #: pcbnew/tools/placement_tool.cpp:518
 msgid "Align to center"
-msgstr "Wyrównaj centralnie"
+msgstr "Wyrównaj do środka"
 
 #: pcbnew/tools/placement_tool.cpp:569
 msgid "Distribute horizontally"
@@ -27706,9 +27972,8 @@ msgid "Remove corner"
 msgstr "Usuń narożnik"
 
 #: pcbnew/tools/point_editor.cpp:358
-#, fuzzy
 msgid "Drag a corner"
-msgstr "Utwórz narożnik"
+msgstr "Przeciągnij narożnik"
 
 #: pcbnew/tools/point_editor.cpp:945
 msgid "Add a zone corner"
@@ -27716,23 +27981,25 @@ msgstr "Dodaj narożnik strefy"
 
 #: pcbnew/tools/point_editor.cpp:984
 msgid "Split segment"
-msgstr "Rozdziel segment"
+msgstr "Podziel segment"
 
 #: pcbnew/tools/point_editor.cpp:1057
 msgid "Remove a zone/polygon corner"
-msgstr ""
+msgstr "Usuń narożnik strefy"
 
 #: pcbnew/tools/position_relative_tool.cpp:44
 msgid "Position Relative To..."
-msgstr ""
+msgstr "Pozycja względem..."
 
 #: pcbnew/tools/position_relative_tool.cpp:45
 msgid "Positions the selected item(s) by an exact amount relative to another"
 msgstr ""
+"Ustawia pozycję wybranych elementów stosunku do siebie o dokładnie wybraną "
+"odległość"
 
 #: pcbnew/tools/selection_tool.cpp:97
 msgid "Trivial Connection"
-msgstr ""
+msgstr "Od najbliższego węzła do najbliższego węzła"
 
 #: pcbnew/tools/selection_tool.cpp:97
 msgid "Selects a connection between two junctions."
@@ -27740,44 +28007,44 @@ msgstr "Wybiera połączenie pomiędzy dwoma węzłami."
 
 #: pcbnew/tools/selection_tool.cpp:101
 msgid "Copper Connection"
-msgstr "Połączenia na warstwach miedzi"
+msgstr "Połączenie na warstwie sygnałowej"
 
 #: pcbnew/tools/selection_tool.cpp:101
 msgid "Selects whole copper connection."
-msgstr "Wybiera wszystkie połączenia."
+msgstr "Wybiera wszystkie połączenia na warstwie sygnałowej."
 
 #: pcbnew/tools/selection_tool.cpp:105
 msgid "Expand Selected Connection"
-msgstr ""
+msgstr "Rozszerz zaznaczone połączenie"
 
 #: pcbnew/tools/selection_tool.cpp:106
 msgid ""
 "Expands the current selection to select a connection between two junctions."
-msgstr ""
+msgstr "Rozszerza bieżący wybór do połączenia pomiędzy dwoma węzłami."
 
 #: pcbnew/tools/selection_tool.cpp:110
 msgid "Whole Net"
-msgstr "Cała sieć"
+msgstr "Cała sieć o tej samej nazwie"
 
 #: pcbnew/tools/selection_tool.cpp:110
 msgid "Selects all tracks & vias belonging to the same net."
-msgstr "Wybeira wszystkie ściezki i przelotki należące do tej samej sieci."
+msgstr "Wybiera wszystkie ścieżki i przelotki należące do tej samej sieci."
 
 #: pcbnew/tools/selection_tool.cpp:114
 msgid "Selects all modules and tracks in the schematic sheet"
-msgstr ""
+msgstr "Wybiera wszystkie footprinty i ścieżki na bieżącym arkuszu"
 
 #: pcbnew/tools/selection_tool.cpp:118
 msgid "Items in Same Hierarchical Sheet"
-msgstr ""
+msgstr "Elementy znajdujące się na tym samym arkuszu hierarchicznym"
 
 #: pcbnew/tools/selection_tool.cpp:119
 msgid "Selects all modules and tracks in the same schematic sheet"
-msgstr ""
+msgstr "Wybiera wszystkie footprinty i ścieżki w tym samym arkuszu"
 
 #: pcbnew/tools/selection_tool.cpp:123
 msgid "Find Item..."
-msgstr "Znajdź element"
+msgstr "Znajdź element..."
 
 #: pcbnew/tools/selection_tool.cpp:123
 msgid "Searches the document for an item"
@@ -27787,18 +28054,20 @@ msgstr "Przeszukuje dokument w poszukiwaniu elementu"
 msgid ""
 "Selects a footprint by reference and places it under the cursor for moving"
 msgstr ""
+"Wybiera footprint na podstawie odnośnika i umieszcza go \"pod\" kursorem w "
+"celu przesunięcia"
 
 #: pcbnew/tools/selection_tool.cpp:133
 msgid "Filter Selection..."
-msgstr "Wybór filtrowania..."
+msgstr "Wybór filtra..."
 
 #: pcbnew/tools/selection_tool.cpp:133
 msgid "Filter the types of items in the selection"
-msgstr ""
+msgstr "Filtruje po typie elementy z wybranych"
 
 #: pcbnew/tools/selection_tool.cpp:1335
 msgid "Filter selection"
-msgstr "Wybór filtorwania"
+msgstr "Wybór filtra"
 
 #: pcbnew/tools/size_menu.cpp:130
 msgid "Track "
@@ -27806,7 +28075,7 @@ msgstr "Ścieżka "
 
 #: pcbnew/tools/size_menu.cpp:133
 msgid "net class width"
-msgstr "Szerokość z klasy sieci"
+msgstr "szerokość z klasy sieci"
 
 #: pcbnew/tools/size_menu.cpp:146
 msgid "Via "
@@ -27814,7 +28083,7 @@ msgstr "Przelotka "
 
 #: pcbnew/tools/size_menu.cpp:150
 msgid "net class size"
-msgstr "Rozmiar z klasy sieci"
+msgstr "rozmiar z klasy sieci"
 
 #: pcbnew/tools/size_menu.cpp:159
 msgid ", drill: default"
@@ -27822,11 +28091,11 @@ msgstr ", otwór: domyślny"
 
 #: pcbnew/tools/size_menu.cpp:163
 msgid ", drill: "
-msgstr ", otwór:"
+msgstr ", otwór: "
 
 #: pcbnew/tools/zone_create_helper.cpp:156
 msgid "Add a zone cutout"
-msgstr "Dodaj wycięcie strefy"
+msgstr "Dodaje strefę odciętą"
 
 #: pcbnew/tools/zone_create_helper.cpp:171
 msgid "Add a zone"
@@ -27834,7 +28103,7 @@ msgstr "Dodaj strefę"
 
 #: pcbnew/tools/zone_create_helper.cpp:184
 msgid "Add a graphical polygon"
-msgstr "Dodaj graficzne wypełnienie"
+msgstr "Dodaj strefę graficzną"
 
 #: pcbnew/tools/zone_filler_tool.cpp:47
 msgid "Fill"
@@ -27842,11 +28111,11 @@ msgstr "Wypełnij"
 
 #: pcbnew/tools/zone_filler_tool.cpp:47
 msgid "Fill zone(s)"
-msgstr "Wypełnij strefę(y)"
+msgstr "Wypełnia strefę(y)"
 
 #: pcbnew/tools/zone_filler_tool.cpp:51
 msgid "Fill All"
-msgstr "Wypełnij wszystkie"
+msgstr "Wypełnij wszystkie strefy"
 
 #: pcbnew/tools/zone_filler_tool.cpp:51
 msgid "Fill all zones"
@@ -27854,15 +28123,15 @@ msgstr "Wypełnia wszystkie strefy"
 
 #: pcbnew/tools/zone_filler_tool.cpp:55
 msgid "Unfill"
-msgstr "Usuń wypełnienia"
+msgstr "Usuń wypełnienie"
 
 #: pcbnew/tools/zone_filler_tool.cpp:55
 msgid "Unfill zone(s)"
-msgstr "Usuń wypełnienie stref(y)"
+msgstr "Usuwa wypełnienie ze strefy"
 
 #: pcbnew/tools/zone_filler_tool.cpp:59
 msgid "Unfill All"
-msgstr "Usuń wszystkie wypełnienia"
+msgstr "Usuń wypełnienie wszystkich stref"
 
 #: pcbnew/tools/zone_filler_tool.cpp:59
 msgid "Unfill all zones"
@@ -27874,58 +28143,57 @@ msgstr "Wypełnij wszystkie strefy"
 
 #: pcbnew/tools/zone_filler_tool.cpp:145
 msgid "Unfill Zone"
-msgstr "Usuń wypełnienie stref(y)"
+msgstr "Usuń wypełnienia strefy"
 
 #: pcbnew/tools/zone_filler_tool.cpp:163
 msgid "Unfill All Zones"
-msgstr "Usuwa wypełnienia ze wszystkich stref"
+msgstr "Usuń wypełnienia wszystkich stref"
 
 #: pcbnew/tracks_cleaner.cpp:169 pcbnew/tracks_cleaner.cpp:741
 msgid "Board cleanup"
-msgstr "Wyczyść płytkę"
+msgstr "Oczyszczanie obwodu drukowanego"
 
 #: pcbnew/zone_filler.cpp:114
-#, fuzzy
 msgid "Checking zone fills..."
-msgstr "Obliczanie wypełnienia strefy ..."
+msgstr "Sprawdzenie wypełnień strefy..."
 
 #: pcbnew/zone_filler.cpp:161
 msgid "Removing insulated copper islands..."
-msgstr ""
+msgstr "Usuwanie izolowanych obszarów miedzi..."
 
 #: pcbnew/zone_filler.cpp:188
 msgid "Zone fills are out-of-date. Re-fill?"
-msgstr ""
+msgstr "Wypełnienie strefy jest nieaktualne. Wypełnić ponownie?"
 
 #: pcbnew/zone_filler.cpp:215
-#, fuzzy
 msgid "Performing polygon fills..."
-msgstr "Rozpoczęcie wypełnienia strefy..."
+msgstr "Wypełnianie stref polygonami..."
 
 #: pcbnew/zone_filler.cpp:267
-#, fuzzy
 msgid "Performing segment fills..."
-msgstr "Wczytywanie plików Gerber..."
+msgstr "Wypełnianie stref segmentami..."
 
 #: pcbnew/zone_filler.cpp:294
 msgid "Committing changes..."
-msgstr ""
+msgstr "Wprowadzanie zmian..."
 
 #: pcbnew/zone_filler.cpp:301
 msgid "Fill Zone(s)"
-msgstr "Wypełnij strefę(y)"
+msgstr "Wypełnij strefę(-y)"
 
 #: pcbnew/zones_by_polygon.cpp:139
 msgid "The duplicated zone cannot be on the same layers as the original zone."
 msgstr ""
+"Powielona strefa nie może być na tej samej warstwie co strefa powielana."
 
 #: pcbnew/zones_by_polygon.cpp:145
 msgid "The duplicated zone cannot be on the same layer as the original zone."
 msgstr ""
+"Powielana strefa nie może być na tej samej warstwie co oryginalna strefa."
 
 #: pcbnew/zones_by_polygon.cpp:177
 msgid "Warning: The new zone fails DRC"
-msgstr ""
+msgstr "Ostrzeżenie: Nowa strefa nie przejdzie testów DRC"
 
 #: pcbnew/zones_by_polygon.cpp:379 pcbnew/zones_by_polygon.cpp:438
 #: pcbnew/zones_by_polygon.cpp:831
@@ -27937,5954 +28205,24 @@ msgid "Error: a keepout area is allowed only on copper layers"
 msgstr "BŁĄD: strefa chroniona jest dozwolona tylko na wartwach sygnałowych"
 
 #: pcbnew/zones_by_polygon.cpp:701
-#, fuzzy
 msgid "DRC error: this start point is inside or too close another area"
-msgstr "Błąd DRC: punkt początkowy jest wewnątrz lub za blisko innego obszaru"
+msgstr ""
+"Błąd DRC: ten punkt początkowy jest wewnątrz lub zbyt blisko innego obszaru"
 
 #: pcbnew/zones_by_polygon.cpp:769
-#, fuzzy
 msgid "DRC error: closing this area creates a DRC error with another area"
-msgstr "Błąd DRC: zamknięcie tego obszaru wywołuje błąd DRC z innym obszarem"
+msgstr ""
+"Błąd DRC: zamknięcie tego obszaru spowoduje błąd DRC względem innego obszaru"
 
 #: pcbnew/zones_by_polygon.cpp:927 pcbnew/zones_by_polygon.cpp:991
 msgid "Modify zone properties"
-msgstr ""
+msgstr "Zmień ustawienia strefy"
 
 #: pcbnew/zones_by_polygon.cpp:982
 #, c-format
 msgid "Refill %d Zones"
-msgstr ""
+msgstr "Wypełniono %d strefy"
 
 #: pcbnew/zones_by_polygon_fill_functions.cpp:120
-#, fuzzy
 msgid "Checking Zones"
-msgstr "Połącz strefy"
-
-#~ msgid "Run CvPcb to associate footprints to symbols"
-#~ msgstr "Uruchom CvPcb - Przypisz footprinty komponentom ze schematu"
-
-#~ msgid "Figure out what's best"
-#~ msgstr "Pokaż najlepszą opcję"
-
-#~ msgid "Routing Options..."
-#~ msgstr "Opcje trasowania..."
-
-#~ msgid "Shows a dialog containing router options."
-#~ msgstr "Pokazuje okno dialogowe z opcjami routera."
-
-#~ msgid "Differential Pair Dimensions..."
-#~ msgstr "Rozmiary par różnicowych..."
-
-#~ msgid "Sets the width and gap of the currently routed differential pair."
-#~ msgstr ""
-#~ "Ustawia szerokość i prześwit bieżąco prowadzonych ścieżek różnicowych."
-
-#~ msgid ""
-#~ "3D search path list is empty;\n"
-#~ "continue to write empty file?"
-#~ msgstr ""
-#~ "Lista ścieżek wyszukiwania 3D jest pusta.\n"
-#~ "Kontynuować zapisanie pustego pliku?"
-
-#~ msgid "Fit in page"
-#~ msgstr "Dopasuj do rozmiaru strony"
-
-#~ msgid "Rotate X <-"
-#~ msgstr "Obrót w osi X ←"
-
-#~ msgid "Rotate X ->"
-#~ msgstr "Obrót w osi X →"
-
-#~ msgid "Rotate Y <-"
-#~ msgstr "Obrót w osi Y ←"
-
-#~ msgid "Rotate Y ->"
-#~ msgstr "Obrót w osi Y →"
-
-#~ msgid "Rotate Z <-"
-#~ msgstr "Obrót w osi Z ←"
-
-#~ msgid "Rotate Z ->"
-#~ msgstr "Obrót w osi Z →"
-
-#~ msgid "Realistic Mode"
-#~ msgstr "Tryb realistyczny"
-
-#~ msgid "Show Board Bod&y"
-#~ msgstr "Pokaż ciało płytki"
-
-#~ msgid "Show Zone &Filling"
-#~ msgstr "Pokaż stre&fy wypełnień"
-
-#~ msgid "Show 3D M&odels"
-#~ msgstr "Pokaż modele 3D"
-
-#~ msgid "Through Hole"
-#~ msgstr "Otwór przelotowy"
-
-#~ msgid "Surface Mount"
-#~ msgstr "Montaż powierzchniowy"
-
-#~ msgid "Show &Layers"
-#~ msgstr "Pokaż warstwy"
-
-#~ msgid "Show &Adhesive Layers"
-#~ msgstr "Pokaż w&arstwy kleju"
-
-#~ msgid "Show &Silkscreen Layers"
-#~ msgstr "Pokaż warstwy opisowe"
-
-#~ msgid "Show Solder &Mask Layers"
-#~ msgstr "Pokaż warstwy z solder&maską"
-
-#~ msgid "Show Solder &Paste Layers"
-#~ msgstr "Pokaż warstwy do nakładania &pasty"
-
-#~ msgid "Show &Eco Layers"
-#~ msgstr "Pokaż warstwy &ECO"
-
-#~ msgid "User layers:"
-#~ msgstr "Warstwy użytkownika:"
-
-#~ msgid "Format"
-#~ msgstr "Format"
-
-#~ msgid ""
-#~ "<b>KICAD_PTEMPLATES</b> is optional and can be defined if you want to "
-#~ "create your own project templates folder."
-#~ msgstr ""
-#~ "Zmienna <b>KICAD_PTEMPLATES</b> jest opcjonalna i można ją zdefiniować "
-#~ "jeśli istnieje potrzeba utworzenia i używania szablonów projektów "
-#~ "(specjalnych folderów z plikami szablonu) zapisanych w ściśle określonym "
-#~ "folderze nadrzędnym."
-
-#~ msgid ""
-#~ "The program cannot be closed\n"
-#~ "A quasi-modal dialog window is currently open, please close it first."
-#~ msgstr ""
-#~ "Program nie może zostać zamknięty\n"
-#~ "Jedno z okien dialogowych jest wciąż otwarte, należy je najpierw zamknąć."
-
-#~ msgid "Zoom Select"
-#~ msgstr "Wybór powiększenia"
-
-#~ msgid "Grid Select"
-#~ msgstr "Wybór siatki"
-
-#~ msgid "Components: %d, unassigned: %d"
-#~ msgstr "Komponenty: %d, nieprzydzielone: %d"
-
-#~ msgid "Filter list: "
-#~ msgstr "Filtruj listę wg: "
-
-#~ msgid "Key words: "
-#~ msgstr "Słowa kluczowe:"
-
-#~ msgid "name"
-#~ msgstr "Nazwa:"
-
-#~ msgid "&Save Footprint Associations\tCtrl+S"
-#~ msgstr "Zapi&sz skojarzenia footprintów\tCtrl+S"
-
-#~ msgid "Close CvPcb"
-#~ msgstr "Zamknij CvPcb"
-
-#~ msgid "&Keep Open On Save"
-#~ msgstr "Pozostaw otwarte okno po zapisie"
-
-#~ msgid "Prevent CvPcb from exiting after saving netlist file"
-#~ msgstr "Zablokuj zamknięcie CvPcb po zapisaniu pliku listy sieci"
-
-#~ msgid "Plugins"
-#~ msgstr "Dostępne wtyczki:"
-
-#~ msgid "Keywords"
-#~ msgstr "Słowa kluczowe"
-
-#~ msgid "  Fields"
-#~ msgstr "Pola"
-
-#~ msgid "Current Symbol"
-#~ msgstr "Bieżące symbol"
-
-#~ msgid "New Symbol"
-#~ msgstr "Nowy symbol"
-
-#~ msgid "Horiz. Justify"
-#~ msgstr "Wyrównanie w poziomie"
-
-#~ msgid "Vert. Justify"
-#~ msgstr "Wyrównanie w pionie"
-
-#~ msgid "Visibility"
-#~ msgstr "Widoczność"
-
-#~ msgid "Field Value"
-#~ msgstr "Wartość pola"
-
-#~ msgid "X Position"
-#~ msgstr "Pozycja X"
-
-#~ msgid "Y Position"
-#~ msgstr "Pozycja Y"
-
-#~ msgid "Default Value"
-#~ msgstr "Domyślna wartość"
-
-#~ msgid "Default Fields"
-#~ msgstr "Domyślne pola"
-
-#~ msgid "Sort"
-#~ msgstr "Sortuj"
-
-#~ msgid " - %u changed"
-#~ msgstr "- %u zostało mienione"
-
-#~ msgid "Apply Changes"
-#~ msgstr "Zastosuj zmiany"
-
-#~ msgid "Revert Changes"
-#~ msgstr "Przywróć zmiany"
-
-#~ msgid "Horizontal Justify"
-#~ msgstr "Wyrównanie w poziomie"
-
-#~ msgid "Vertical Justify"
-#~ msgstr "Wyrównanie w pionie"
-
-#~ msgid "General Pin Settings"
-#~ msgstr "Ustawienia główne pinu"
-
-#~ msgid "Page Size"
-#~ msgstr "Rozmiar strony"
-
-#~ msgid "DC [V/A]"
-#~ msgstr "DC [V/A]"
-
-#~ msgid "Pulse width [s]"
-#~ msgstr "Szerokość impulsu [s]"
-
-#~ msgid "Frequency [Hz]"
-#~ msgstr "Częstotliwość [Hz]"
-
-#~ msgid "Delay [s]"
-#~ msgstr "Opóźnienie [s]"
-
-#~ msgid "Value [V/A]"
-#~ msgstr "Wartość [V/A]"
-
-#~ msgid "Table:"
-#~ msgstr "Tabela:"
-
-#~ msgid "Input Pin.........."
-#~ msgstr "Pin wejściowy............."
-
-#~ msgid "Output Pin........."
-#~ msgstr "Pin wyjściowy............."
-
-#~ msgid "Bidirectional Pin.."
-#~ msgstr "Pin dwukierunkkowy........"
-
-#~ msgid "Tri-State Pin......"
-#~ msgstr "Pin trójstanowy..........."
-
-#~ msgid "Passive Pin........"
-#~ msgstr "Pin pasywny..............."
-
-#~ msgid "Unspecified Pin...."
-#~ msgstr "Pin nieokreślony.........."
-
-#~ msgid "Power Input Pin...."
-#~ msgstr "Pin wejścia zasilania....."
-
-#~ msgid "Power Output Pin..."
-#~ msgstr "Pin wyjścia zasilania....."
-
-#~ msgid "Open Collector....."
-#~ msgstr "Pin z otwartym kolektorem."
-
-#~ msgid "Open Emitter......."
-#~ msgstr "Pin z otwartym emiterem..."
-
-#~ msgid "No Connection......"
-#~ msgstr "Nie połączony............."
-
-#~ msgid "Enter a name to create a new component based on this one."
-#~ msgstr "Wpisz nazwę by stworzyć nowy symbol na podstawie tego symbolu."
-
-#~ msgid "Enter a new value for the %s field."
-#~ msgstr "Wprowadź nową wartość dla pola %s."
-
-#~ msgid "Library &Editor"
-#~ msgstr "&Edytor bibliotek"
-
-#~ msgid "S&ymbol Table..."
-#~ msgstr "Tabela s&ymboli..."
-
-#~ msgid "Run CvPcb"
-#~ msgstr "Uruchom CvPcb"
-
-#~ msgid "Manage Symbol Library Tables..."
-#~ msgstr "Menadżer tabeli bibliotek schematowych..."
-
-#~ msgid "&Save Preferences..."
-#~ msgstr "Zapi&sz preferencje..."
-
-#~ msgid "Save application preferences"
-#~ msgstr "Zapisz ustawienia aplikacji"
-
-#~ msgid "Load Prefe&rences..."
-#~ msgstr "Wczytaj prefe&rencje..."
-
-#~ msgid "Load application preferences"
-#~ msgstr "Wczytaj ustawienia aplikacji"
-
-#~ msgid "Save the current active library"
-#~ msgstr "Zapisz aktywną bibliotekę"
-
-#~ msgid ""
-#~ "\n"
-#~ "\n"
-#~ "Do you want to create a sheet with the contents of this file?"
-#~ msgstr ""
-#~ "\n"
-#~ "\n"
-#~ "Czy chcesz utworzyć arkusz z zawartością tego pliku?"
-
-#~ msgid ""
-#~ "\n"
-#~ "\n"
-#~ "Do you want to replace the sheet with the contents of this file?"
-#~ msgstr ""
-#~ "\n"
-#~ "\n"
-#~ "Czy chcesz zamienić arkusz z zawartością tego pliku?"
-
-#~ msgid ""
-#~ "This sheet uses shared data in a complex hierarchy.\n"
-#~ "\n"
-#~ msgstr ""
-#~ "Ten arkusz używa danych współdzielonych w zaawansowanej hierarchii.\n"
-#~ "\n"
-
-#~ msgid "Do you wish to convert it to a simple hierarchical sheet?"
-#~ msgstr "Czy chcesz go zamienić na prosty arkusz kierarchiczny?"
-
-#~ msgid "Scale:"
-#~ msgstr "Skala:"
-
-#~ msgid "X scale adjust"
-#~ msgstr "Dostosuj skalę X"
-
-#~ msgid "Y scale adjust"
-#~ msgstr "Dostosuj skalę Y"
-
-#~ msgid "METRIC command has no parameter"
-#~ msgstr "Polecenie METRIC nie posiada parametru"
-
-#~ msgid "INCH command has no parameter"
-#~ msgstr "Polecenie INCH nie posiada parametru"
-
-#~ msgid "Show spots in sketch mode"
-#~ msgstr "Pokaż zarys punktów"
-
-#~ msgid "Show polygons in sketch mode"
-#~ msgstr "Pokaż zarysy wypełnień"
-
-#~ msgid "Portable Templates"
-#~ msgstr "Szablony przenośne"
-
-#~ msgid "undefined pin"
-#~ msgstr "Nieokreślony pin"
-
-#~ msgid "undefined pin %s"
-#~ msgstr "Nieokreślony pin %s"
-
-#~ msgid "Pos X (mm)"
-#~ msgstr "Poz X (mm)"
-
-#~ msgid "Pos Y (mm)"
-#~ msgstr "Poz Y (mm)"
-
-#~ msgid "End X (mm)"
-#~ msgstr "Koniec X (mm)"
-
-#~ msgid "End Y (mm)"
-#~ msgstr "Koniec Y (mm)"
-
-#~ msgid "Horizontal justification"
-#~ msgstr "Wyrównanie w poziomie"
-
-#~ msgid "Text width (mm)"
-#~ msgstr "Szerokość tekstu (mm)"
-
-#~ msgid "Text height (mm)"
-#~ msgstr "Wysokość tekstu (mm)"
-
-#~ msgid "Maximum width (mm)"
-#~ msgstr "Maksymalna szerokość (mm)"
-
-#~ msgid "Position X (mm)"
-#~ msgstr "Pozycja X (mm)"
-
-#~ msgid "Position Y (mm)"
-#~ msgstr "Pozycja Y (mm)"
-
-#~ msgid "Line Thickness (mm)"
-#~ msgstr "Grubość linii (mm)"
-
-#~ msgid "Text Thickness"
-#~ msgstr "Grubość tekstu"
-
-#~ msgid "Left margin (mm)"
-#~ msgstr "Lewy margines (mm)"
-
-#~ msgid "Right margin (mm)"
-#~ msgstr "Prawy margines (mm)"
-
-#~ msgid "Top margin (mm)"
-#~ msgstr "Górny margines (mm)"
-
-#~ msgid "Bottom margin (mm)"
-#~ msgstr "Margines dolny (mm)"
-
-#~ msgid "Parameters"
-#~ msgstr "Parametry"
-
-#~ msgid "Rho"
-#~ msgstr "Rho"
-
-#~ msgid "H_t"
-#~ msgstr "H_t"
-
-#~ msgid "label"
-#~ msgstr "etykieta"
-
-#~ msgid "Z0"
-#~ msgstr "Z0"
-
-#~ msgid "Din"
-#~ msgstr "Din"
-
-#~ msgid "Default pen size"
-#~ msgstr "Domyślny rozmiar pisaka:"
-
-#~ msgid "Segments / 360 deg:"
-#~ msgstr "Segmenty / 360 stopni:"
-
-#~ msgid "Net Classes"
-#~ msgstr "Klasy sieci"
-
-#~ msgid "Custom Via Sizes"
-#~ msgstr "Własny rozmiar przelotek"
-
-#~ msgid "Custom Track Widths"
-#~ msgstr "Własna szerokość ścieżek"
-
-#~ msgid "Text width"
-#~ msgstr "Szerokość tekstu"
-
-#~ msgid "Text height"
-#~ msgstr "Wysokość tekstu"
-
-#~ msgid "Text thickness"
-#~ msgstr "Grubość tekstu"
-
-#~ msgid "Position:"
-#~ msgstr "Pozycja:"
-
-#~ msgid "Rotate 90 degrees"
-#~ msgstr "Obrót o 90 stopni"
-
-#~ msgid "Rotate 180 degrees"
-#~ msgstr "Obrót o 180 stopni"
-
-#~ msgid "Rotation 90 degree"
-#~ msgstr "Obrót o 90 stopni"
-
-#~ msgid "Rotation 180 degree"
-#~ msgstr "Obrót o 180 stopni"
-
-#~ msgid "Local Clearance Values"
-#~ msgstr "Lokalny prześwit"
-
-#~ msgid "Append with Wizard"
-#~ msgstr "Dołącz za pomocą kreatora"
-
-#~ msgid "&Delete unconnected tracks"
-#~ msgstr "Usuń niepołączone ścieżki"
-
-#~ msgid "Point X:"
-#~ msgstr "Punkt X:"
-
-#~ msgid "Point Y:"
-#~ msgstr "Punkt Y:"
-
-#~ msgid "The arc angle must be greater than zero."
-#~ msgstr "Kąt łuku musi być większy niż zero"
-
-#~ msgid "Center X"
-#~ msgstr "Pkt. centralny X"
-
-#~ msgid "Center Y"
-#~ msgstr "Pkt. centralny Y"
-
-#~ msgid "Point X"
-#~ msgstr "Promień X"
-
-#~ msgid "Point Y"
-#~ msgstr "Promień Y"
-
-#~ msgid "Start Point X"
-#~ msgstr "Pozycja początkowa X"
-
-#~ msgid "Start Point Y"
-#~ msgstr "Pozycja początkowa Y"
-
-#~ msgid "Error list"
-#~ msgstr "Lista błędów"
-
-#~ msgid "Properties:"
-#~ msgstr "Właściwości:"
-
-#~ msgid "Any orientation"
-#~ msgstr "Dowolna orientacja"
-
-#~ msgid "180, 90, and 45 degrees"
-#~ msgstr "Poziomo, pionowo i 45 stopni"
-
-#~ msgid "Keepout Options:"
-#~ msgstr "Opcje strefy chronionej:"
-
-#~ msgid "No tracks"
-#~ msgstr "Bez ścieżek"
-
-#~ msgid "No vias"
-#~ msgstr "Bez przelotek"
-
-#~ msgid "Copper Layers"
-#~ msgstr "Warstwy ścieżek"
-
-#~ msgid "On new graphic item creation:"
-#~ msgstr "Domyślne wartości przy tworzeniu nowego elementu graficznego:"
-
-#~ msgid "&Reference"
-#~ msgstr "Oznaczenie"
-
-#~ msgid "Footprint Selection"
-#~ msgstr "Wybór footprintów"
-
-#~ msgid "x:"
-#~ msgstr "x:"
-
-#~ msgid "y:"
-#~ msgstr "y:"
-
-#~ msgid "Included Layers"
-#~ msgstr "Dołączone warstwy"
-
-#~ msgid "UNKNOWN"
-#~ msgstr "NIEZNANA"
-
-#~ msgid "Downloading libraries"
-#~ msgstr "Pobierz biblioteki"
-
-#~ msgid "Please wait..."
-#~ msgstr "Proszę czekać..."
-
-#~ msgid "Validating libraries"
-#~ msgstr "Sprawdź biblioteki"
-
-#~ msgid "NOT CHECKED"
-#~ msgstr "NIESPRAWDZONA"
-
-#~ msgid "INVALID"
-#~ msgstr "BŁĘDNA"
-
-#~ msgid "Validating libraries %d/%d"
-#~ msgstr "Walidacja bibliotek %d/%d"
-
-#~ msgid ""
-#~ "Welcome to the Add Footprint Libraries Wizard!\n"
-#~ "\n"
-#~ "Please select the source for the libraries to add:"
-#~ msgstr ""
-#~ "Witamy w Kreatorze Tabeli Bibliotek!\n"
-#~ "\n"
-#~ "Proszę wybrać źródło bibliotek w celu dodania ich do tabeli:"
-
-#~ msgid "Files on my computer"
-#~ msgstr "Pliki na tym komputerze"
-
-#~ msgid "Github repository"
-#~ msgstr "Repozytorium GitHub"
-
-#~ msgid "https://github.com/KiCad"
-#~ msgstr "https://github.com/KiCad"
-
-#~ msgid "Save a local copy to:"
-#~ msgstr "Zapisz lokalną kopię do:"
-
-#~ msgid "Select files or folders to add:"
-#~ msgstr "Wybierz pliki lub foldery w celu dodania:"
-
-#~ msgid "Review and confirm the changes to the libraries:"
-#~ msgstr "Przejrzyj i potwierdź zmiany w bibliotekach:"
-
-#~ msgid "Where do you wish the new libraries to be added:"
-#~ msgstr "Gdzie nowe biblioteki mają zostać dodane:"
-
-#~ msgid "To global library configuration (visible by all projects)"
-#~ msgstr "Do globalnej tabeli bibliotek (widocznej dla wszystkich projektów)"
-
-#~ msgid "To the current project only"
-#~ msgstr "Tylko dla tabeli bieżącego projektu"
-
-#~ msgid "Fill zones...\n"
-#~ msgstr "Strefy wypełnień...\n"
-
-#~ msgid "Test zones...\n"
-#~ msgstr "Strefy testowe...\n"
-
-#~ msgid "Track Len"
-#~ msgstr "Długość ścieżki"
-
-#~ msgid "Full Len"
-#~ msgstr "Pełna długość"
-
-#~ msgid "Pad to die"
-#~ msgstr "Od pola do krzemu"
-
-#~ msgid "Loading incomplete; cancelled by user."
-#~ msgstr "Wczytywanie niekompletne, przerwane przez użytkownika"
-
-#~ msgid "Footprint Builder Messages"
-#~ msgstr "Wiadomości"
-
-#~ msgid "Load Footprint"
-#~ msgstr "Zapisz footprint"
-
-#~ msgid "&Footprint Library Wizard..."
-#~ msgstr "Kreator tabeli bibliotek..."
-
-#~ msgid "Add footprint libraries with wizard"
-#~ msgstr "Dodaje biblioteki footprintów za pomocą kreatora"
-
-#~ msgid "Footprint Li&brary Table..."
-#~ msgstr "Tabele &bibliotek płytkowych..."
-
-#~ msgid "&3D Shape Downloader..."
-#~ msgstr "Pobieranie bibliotek &3D..."
-
-#~ msgid "Download from Github 3D shape libraries using wizard"
-#~ msgstr "Dodaje biblioteki modeli 3D z serwerów GitHub za pomocą kreatora"
-
-#~ msgid "&FreeRoute"
-#~ msgstr "&FreeRoute"
-
-#~ msgid "Fast access to the FreeROUTE external advanced router"
-#~ msgstr "Szybki dostęp do zaawansowanego routera FreeROUTE"
-
-#~ msgid "Automatically Place Footprint"
-#~ msgstr "Automatyczne rozłóż footprint"
-
-#~ msgid "Automatically Route Footprint"
-#~ msgstr "Automatycznie trasuj ścieżki footprintu"
-
-#~ msgid "Automatically Place All Footprints"
-#~ msgstr "Automatyczne rozłóż wszystkie footprinty"
-
-#~ msgid "Automatically Place New Footprints"
-#~ msgstr "Automatyczne rozłóż nowe footprinty"
-
-#~ msgid "Automatically Place Next Footprints"
-#~ msgstr "Automatyczne rozłóż następne footprinty"
-
-#~ msgid "Autoroute"
-#~ msgstr "Autorouter"
-
-#~ msgid "Select Layer Pair..."
-#~ msgstr "Wybierz parę warstw..."
-
-#~ msgid "Automatically Route All Footprints"
-#~ msgstr "Automatycznie trasuj ścieżki wszystkich footprintów"
-
-#~ msgid "Automatically Route Pad"
-#~ msgstr "Automatycznie trasuj ścieżki pola lutowniczego"
-
-#~ msgid "Automatically Route Net"
-#~ msgstr "Automatycznie trasuj ścieżki tej sieci połączeń"
-
-#~ msgid "Swap Layers:"
-#~ msgstr "Zamień warstwy:"
-
-#~ msgid "Mode footprint: manual and automatic movement and placement"
-#~ msgstr ""
-#~ "Tryb ręcznego i automatycznego przesuwania oraz ustawiania footprintów"
-
-#~ msgid "Mode track: autorouting"
-#~ msgstr "Tryb ścieżek i autoroutingu"
-
-#~ msgid "Enable automatic track deletion"
-#~ msgstr "Włącz automatyczne kasowanie starych ścieżek"
-
-#~ msgid "Disable auto delete old track"
-#~ msgstr "Wyłącz automatyczne usuwanie starych ścieżek"
-
-#~ msgid "Are you sure you want to delete item?"
-#~ msgstr "Czy usunąć wybrany element?"
-
-#~ msgid "Drag a line ending"
-#~ msgstr "Przeciągnij koniec linii"
-
-#~ msgid "missing function 'GetModelExtension'"
-#~ msgstr "brakująca funkcja 'GetModelExtension'"
-
-#~ msgid "missing function 'GetNFilters'"
-#~ msgstr "brakująca funkcja 'GetNFilters'"
-
-#~ msgid "missing function 'GetFileFilter'"
-#~ msgstr "brakująca funkcja 'GetFileFilter'"
-
-#~ msgid "missing function 'CanRender'"
-#~ msgstr "brakująca funkcja 'CanRender'"
-
-#~ msgid "missing function 'Load'"
-#~ msgstr "brakująca funkcja 'Load'"
-
-#~ msgid "missing function 'GetClassVersion'"
-#~ msgstr "brakująca funkcja 'GetClassVersion'"
-
-#~ msgid "missing function 'CheckClassVersion'"
-#~ msgstr "brakująca funkcja 'CheckClassVersion'"
-
-#~ msgid "missing function 'GetKicadPluginName'"
-#~ msgstr "brakująca funkcja 'GetKicadPluginName'"
-
-#~ msgid "missing function 'GetVersion'"
-#~ msgstr "brakująca funkcja 'GetVersion'"
-
-#~ msgid "pcb_filename"
-#~ msgstr "pcb_nazwa_pliku"
-
-#~ msgid "Fields editor"
-#~ msgstr "Edytor pól"
-
-#~ msgid "Schematic Library Tables"
-#~ msgstr "Tabela bibliotek schematowych"
-
-#~ msgid "Fit schematic sheet on screen"
-#~ msgstr "Dopasuj wymiary schematu do rozmiarów ekranu"
-
-#~ msgid "PCB Library Tables"
-#~ msgstr "Tabele bibliotek PCB"
-
-#~ msgid "Search for Footprint"
-#~ msgstr "Szukaj footprintu"
-
-#~ msgid "Add Footprint Libraries Wizard"
-#~ msgstr "Kreator Tabeli Bibliotek"
-
-#~ msgid "KiCad"
-#~ msgstr "KiCad"
-
-#~ msgid "EDA Suite"
-#~ msgstr "EDA Suite"
-
-#~ msgid "Eeschema Schematic Editor"
-#~ msgstr "Eeschema edytor schematów "
-
-#~ msgid "Configure Path"
-#~ msgstr "Skonfiguruj ścieżkę"
-
-#~ msgid "Render with improoved quality on final render (slow)"
-#~ msgstr "Renderowanie z poprawioną jakością renderowania końcowego (powolne)"
-
-#~ msgid " mils"
-#~ msgstr " milsy"
-
-#~ msgid " in"
-#~ msgstr " w"
-
-#~ msgid " mm"
-#~ msgstr " mm"
-
-#~ msgid " \""
-#~ msgstr " \""
-
-#~ msgid " deg"
-#~ msgstr " st."
-
-#~ msgid "%s is already running, Continue?"
-#~ msgstr "%s jest już uruchomiony. Kontynuować?"
-
-#~ msgid "No editor defined in Kicad. Please choose it."
-#~ msgstr "W KiCad nie zdefiniowano edytora. Proszę go wybrać."
-
-#~ msgid "&About Kicad"
-#~ msgstr "O programie KiCad"
-
-#~ msgid "Illegal reference. A reference must start with a letter"
-#~ msgstr "Niepoprawne oznaczenie. Oznaczenie musi rozpoczynać się literą"
-
-#~ msgid "Mirror horizontally"
-#~ msgstr "Odbij poziomo"
-
-#~ msgid "Mirror vertically"
-#~ msgstr "Odbij pionowo"
-
-#~ msgid "Alias of "
-#~ msgstr "Alias "
-
-#~ msgid "Navigate hierarchical sheets"
-#~ msgstr ""
-#~ "Otwiera okno umożliwiające na szybkie przemieszczanie się po hierarchii "
-#~ "schematów"
-
-#~ msgid "&Import Non-Kicad Schematic File..."
-#~ msgstr "&Importuj pliki schematu inne niż KiCad..."
-
-#~ msgid "Contribute to KiCad (open web browser)"
-#~ msgstr "Twórcy KiCada (otwiera przeglądarkę internetową)"
-
-#~ msgid "Key Words"
-#~ msgstr "Słowa Kluczowe"
-
-#~ msgid "Open Gerber File"
-#~ msgstr "Otwórz plik Gerber"
-
-#~ msgid "Open Drill File"
-#~ msgstr "Otwórz plik wierceń"
-
-#~ msgid "Load &Gerber File..."
-#~ msgstr "Wczytaj plik &Gerber..."
-
-#~ msgid ""
-#~ "Load a new Gerber file on the current layer. Previous data will be deleted"
-#~ msgstr ""
-#~ "Wczytaj nowy plik Gerbera na bieżącą warstwę.  Poprzednie dane zostaną "
-#~ "usunięte"
-
-#~ msgid "Load &EXCELLON Drill File..."
-#~ msgstr "Wczytaj plik wierceń &EXCELLON..."
-
-#~ msgid "Load excellon drill file"
-#~ msgstr "Otwórz plik wierceń EXCELLON"
-
-#~ msgid "Load &Zip Archive File..."
-#~ msgstr "Wczytaj plik archiwum &ZIP..."
-
-#~ msgid "Open Recent Dri&ll File"
-#~ msgstr "Otwórz p&lik wierceń"
-
-#~ msgid "Clear &All"
-#~ msgstr "Wyczyść wszystkie"
-
-#~ msgid "Print gerber"
-#~ msgstr "Wydrukuj plik gerbera"
-
-#~ msgid "Erase all layers"
-#~ msgstr "Wyczyść wszystkie warstwy"
-
-#~ msgid ""
-#~ "Load an excellon drill file on the current layer. Previous data will be "
-#~ "deleted"
-#~ msgstr ""
-#~ "Wczytaj plik wierceń Excellon na bieżącej warstwie.  Poprzednie dane "
-#~ "zostaną usunięte"
-
-#~ msgid "&Favourite PDF Viewer"
-#~ msgstr "Preferowana przeglądarka PDF"
-
-#~ msgid "Use favourite PDF viewer"
-#~ msgstr "Użyj preferowanej przeglądarki PDF do przeglądania dokumentacji"
-
-#~ msgid "Set favourite PDF viewer"
-#~ msgstr "Wybierz preferowaną przeglądarkę PDF do przeglądania dokumentacji"
-
-#~ msgid "Synthetize"
-#~ msgstr "Syntetyzuj"
-
-#~ msgid "Electrical length"
-#~ msgstr "Długość elektryczna"
-
-#~ msgid " Yes"
-#~ msgstr " Tak"
-
-#~ msgid " No"
-#~ msgstr " Nie"
-
-#~ msgid "Outline Appearence:"
-#~ msgstr "Wygląd obrysów:"
-
-#~ msgid "Mouse drag behaviour:"
-#~ msgstr "Przy przeciąganiu myszą:"
-
-#~ msgid "No board currently edited"
-#~ msgstr "Żadna płytka nie jest obecnie edytowana"
-
-#~ msgid "Unknown PCB_FILE_T value: %d"
-#~ msgstr "Nieznana wartość PCB_FILE_T: %d"
-
-#~ msgid "&Lines"
-#~ msgstr "&Linie"
-
-#~ msgid "&Polygons"
-#~ msgstr "Wy&pełnienie"
-
-#~ msgid "Add graphic polygons"
-#~ msgstr "Dodaj graficzne wypełnienie"
-
-#~ msgid "Import Non-Kicad Board File..."
-#~ msgstr "Importuje plik płytki inny niż KiCad..."
-
-#~ msgid "page type \"%s\" is not valid "
-#~ msgstr "typ strony \"%s\" nie jest poprawny"
-
-#~ msgid "cannot handle footprint text type %s"
-#~ msgstr "nie mogę obsłużyć tekstu footprintu typu %s"
-
-#~ msgid "Change Cursor Shape"
-#~ msgstr "Zmień kształt kursora"
-
-#~ msgid "Move left <-"
-#~ msgstr "Przesuń w lewo <-"
-
-#~ msgid "Move right ->"
-#~ msgstr "Przesuń w prawo ->"
-
-#~ msgid "Zoom: %3.1f"
-#~ msgstr "Powiększenie: %3.1f"
-
-#~ msgid "Build time %.3f s"
-#~ msgstr "Czas budowania %.3f s"
-
-#~ msgid "Build layer %s"
-#~ msgstr "Budowanie warstwy %s"
-
-#~ msgid "Load 3D Shapes"
-#~ msgstr "Ładowanie kształtów 3D"
-
-#~ msgid ""
-#~ "Unable to calculate the board outlines.\n"
-#~ "Therefore use the board boundary box."
-#~ msgstr ""
-#~ "Nie można obliczyć obrysu płytki.\n"
-#~ "Użyte zostanie pole określone przez krawędzie płytki."
-
-#~ msgid "Create Image (png format)"
-#~ msgstr "Zapisz obraz w formacie PNG"
-
-#~ msgid "Create Image (jpeg format)"
-#~ msgstr "Zapisz obraz w formacie JPEG"
-
-#~ msgid "Copy 3D Image to Clipboard"
-#~ msgstr "Kopiuj obraz 3D do schowka"
-
-#~ msgid "Show Holes in Zones"
-#~ msgstr "Pokaż otwory w strefach"
-
-#~ msgid ""
-#~ "Holes inside a copper layer copper zones are shown, but the calculation "
-#~ "time is longer"
-#~ msgstr ""
-#~ "Otwory w strefach wypełnień są wyświetlane, jednak czas kalkulacji obrazu "
-#~ "staje się dłuższy"
-
-#~ msgid "Render Textures"
-#~ msgstr "Renderuj tekstury"
-
-#~ msgid "Apply a grid/cloud textures to board, solder mask and silk screen"
-#~ msgstr ""
-#~ "Dodaj teksturę laminatu do ciała płytki, soldermaski i warstwy opisowej"
-
-#~ msgid "Render Smooth Normals"
-#~ msgstr "Renderuj stosując wygładzanie"
-
-#~ msgid "Use Model Normals"
-#~ msgstr "Użyj ustawień wygładzania z modeli"
-
-#~ msgid "Render Material Properties"
-#~ msgstr "Użyj właściwości materiałów podczas renderowania"
-
-#~ msgid "Background Top Color"
-#~ msgstr "Kolor górnej części tła"
-
-#~ msgid "Background Bottom Color"
-#~ msgstr "Kolor dolnej części tła"
-
-#~ msgid "Silkscreen Color"
-#~ msgstr "Kolor warstwy opisowej"
-
-#~ msgid "Copper/Surface Finish Color"
-#~ msgstr "Kolor wykończenia miedzi/powierzchni"
-
-#~ msgid "Show Copper &Thickness"
-#~ msgstr "Pokazuj grubość miedzi"
-
-#~ msgid "Show &Comments and Drawing Layers"
-#~ msgstr "Pokaż warstwę rysunków i komentarzy"
-
-#~ msgid "Show All"
-#~ msgstr "Pokazuj wszystkie"
-
-#~ msgid "Show None"
-#~ msgstr "Nie pokazuj żadnej"
-
-#~ msgid "Create a logo file"
-#~ msgstr "Utwórz plik grafiki dla tabliczki tytułowej"
-
-#~ msgid "File '%s' could not be created."
-#~ msgstr "Plik '%s' nie może zostać utworzony."
-
-#~ msgid "Create a Postscript file"
-#~ msgstr "Utwórz plik Postscipt"
-
-#~ msgid "Create a component library file for Eeschema"
-#~ msgstr "Utwórz bibliotekę symboli dla Eeschema"
-
-#~ msgid "Create a footprint file for Pcbnew"
-#~ msgstr "Utwórz plik footprintu dla Pcbnew"
-
-#~ msgid "Threshold Value:"
-#~ msgstr "Poziom odcięcia:"
-
-#~ msgid "User Layer Eco2"
-#~ msgstr "Warstwa użytkownika ECO2"
-
-#~ msgid "User Grid"
-#~ msgstr "Siatka użytkownika"
-
-#~ msgid ""
-#~ "Html or pdf help file \n"
-#~ "'%s'\n"
-#~ " or\n"
-#~ "'%s' could not be found."
-#~ msgstr ""
-#~ "Plik pomocy \n"
-#~ "'%s'\n"
-#~ "ani\n"
-#~ "'%s' nie może zostać odnaleziony."
-
-#~ msgid "Help file '%s' could not be found."
-#~ msgstr "Nie można odnaleźć pliku pomocy '%s'."
-
-#~ msgid "Executable file (%s)|%s"
-#~ msgstr "Plik wykonywalny (%s)|%s"
-
-#~ msgid "Copy &Version Information"
-#~ msgstr "Kopiuj informacje o &wersji"
-
-#~ msgid "Copy the version string to clipboard to send with bug reports"
-#~ msgstr ""
-#~ "Skopiuj informację o wersji do schowka by wysłać ją razem z raportem "
-#~ "błędów"
-
-#~ msgid "Version Information (copied to the clipboard)"
-#~ msgstr "Informacje o wersji (kopiowane do schowka)"
-
-#~ msgid "You do not have write permissions to folder <%s>."
-#~ msgstr "Nie masz uprawnień zapisu do folderu <%s>."
-
-#~ msgid "You do not have write permissions to save file <%s> to folder <%s>."
-#~ msgstr "Nie masz uprawnień zapisu do pliku <%s> w folderze <%s>."
-
-#~ msgid "You do not have write permissions to save file <%s>."
-#~ msgstr "Nie masz uprawnień zapisu do pliku <%s>."
-
-#~ msgid ""
-#~ "Well this is potentially embarrassing!\n"
-#~ "It appears that the last time you were editing the file\n"
-#~ "'%s'\n"
-#~ "it was not saved properly.  Do you wish to restore the last saved edits "
-#~ "you made?"
-#~ msgstr ""
-#~ "Uuups!\n"
-#~ "Wygląda na to, że podczas ostatniej modyfikacji PCB\n"
-#~ "plik '%s'\n"
-#~ "nie został zapisany poprawnie. Czy chcesz by przywrócono ostatnie edycje "
-#~ "jakie wykonano?"
-
-#~ msgid "Could not create backup file <%s>"
-#~ msgstr "Nie mogę utworzyć pliku kopii zapasowej <%s>"
-
-#~ msgid "Block Save"
-#~ msgstr "Zapisz blok"
-
-#~ msgid "Win Zoom"
-#~ msgstr "Powiększ okno"
-
-#~ msgid "Cannot make path '%s' absolute with respect to '%s'."
-#~ msgstr "Nie mogę utworzyć względnej ścieżki '%s' w stosunku do '%s'."
-
-#~ msgid "Output directory '%s' created.\n"
-#~ msgstr "Folder wyjściowy '%s' został utworzony.\n"
-
-#~ msgid "Cannot create output directory '%s'.\n"
-#~ msgstr "Nie można utworzyć folderu wyjściowego '%s'.\n"
-
-#~ msgid ""
-#~ "The KiCad EDA Suite is a set of open source applications for the creation "
-#~ "of electronic schematics and to design printed circuit boards."
-#~ msgstr ""
-#~ "KiCad EDA Suite jest zespłem aplikacji o otwartym kodzie, służącym do "
-#~ "tworzenia schematów elektronicznych i projektowania płytek drukowanych."
-
-#~ msgid "The original site of the KiCad project founder"
-#~ msgstr "Witryna założyciela projektu KiCad"
-
-#~ msgid "Repository with additional component libraries"
-#~ msgstr "Repozytorium dodatkowych bibliotek symboli"
-
-#~ msgid "Contribute to KiCad"
-#~ msgstr "Skomentuj KiCad-a"
-
-#~ msgid "Report bugs if you found any"
-#~ msgstr "Raportuj znalezione błędy"
-
-#~ msgid "File an idea for improvement"
-#~ msgstr "Zaproponuj unowocześnienie"
-
-#~ msgid "KiCad links to user groups, tutorials and much more"
-#~ msgstr "Odnośniki do grup użytkowników, samouczków i innych"
-
-#~ msgid "Invalid Input"
-#~ msgstr "Błąd wprowadzania"
-
-#~ msgid ""
-#~ "The first character of an environment variable name cannot be a digit "
-#~ "(0-9)."
-#~ msgstr ""
-#~ "Pierwszym znakiem w nazwie zmiennej środowiskowej nie może być liczba "
-#~ "(0-9)."
-
-#~ msgid "Cannot have duplicate environment variable names."
-#~ msgstr "Nie może być dwóch takich samych nazw zmiennych środowiskowych."
-
-#~ msgid ""
-#~ "Enter the name and path for each environment variable.  Grey entries are "
-#~ "names that have been defined externally at the system or user level.  "
-#~ "Environment variables defined at the system or user level take precedence "
-#~ "over the ones defined in this table.  This means the values in this table "
-#~ "are ignored."
-#~ msgstr ""
-#~ "Wpisz nazwę oraz ścieżkę dla każdej zmiennej środowiskowej. Elementy na "
-#~ "szarym tle są nazwami, które zostały już zdefiniowane zewnętrznie w "
-#~ "systemie lub przez użytkownika. Zmienne środowiskowe zdefiniowane w "
-#~ "systemie lub przez użytkownika maja pierwszeństwo przed zmiennymi "
-#~ "zdefiniowanymi w tej tabeli. Wartości nadane w tabeli zostaną zatem "
-#~ "zignorowane."
-
-#~ msgid ""
-#~ "<b>KIGITHUB</b> is used by KiCad to define the URL of the repository of "
-#~ "the official KiCad libraries."
-#~ msgstr ""
-#~ "<b>KIGITHUB</b>jest używana przez KiCad do zdefiniowania adresu URL "
-#~ "oficjalnego repozytorium z bibliotekami."
-
-#~ msgid "Add a new entry to the table."
-#~ msgstr "Dodaje nowy wpis do tabeli"
-
-#~ msgid "Remove the selectect entry from the table."
-#~ msgstr "Usuwa wybrany wpis z tabeli"
-
-#~ msgid ""
-#~ "<%s> is already assigned to \"%s\" in section \"%s\". Are you sure you "
-#~ "want to change its assignment?"
-#~ msgstr ""
-#~ "'%s' jest już przypisany do \"%s\" w sekcji \"%s\". Czy jesteś pewien, że "
-#~ "chcesz zmienić to przypisanie?"
-
-#~ msgid "Select a row and press a new key combination to alter the binding."
-#~ msgstr ""
-#~ "Wybierz rząd tabeli i naciśnij nową kombinację klawiszy by zmienić "
-#~ "powiązanie."
-
-#~ msgid "Page layout description file <%s> not found. Abort"
-#~ msgstr ""
-#~ "Plik <%s> z definicją układu strony nie został znaleziony. Przerwano."
-
-#~ msgid "Select Page Layout Descr File"
-#~ msgstr "Wybierz plik definicji układu strony"
-
-#~ msgid "<b>Error: </b></font><font size=2>"
-#~ msgstr "<b>BŁĄD: </b></font><font size=2>"
-
-#~ msgid "<b>Warning: </b></font><font size=2>"
-#~ msgstr "<b>Ostrzeżenie: </b></font><font size=2>"
-
-#~ msgid "<b>Info: </b>"
-#~ msgstr "<b>Informacja: </b>"
-
-#~ msgid "Save report to file"
-#~ msgstr "Zapisuje rapot do pliku"
-
-#~ msgid "Cannot write report to file '%s'."
-#~ msgstr "Nie można zapisać raportu do pliku '%s'."
-
-#~ msgid "Save report to file..."
-#~ msgstr "Zapisz rapot do pliku..."
-
-#~ msgid "Unexpected '%s'"
-#~ msgstr "Niespodziewano się '%s'"
-
-#~ msgid "need a NUMBER for '%s'"
-#~ msgstr "potrzebny NUMER dla '%s'"
-
-#~ msgid "Doc File '%s' not found"
-#~ msgstr "Nie znaleziono pliku dokumentacji '%s'"
-
-#~ msgid "Unknown MIME type for doc file <%s>"
-#~ msgstr "Nieznany typ MIME pliku dokumentacji <%s>"
-
-#~ msgid "Errors were encountered loading footprints"
-#~ msgstr "Wystąpiły błędy podczas ładowania footprintów"
-
-#~ msgid "'%s' is a duplicate footprint library nickName"
-#~ msgstr "'%s' jest duplikatem footprintu biblioteki "
-
-#~ msgid "fp-lib-table files contain no lib with nickname '%s'"
-#~ msgstr "Plik fp-lib-table nie zawiera biblioteki z nazwą sktrótową '%s'"
-
-#~ msgid "Cannot create global library table path '%s'."
-#~ msgstr "Nie można utworzyć globalnej tabeli bibliotek w ścieżce '%s'."
-
-#~ msgid "Illegal character found in FPID string"
-#~ msgstr "Znaleziono niepoprawny znak w ciągu FPID"
-
-#~ msgid "Command <%s> could not found"
-#~ msgstr "Polecenie <%s> nie zostało znalezione"
-
-#~ msgid ""
-#~ "Problem while running the PDF viewer\n"
-#~ "Command is '%s'"
-#~ msgstr ""
-#~ "Wystąpił problem przy uruchamianiu przeglądarki PDF\n"
-#~ "Polecenie to '%s'"
-
-#~ msgid "Unable to find a PDF viewer for <%s>"
-#~ msgstr "Nie mogę znaleźć przeglądarki PDF dla <%s>"
-
-#~ msgid "&List Current Keys"
-#~ msgstr "&Lista bieżących skrótów klawiszowych"
-
-#~ msgid "&Edit Hotkeys"
-#~ msgstr "&Edytuj plik konfiguracji klawiszy skrótów"
-
-#~ msgid "Call the hotkeys editor"
-#~ msgstr "Uruchom edytor skrótów klawiszowych"
-
-#~ msgid "E&xport Hotkeys"
-#~ msgstr "Eksportuj plik konfiguracji klawiszy skrótów"
-
-#~ msgid "Create a hotkey configuration file to export the current hotkeys"
-#~ msgstr ""
-#~ "Utwórz plik konfiguracji klawiszy skrótów by wyeksportować bieżącą "
-#~ "konfigurację klawiszy skrótów"
-
-#~ msgid "&Import Hotkeys"
-#~ msgstr "&Importuj konfigurację skrótów klawiszowych"
-
-#~ msgid "Load an existing hotkey configuration file"
-#~ msgstr "Wczytaj istniejący plik konfiguracji klawiszy skrótów"
-
-#~ msgid "&Hotkeys"
-#~ msgstr "Skróty klawiszowe"
-
-#~ msgid "Hotkeys configuration and preferences"
-#~ msgstr "Konfiguracja i właściwości skrótów klawiszowych"
-
-#~ msgid "The file <%s> was not fully read"
-#~ msgstr "Plik <%s> nie został w pełni odczytany"
-
-#~ msgid "Preferred Editor:"
-#~ msgstr "Preferowany edytor:"
-
-#~ msgid "Language"
-#~ msgstr "Język"
-
-#~ msgid "Select application language (only for testing!)"
-#~ msgstr "Wybierz język aplikacji (tylko do testowania!)"
-
-#~ msgid "Unable to find '%s' template config file."
-#~ msgstr "Nie można odnaleźć pliku szablonu '%s'."
-
-#~ msgid "Cannot create prj file '%s' (Directory not writable)"
-#~ msgstr ""
-#~ "Nie można utworzyć pliku projektu '%s' (Folder jest tylko do odczytu)"
-
-#~ msgid "Unable to open filename '%s' for reading"
-#~ msgstr "Nie mogę otworzyć pliku '%s' do odczytu"
-
-#~ msgid "cannot open or save file '%s'"
-#~ msgstr "nie mogę otworzyć lub zapisać pliku '%s'"
-
-#~ msgid "error writing to file '%s'"
-#~ msgstr "błąd zapisu do pliku '%s'"
-
-#~ msgid "KiCad drawing symbol file (*.sym)|*.sym"
-#~ msgstr "Plik rysunków symboli programu KiCad (*.sym)|*.sym"
-
-#~ msgid "KiCad component library file (*.lib)|*.lib"
-#~ msgstr "Plik bibliotek symboli programu KiCad (*.lib)|*.lib"
-
-#~ msgid "KiCad project files (*.pro)|*.pro"
-#~ msgstr "Pliki projektu programu KiCad (*.pro)|*.pro"
-
-#~ msgid "KiCad schematic files (*.sch)|*.sch"
-#~ msgstr "Pliki schematów programu KiCad (*.sch)|*.sch"
-
-#~ msgid "KiCad netlist files (*.net)|*.net"
-#~ msgstr "Pliki listy sieci programu KiCad (*.net)|*.net"
-
-#~ msgid "Gerber files (*.pho)|*.pho"
-#~ msgstr "Pliki Gerber (*.pho)|*.pho"
-
-#~ msgid "KiCad printed circuit board files (*.brd)|*.brd"
-#~ msgstr "Pliki PCB programu KiCad (*.brd)|*.brd"
-
-#~ msgid "Eagle ver. 6.x XML PCB files (*.brd)|*.brd"
-#~ msgstr "Pliki PCB programu Eagle v6.x XML (*.brd)|*.brd"
-
-#~ msgid "P-Cad 200x ASCII PCB files (*.pcb)|*.pcb"
-#~ msgstr "Pliki ASCII PCB programu P-Cad 200x (*.pcb)|*.pcb"
-
-#~ msgid "KiCad s-expr printed circuit board files (*.kicad_pcb)|*.kicad_pcb"
-#~ msgstr "Pliki PCB S-expression (*.kicad_pcb)|*.kicad_pcb"
-
-#~ msgid "KiCad footprint s-expre file (*.kicad_mod)|*.kicad_mod"
-#~ msgstr "Pliki footprintów S-expression (*.kicad_mod)|*.kicad_mod"
-
-#~ msgid "KiCad footprint s-expre library path (*.pretty)|*.pretty"
-#~ msgstr ""
-#~ "Ścieżka bibliotek footprintów S-expression programu KiCad (*.pretty)|*."
-#~ "pretty"
-
-#~ msgid "Legacy footprint library file (*.mod)|*.mod"
-#~ msgstr "Starsze pliki bibliotek footprintów programu KiCad (*.mod)|*.mod"
-
-#~ msgid "Eagle ver. 6.x XML library files (*.lbr)|*.lbr"
-#~ msgstr "Pliki bibliotek programu Eagle v6.x XML (*.lbr)|*.lbr"
-
-#~ msgid "Geda PCB footprint library file (*.fp)|*.fp"
-#~ msgstr "Plik bibliotek footprintów programu Geda PCB (*.fb)|*.fb"
-
-#~ msgid "KiCad recorded macros (*.mcr)|*.mcr"
-#~ msgstr "Pliki nagrań makr programu KiCad (*.mcr)|*.mcr"
-
-#~ msgid "Component-footprint link file (*.cmp)|*cmp"
-#~ msgstr "Pliki łącz komponent-footprint (*.cmp)|*.cmp"
-
-#~ msgid "Page layout descr file (*.kicad_wks)|*kicad_wks"
-#~ msgstr "Pliki układu strony (*.kicad_wks)|*.kicad_wks"
-
-#~ msgid "KiCad cmp/footprint link files (*.cmp)|*.cmp"
-#~ msgstr "Pliki łącznikowe komponent-footprint programu KiCad (*.cmp)|*.cmp"
-
-#~ msgid "Drill files (*.drl)|*.drl;*.DRL"
-#~ msgstr "Pliki wierceń (*.drl)|*.drl;*.DRL"
-
-#~ msgid "SVG files (*.svg)|*.svg;*.SVG"
-#~ msgstr "Pliki SVG (*.svg)|*.svg;*.SVG"
-
-#~ msgid "HTML files (*.html)|*.htm;*.html"
-#~ msgstr "Pliki HTML (*.html)|*.htm;*.html"
-
-#~ msgid "Portable document format files (*.pdf)|*.pdf"
-#~ msgstr "Pliki PDF (*.pdf)|*.pdf"
-
-#~ msgid "PostScript files (.ps)|*.ps"
-#~ msgstr "Pliki PostScript (.ps)|*.ps"
-
-#~ msgid "Report files (*.rpt)|*.rpt"
-#~ msgstr "Pliki raportów (*.rpt)|*.rpt"
-
-#~ msgid "Footprint place files (*.pos)|*.pos"
-#~ msgstr "Pliki położeń footprintów (*.pos)|*.pos"
-
-#~ msgid "Vrml and x3d files (*.wrl *.x3d)|*.wrl;*.x3d"
-#~ msgstr "Pliki VRML i X3D (*.wrl *.x3d)|*.wrl;*.x3d"
-
-#~ msgid "IDFv3 component files (*.idf)|*.idf"
-#~ msgstr "Pliki komponenetów IDFv3 (*.idf)|*.idf"
-
-#~ msgid "Text files (*.txt)|*.txt"
-#~ msgstr "Pliki tekstowe (*.txt)|*.txt"
-
-#~ msgid "default "
-#~ msgstr "domyślny "
-
-#~ msgid "Zoom select"
-#~ msgstr "Wybór powiększenia"
-
-#~ msgid ""
-#~ "Equivalence file '%s' could not be found in the default search paths."
-#~ msgstr ""
-#~ "Plik automatycznego przypisania '%s' nie może zostać odnaleziony w "
-#~ "domyślnych ścieżkach przeszukiwań."
-
-#~ msgid "Error opening equivalence file '%s'."
-#~ msgstr "Wystąpił błąd podczas otwierania pliku '%s'."
-
-#~ msgid "Project file: '%s'"
-#~ msgstr "Plik projektu: '%s'"
-
-#~ msgid "Project file '%s' is not writable"
-#~ msgstr "Plik projektu '%s' jest oznaczony jako 'Tylko do odczytu'"
-
-#~ msgid "Units in inches"
-#~ msgstr "Jednostki w calach"
-
-#~ msgid "Units in millimeters"
-#~ msgstr "Jednostki w milimetrach"
-
-#~ msgid "Footprint '%s' not found"
-#~ msgstr "Footprintu '%s' nie znaleziono"
-
-#~ msgid ""
-#~ "Error occurred saving the global footprint library table:\n"
-#~ "'%s'\n"
-#~ "%s"
-#~ msgstr ""
-#~ "Wystąpił błąd przy próbie zapisu globlalnej tablicy bibliotek "
-#~ "footprintów:\n"
-#~ "'%s'\n"
-#~ "%s"
-
-#~ msgid "Project: '%s'"
-#~ msgstr "Projekt: '%s'"
-
-#~ msgid "[no project]"
-#~ msgstr "[brak projektu]"
-
-#~ msgid "Component/footprint equ files (*.equ)|*.equ"
-#~ msgstr "Pliki aut. przypisań footprintów (*.equ)|*.equ"
-
-#~ msgid ""
-#~ "You have run CvPcb for the first time using the new footprint library "
-#~ "table method for finding footprints.  CvPcb has either copied the default "
-#~ "table or created an empty table in your home folder.  You must first "
-#~ "configure the library table to include all footprint libraries not "
-#~ "included with KiCad.  See the \"Footprint Library Table\" section of the "
-#~ "CvPcb documentation for more information."
-#~ msgstr ""
-#~ "CvPcb został uruchomiony pierwszy raz z użyciem nowej metody wyszukiwania "
-#~ "fooptrintów w Tabeli Bibliotek. CvPcb skopiuje teraz domyślną tabelę bądź "
-#~ "utworzy pustą tabele w katalogu domowym użytkownika. Konfigurację tabeli "
-#~ "bibliotek należy uzupełnić o pozostałe biblioteki footprintów nie będące "
-#~ "składnikami programu. Zobacz rozdział \"Tabele bibliotek\" w dokumentacji "
-#~ "programu CvPcb by uzyskać więcej informacji."
-
-#~ msgid ""
-#~ "An error occurred attempting to load the global footprint library table:\n"
-#~ "\n"
-#~ "%s"
-#~ msgstr ""
-#~ "Wystąpił błąd przy próbie załadowania globlalnej tablicy bibliotek "
-#~ "footprintów:\n"
-#~ "\n"
-#~ "%s"
-
-#~ msgid "No editor defined in Kicad. Please chose it"
-#~ msgstr "Edytor tekstu nie został zdefiniowany. Proszę go wybrać."
-
-#~ msgid "Equ files:"
-#~ msgstr "Pliki aut. przypisań:"
-
-#~ msgid "File '%s' already exists in list"
-#~ msgstr "Plik '%s' już istnieje na liście"
-
-#~ msgid "Footprint/Component equ files (.equ files)"
-#~ msgstr "Pliki aut. przypisań Footprint/Komponent (pliki .equ)"
-
-#~ msgid "Unload the selected library"
-#~ msgstr "Usuń wybraną bibliotekę z pamięci"
-
-#~ msgid "Edit Equ File"
-#~ msgstr "Edytuj plik .equ"
-
-#~ msgid "Absolute path"
-#~ msgstr "Ścieżka bezwzględna"
-
-#~ msgid "Relative path"
-#~ msgstr "Ścieżka względna"
-
-#~ msgid "Path option:"
-#~ msgstr "Opcje ścieżek:"
-
-#~ msgid "Draw options"
-#~ msgstr "Opcje rysowania"
-
-#~ msgid "Do not center and warp cusor on zoom"
-#~ msgstr "Nie centruj i nie przesuwaj kursora przy powiększaniu"
-
-#~ msgid "Use middle mouse button to pan"
-#~ msgstr "Użyj środkowego klawisza myszy do przesuwania widoku"
-
-#~ msgid "Limit panning to scroll size"
-#~ msgstr "Panoramuj tylko do obszaru dającego się przesuwać"
-
-#~ msgid "&Save Edits\tCtrl+S"
-#~ msgstr "Zapisz wykonane edycje\tCtrl+S"
-
-#~ msgid "Configure footprint libraries"
-#~ msgstr "Konfiguruje listę bibliotek footprintów"
-
-#~ msgid "Configure Pa&ths"
-#~ msgstr "Konfiguracja ścieżek dostępu"
-
-#~ msgid "Edit &Equ Files List"
-#~ msgstr "Edytuj listę plików .equ"
-
-#~ msgid ""
-#~ "Setup equ files list (.equ files)\n"
-#~ "They are files which give the footprint name from the component value"
-#~ msgstr ""
-#~ "Ustawienia listy plików aut. przypisań (pliki .equ)\n"
-#~ "Są to pliki zawierające dane o wartości elementów i powiązane z nią "
-#~ "odpowiednie footprinty"
-
-#~ msgid "Save changes to the project configuration file"
-#~ msgstr "Zapisuje zmiany w pliku konfiguracji projektu"
-
-#~ msgid ""
-#~ "Some of the assigned footprints are legacy entries (are missing lib "
-#~ "nicknames). Would you like CvPcb to attempt to convert them to the new "
-#~ "required FPID format? (If you answer no, then these assignments will be "
-#~ "cleared out and you will have to re-assign these footprints yourself.)"
-#~ msgstr ""
-#~ "Niektóre z przypisanych footprintów to odnośniki do bibliotek Legacy (nie "
-#~ "posiadają nazw skrótowych). Czy chcesz by CvPcb próbował skonwertować te "
-#~ "wpisy do nowego formatu FPID? (Jeśli pominiesz ten krok, wadliwe "
-#~ "przypisania zostaną usunięte i trzeba będzie je wykonać na nowo.)"
-
-#~ msgid "Component '%s' footprint '%s' was <b>not found</b> in any library.\n"
-#~ msgstr ""
-#~ "Komponent '%s' footprint '%s' <b>nie został znaleziony</b> w żadnej z "
-#~ "bibliotek.\n"
-
-#~ msgid ""
-#~ "Component '%s' footprint '%s' was found in <b>multiple</b> libraries.\n"
-#~ msgstr ""
-#~ "Komponent '%s' footprint '%s' został znaleziony w <b>więcej niż jednej</"
-#~ "b> bibliotece.\n"
-
-#~ msgid "Edits sent to Eeschema"
-#~ msgstr "Edycje wysłane do Eeschema"
-
-#~ msgid "Select previous unlinked component"
-#~ msgstr "Wybierz poprzedni wolny komponent "
-
-#~ msgid "Select next unlinked component"
-#~ msgstr "Wybierz następny wolny komponent "
-
-#~ msgid "Delete all associations (links)"
-#~ msgstr "Usuń wszystkie skojarzenia (łącza)"
-
-#~ msgid "Display footprint documentation"
-#~ msgstr "Pokaż dokumentację footprintu"
-
-#~ msgid "Filter footprint list by keywords"
-#~ msgstr ""
-#~ "Filtruj listę footprintów dla bieżącego komponentu według słów kluczowych"
-
-#~ msgid "Load Component Footprint Link File"
-#~ msgstr "Otwórz plik łącz komponentów z footprintami"
-
-#~ msgid "Failed to open component-footprint link file '%s'"
-#~ msgstr "Nie udało się otworzyć pliku łącz symboli i footprintów '%s'"
-
-#~ msgid ""
-#~ "The sheet changes cannot be made because the destination sheet already "
-#~ "has the sheet <%s> or one of it's subsheets as a parent somewhere in the "
-#~ "schematic hierarchy."
-#~ msgstr ""
-#~ "Zmiany w arkuszach nie mogą zostać wykonane, poniewać docelowy arkusz "
-#~ "posiada obecnie arkusz <%s> lub jeden z jego arkuszy stanowi nadrzędny "
-#~ "arkusz wewnątrz całej hierarchii."
-
-#~ msgid ""
-#~ "Library '%s' has duplicate entry name '%s'.\n"
-#~ "This may cause some unexpected behavior when loading components into a "
-#~ "schematic."
-#~ msgstr ""
-#~ "Biblioteka '%s' posiada zdublowany wpis '%s'.\n"
-#~ "Może to spowodować niespodziewane efekty przy ładowaniu symboli do "
-#~ "schematu."
-
-#~ msgid "Cannot add duplicate alias '%s' to library '%s'."
-#~ msgstr "Nie można dodać zdublowanego aliasu '%s' do biblioteki '%s'."
-
-#~ msgid "The component library file name is not set."
-#~ msgstr "Nazwa pliku biblioteki nie została ustalona."
-
-#~ msgid "The file could not be opened."
-#~ msgstr "Ten plik nie może zostac otwarty."
-
-#~ msgid "The file is empty!"
-#~ msgstr "Plik jest pusty!"
-
-#~ msgid "The file is NOT an Eeschema library!"
-#~ msgstr "Plik NIE jest biblioteką programu Eeschema!"
-
-#~ msgid "The file header is missing version and time stamp information."
-#~ msgstr "Nagłówek pliku nie posiada numeru wersji i odcisku czasowego."
-
-#~ msgid "An error occurred attempting to read the header."
-#~ msgstr "Wystąpił błąd podczas próby odczytu nagłówka."
-
-#~ msgid "Library '%s' component load error %s."
-#~ msgstr "Biblioteka '%s'. Błąd ładowania symbolu %s."
-
-#~ msgid "Could not open component document library file '%s'."
-#~ msgstr "Nie można otworzyc pliku dokumentacji biblioteki '%s'."
-
-#~ msgid "Part document library file '%s' is empty."
-#~ msgstr "Plik dokumentacji biblioteki '%s' jest pusty."
-
-#~ msgid "File '%s' is not a valid component library document file."
-#~ msgstr "Plik '%s' nie jest poprawnym plikiem dokumentacji biblioteki."
-
-#~ msgid "Unable to load project's '%s' file"
-#~ msgstr "Nie mogę załadować pliku '%s' należącego do projektu"
-
-#~ msgid ""
-#~ "Part library '%s' failed to load. Error:\n"
-#~ "%s"
-#~ msgstr ""
-#~ "Biblioteka symboli '%s' nie może zostać załadowana. Błąd:\n"
-#~ "%s"
-
-#~ msgid ""
-#~ "Part library '%s' failed to load.\n"
-#~ "Error: %s"
-#~ msgstr ""
-#~ "Biblioteka symboli '%s' nie może zostać załadowana.\n"
-#~ "Błąd: %s"
-
-#~ msgid "Error item %s%s unit %d and no more than %d parts\n"
-#~ msgstr "Błąd Element %s%s część %d nie może mieć więcej niż %d elementów\n"
-
-#~ msgid "Clear and annotate all of the components on the entire schematic?"
-#~ msgstr "Czy wyczyścić i ponumerować wszystkie symbole na całym schemacie?"
-
-#~ msgid "Clear and annotate all of the components on the current sheet?"
-#~ msgstr "Czy wyczyścić i ponumerować wszystkie symbole na bieżącym arkuszu?"
-
-#~ msgid "Annotate only the unannotated components on the entire schematic?"
-#~ msgstr "Czy ponumerować tylko nieponumerowane symbole na całym schemacie?"
-
-#~ msgid "Annotate only the unannotated components on the current sheet?"
-#~ msgstr "Czy ponumerować tylko nieponumerowane symbole na bieżącym arkuszu?"
-
-#~ msgid "Use the &entire schematic"
-#~ msgstr "Użyj całego &schematu"
-
-#~ msgid "Use the current &page only"
-#~ msgstr "Użyj tylko &bieżącej strony"
-
-#~ msgid "&Keep existing annotation"
-#~ msgstr "&Pozostaw bieżącą numerację"
-
-#~ msgid "&Reset existing annotation"
-#~ msgstr "&Resetuj bieżącą numerację"
-
-#~ msgid "R&eset, but do not swap any annotated multi-unit parts"
-#~ msgstr ""
-#~ "Zresetuj, ale nie zamieniaj żadnej z ponumerowanych części elementów "
-#~ "wieloczęściowych"
-
-#~ msgid "Annotation Order"
-#~ msgstr "Porządek numeracji"
-
-#~ msgid "Annotation Choice"
-#~ msgstr "Wybór numeracji"
-
-#~ msgid "Use first free number in schematic"
-#~ msgstr "Użyj pierwszego wolnego numeru na schemacie"
-
-#~ msgid "Start to  sheet number*100 and use first free number"
-#~ msgstr "Rozpocznij od numer arkusza*100 i użyj pierwszego wolnego numeru"
-
-#~ msgid "Start to  sheet number*1000 and use first free number"
-#~ msgstr "Rozpocznij od numer arkusza*1000 i użyj pierwszego wolnego numeru"
-
-#~ msgid "Dialog"
-#~ msgstr "Okno"
-
-#~ msgid "Always ask for confirmation"
-#~ msgstr "Zawsze pytaj"
-
-#~ msgid "Failed to open file '%s'"
-#~ msgstr "Nie można otworzyć pliku '%s'"
-
-#~ msgid "Plugin Info:"
-#~ msgstr "Informacja o wtyczce:"
-
-#~ msgid "Description\n"
-#~ msgstr "Opis\n"
-
-#~ msgid "Keywords\n"
-#~ msgstr "Słowa kluczowe\n"
-
-#~ msgid "Alias <%s> cannot be removed while it is being edited!"
-#~ msgstr "Alias <%s> nie może zostać usunięty podczas edycji"
-
-#~ msgid "New alias:"
-#~ msgstr "Nowy alias:"
-
-#~ msgid "Component Alias"
-#~ msgstr "Aliasy symbolu"
-
-#~ msgid "Alias or component name <%s> already in use."
-#~ msgstr "Alias albo nazwa symbolu <%s> jest już używana."
-
-#~ msgid "Alias or component name <%s> already exists in library <%s>."
-#~ msgstr "Alias albo nazwa symbolu <%s> już istnieje w bibliotece <%s>"
-
-#~ msgid ""
-#~ "Check this option if the component has an alternate body style (De Morgan)"
-#~ msgstr ""
-#~ "Zaznacz tą opcję gdy symbol posiada alternatywny styl symbolu (DeMorgan)."
-
-#~ msgid ""
-#~ "Enter the number of units for a component that contains more than one unit"
-#~ msgstr ""
-#~ "Wpisz liczbę części dla elementów posiadających więcej niż jedną część "
-#~ "składową"
-
-#~ msgid "Check this option when the component is a power symbol"
-#~ msgstr "Zaznacz tą opcję gdy symbol jest symbolem zasilania"
-
-#~ msgid ""
-#~ "Check this option when creating multiple unit components and all units "
-#~ "are not interchangeable"
-#~ msgstr ""
-#~ "Zaznacz tą opcję gdy tworzony symbol posiada wiele części składowych i "
-#~ "nie mogą one być zamieniane między sobą"
-
-#~ msgid ""
-#~ "Enter key words that can be used to select this component.\n"
-#~ "Key words cannot have spaces and are separated by a space."
-#~ msgstr ""
-#~ "Wpisz słowa kluczowe, które mogą być użyte do zaznaczenia tego symbolu.\n"
-#~ "Słowa kluczowe nie mogą posiadać spacji gdyż są oddzielane tym znakiem."
-
-#~ msgid ""
-#~ "Enter the documentation file (a .pdf document) associated to the "
-#~ "component."
-#~ msgstr ""
-#~ "Wpisz nazwę (lub ścieżkę URL) pliku z dokumentacją (np. dokument PDF) "
-#~ "przypisaną do tego symbolu."
-
-#~ msgid ""
-#~ "An alias is a component that uses the body of its root component.\n"
-#~ "It has its own documentation and keywords.\n"
-#~ "A fast way to extend a library with similar components"
-#~ msgstr ""
-#~ "Alias jest symbolem używającym postać graficzną innych symboli do których "
-#~ "się odnosi.\n"
-#~ "Posiada własną dokumentację i słowa kluczowe.\n"
-#~ "Jest to szybki sposób na rozszerzenie bibliotek na podstwie podobnych "
-#~ "symboli"
-
-#~ msgid ""
-#~ "A list of footprints names that can be used for this component.\n"
-#~ "Footprints names can used jockers.\n"
-#~ "(like sm* to allow all footprints names starting by sm)."
-#~ msgstr ""
-#~ "Lista nazw footprintów, które mogą być użytych dla tego komponentu.\n"
-#~ "Jako nazwy footprintu można użyć masek.\n"
-#~ "(Przykładowo \"sm*\" pozwala użyć footprintów, których nazwy zaczynają "
-#~ "się na \"sm\")."
-
-#~ msgid "Component '%s' found in library '%s'"
-#~ msgstr "Symbol '%s' został znaleziony w bibliotece '%s'"
-
-#~ msgid "Component '%s' not found in any library"
-#~ msgstr "Symbol '%s' nie został znaleziony w żadnej z biliotek"
-
-#~ msgid "However, some candidates are found:"
-#~ msgstr "Znaleziono jednak podobne symbole:"
-
-#~ msgid "'%s' found in library '%s'"
-#~ msgstr "'%s' został znaleziony w bibliotece '%s'"
-
-#~ msgid "No Component Name!"
-#~ msgstr "Brak nazwy symbolu!"
-
-#~ msgid "Component '%s' not found!"
-#~ msgstr "Symbol '%s' nie został znaleziony!"
-
-#~ msgid ""
-#~ "The field name <%s> does not have a value and is not defined in the field "
-#~ "template list.  Empty field values are invalid an will be removed from "
-#~ "the component.  Do you wish to remove this and all remaining undefined "
-#~ "fields?"
-#~ msgstr ""
-#~ "Pole o nazwie <%s> nie posiada wartości i nie jest ona zdefiniowana na "
-#~ "liście wzorców pól. Puste pola nie są poprawne i zostaną usunięte z "
-#~ "symbolu.\n"
-#~ "Czy chcesz usunąć te pola łącznie z pozostałymi polami niezdefiniowanymi?"
-
-#~ msgid "Assign Footprint"
-#~ msgstr "Przypisz footprint"
-
-#~ msgid "Units are interchangeable:"
-#~ msgstr "Części składowe są zamienne:"
-
-#~ msgid "Orientation (Degrees)"
-#~ msgstr "Orientacja (stopnie)"
-
-#~ msgid "Select if the component is to be rotated when drawn"
-#~ msgstr "Zaznacz jeśli symbol będzie obrócony podczas rysowania"
-
-#~ msgid "Mirror ---"
-#~ msgstr "Odbij poziomo ---"
-
-#~ msgid "Mirror |"
-#~ msgstr "Odbij pionowo |"
-
-#~ msgid ""
-#~ "Pick the graphical transformation to be used when displaying the "
-#~ "component, if any"
-#~ msgstr ""
-#~ "Pobierz transformację graficzną wykorzystaną podczas wyświetlania "
-#~ "symbolu, jeśli istnieje"
-
-#~ msgid "Converted Shape"
-#~ msgstr "Skonwertowany"
-
-#~ msgid ""
-#~ "Use the alternate shape of this component.\n"
-#~ "For gates, this is the \"De Morgan\" conversion"
-#~ msgstr ""
-#~ "Użyj anlternatywnego kształtu dla tego symbolu.\n"
-#~ "Dla bramek, jest to konwersja \"De Morgan\""
-
-#~ msgid "The name of the symbol in the library from which this component came"
-#~ msgstr "Nazwa symbolu w bibliotece, z której został on pobrany"
-
-#~ msgid "Test"
-#~ msgstr "Test"
-
-#~ msgid "Reset to Library Defaults"
-#~ msgstr "Resetuj do standardu biblioteki"
-
-#~ msgid ""
-#~ "Set position and style of fields and component orientation  to default "
-#~ "lib value.\n"
-#~ "Fields texts are not modified."
-#~ msgstr ""
-#~ "Ustal położenie i styl pól oraz orientację symboli na wartość domyślną z "
-#~ "biblioteki.\n"
-#~ "Pola tekstowe nie są modyfikowane."
-
-#~ msgid "Add Field"
-#~ msgstr "Dodaj pole"
-
-#~ msgid "Delete Field"
-#~ msgstr "Usuń pole"
-
-#~ msgid "Move the selected optional fields up one position"
-#~ msgstr "Przesuń zaznaczone pola dodatkowe o jedną pozycję w górę"
-
-#~ msgid "The style of the currently selected field's text in the schemati"
-#~ msgstr "Styl aktualnie zaznaczonego na schemacie pola tekstowego"
-
-#~ msgid ""
-#~ "The name of the currently selected field\n"
-#~ "Some fixed fields names are not editable"
-#~ msgstr ""
-#~ "Nazwa aktualnie zaznaczonego pola\n"
-#~ "Niektóre stałe nazwy pól są nieedytowalne"
-
-#~ msgid "The size of the currently selected field's text in the schematic"
-#~ msgstr "Rozmiar pola tekstowego zaznaczonego aktualnie na schemacie"
-
-#~ msgid "PosX"
-#~ msgstr "Poz. X"
-
-#~ msgid "The X coordinate of the text relative to the component"
-#~ msgstr "Pozycja X tekstu relatywnie do symbolu"
-
-#~ msgid "PosY"
-#~ msgstr "Poz. Y"
-
-#~ msgid "The Y coordinate of the text relative to the component"
-#~ msgstr "Pozycja Y tekstu relatywnie do symbolu"
-
-#~ msgid "Illegal reference prefix. A reference must start by a letter"
-#~ msgstr ""
-#~ "Niepoprawny przedrostek oznaczenia. Oznaczenie musi rozpoczynać sie literą"
-
-#~ msgid ""
-#~ "Whitespace is not permitted inside references or values (symbol names in "
-#~ "lib).\n"
-#~ "The text you entered has been converted to use underscores: %s"
-#~ msgstr ""
-#~ "Spacje nie są dozwolone wewnątrz nazw odnośników lub wartości (nazwy "
-#~ "symbolu w bibliotece).\n"
-#~ "Wpisany tekst zostanie zamieniony na tekst ze znakiem dolnej kreski: %s"
-
-#~ msgid "Project '%s'"
-#~ msgstr "Projekt '%s'"
-
-#~ msgid "'%s' : library already in use"
-#~ msgstr "'%s' : biblioteka jest już w użyciu"
-
-#~ msgid "Path type"
-#~ msgstr "Typ ścieżki"
-
-#~ msgid "Path already in use"
-#~ msgstr "Jest już w użyciu"
-
-#~ msgid "Component library files"
-#~ msgstr "Plik bibliotek symboli"
-
-#~ msgid ""
-#~ "List of active library files.\n"
-#~ "Only library files in this list are loaded by Eeschema.\n"
-#~ "The order of this list is important:\n"
-#~ "Eeschema searchs for a given component using this list order priority."
-#~ msgstr ""
-#~ "Lista aktywnych plików bibliotek.\n"
-#~ "Tylko biblioteki umieszczone na tej liście są ładowane przez Eeschema.\n"
-#~ "Kolejność wystąpień na liście jest istotna:\n"
-#~ "Eeshema wyszukuje symbole posługując się kolejnością wpisów."
-
-#~ msgid "Add a new library after the selected library, and load it"
-#~ msgstr "Dodaj nową bibliotekę po zaznaczonej i załaduj ją"
-
-#~ msgid "Add a new library before the selected library, and load it"
-#~ msgstr "Dodaj nową bibliotekę przed zaznaczoną i załaduj ją"
-
-#~ msgid "User defined search path"
-#~ msgstr "Ścieżka przeszukiwań zdefiniowana przez użytkownika"
-
-#~ msgid ""
-#~ "Additional paths used in this project. The priority is higher than "
-#~ "default KiCad paths."
-#~ msgstr ""
-#~ "Dodatkowe ścieżki dostępu używane w tym projekcie. Ich priorytet jest "
-#~ "wyższy niż ścieżek KiCad-a."
-
-#~ msgid "Current search path list"
-#~ msgstr "Bieżąca lista przeglądanych ścieżek"
-
-#~ msgid ""
-#~ "System and user paths used to search and load library files and component "
-#~ "doc files.\n"
-#~ "Sorted by decreasing priority order."
-#~ msgstr ""
-#~ "Ścieżki dostępu (systemowe i użytkownika) używane w wyszukiwaniu i "
-#~ "ładowaniu plików bibliotek oraz plików dokumentacyjnych.\n"
-#~ "Posortowane według coraz niższych priorytetów."
-
-#~ msgid "Check for cache/library conflicts when loading schematic"
-#~ msgstr ""
-#~ "Sprawdza konflikty pomiędzy biblioteką a pamięcią podręczną podczas "
-#~ "ładowania schematu"
-
-#~ msgid "Hidden"
-#~ msgstr "Tekst ukryty"
-
-#~ msgid "&Default bus thickness:"
-#~ msgstr "Domyślna grubość magistral:"
-
-#~ msgid "D&efault line thickness:"
-#~ msgstr "Domyślna grubość linii:"
-
-#~ msgid "De&fault text size:"
-#~ msgstr "Domyślny rozmiar tekstu:"
-
-#~ msgid "Ma&ximum undo items (0 = unlimited):"
-#~ msgstr "Maksymalna głębokość cofania (0 = nielimitowana):"
-
-#~ msgid "actions"
-#~ msgstr "akcje"
-
-#~ msgid "&Part id notation:"
-#~ msgstr "Notacja ID elementów:"
-
-#~ msgid "Sho&w hidden pins"
-#~ msgstr "Pokaż ukryte piny"
-
-#~ msgid "&Use middle mouse button to pan"
-#~ msgstr "Użyj środkowego klawisza myszy do przesuwania widoku"
-
-#~ msgid "Use middle mouse button dragging to pan"
-#~ msgstr "Użyj środkowego klawisza myszy do przesuwania widoku"
-
-#~ msgid "&Limit panning to scroll size"
-#~ msgstr "Panoramuj tylko do obszaru dającego się przesuwać"
-
-#~ msgid "Middle mouse button panning limited by current scrollbar size"
-#~ msgstr ""
-#~ "Przesuwanie widoku za pomocą środkowego klawisza myszy ograniczone przez "
-#~ "bieżący rozmiar suwaków"
-
-#~ msgid "Pan while moving ob&ject"
-#~ msgstr "Panoramuj podczas przesuwania obiektów"
-
-#~ msgid "Field Settings"
-#~ msgstr "Ustawienia pola"
-
-#~ msgid "&Name"
-#~ msgstr "Nazwa"
-
-#~ msgid "D&efault Value"
-#~ msgstr "Domyślna wartość"
-
-#~ msgid "Template Field Names"
-#~ msgstr "Wzorce nazw pól"
-
-#~ msgid "Electronic rule check file (.erc)|*.erc"
-#~ msgstr "Pliki ERC (*.erc)|*.erc"
-
-#~ msgid "&Delete Markers"
-#~ msgstr "Usuń znaczniki"
-
-#~ msgid "&Run"
-#~ msgstr "Uruchom"
-
-#~ msgid "Power component value text cannot be modified!"
-#~ msgstr "Pole Wartość portu zasilania nie może być zmieniane!"
-
-#~ msgid "Component &name:"
-#~ msgstr "&Nazwa symbolu:"
-
-#~ msgid ""
-#~ "This is the component name in library,\n"
-#~ "and also the default component value when loaded in the schematic."
-#~ msgstr ""
-#~ "Jest to nazwa symbolu w bibliotece,\n"
-#~ "a zarazem wartość domyślna przy ładowaniu go do schematu."
-
-#~ msgid "Create component with alternate body style (DeMorgan)"
-#~ msgstr "Twórz symbol z alternatywnym stylem DeMorgan."
-
-#~ msgid "Create component as power symbol"
-#~ msgstr "Utwórz symbol jako symbol zasilania"
-
-#~ msgid "Prefix references 'U' and 'IC' with 'X'"
-#~ msgstr "Przedrostek odnośnika 'U' i 'IC' z 'X'"
-
-#~ msgid "Use net number as net name"
-#~ msgstr "Użyj numeru sieci jako nazwa sieci"
-
-#~ msgid "SPICE netlist file (.cir)|*.cir"
-#~ msgstr "Lista sieci programu SPICE (.cir)|*cir"
-
-#~ msgid "CadStar netlist file (.frp)|*.frp"
-#~ msgstr "Lista sieci programu CadStar (.frp)|*.frp"
-
-#~ msgid ""
-#~ "Do you want to use a path relative to\n"
-#~ "'%s'"
-#~ msgstr ""
-#~ "Użyć ścieżki względnej w stosunku do\n"
-#~ "'%s'?"
-
-#~ msgid "Could not write plot files to folder '%s'."
-#~ msgstr "Nie mogę zapisać plików z rysunkami w folderze '%s'."
-
-#~ msgid "Force size A4"
-#~ msgstr "Wymuś rozmiar A4"
-
-#~ msgid "Force size A"
-#~ msgstr "Wymuś rozmiar A"
-
-#~ msgid "Page size A4"
-#~ msgstr "Rozmiar strony A4"
-
-#~ msgid "Page size A3"
-#~ msgstr "Rozmiar strony A3"
-
-#~ msgid "Page size A2"
-#~ msgstr "Rozmiar stront A2"
-
-#~ msgid "Page size A1"
-#~ msgstr "Rozmiar strony A1"
-
-#~ msgid "Page size A0"
-#~ msgstr "Rozmiar strony A0"
-
-#~ msgid "Page size A"
-#~ msgstr "Rozmiar strony A"
-
-#~ msgid "Page size B"
-#~ msgstr "Rozmiar strony B"
-
-#~ msgid "Page size C"
-#~ msgstr "Rozmiar strony C"
-
-#~ msgid "Page size D"
-#~ msgstr "Rozmiar strony D"
-
-#~ msgid "Page size E"
-#~ msgstr "Rozmiar strony E"
-
-#~ msgid "Bottom left corner"
-#~ msgstr "Dolny lewy narożnik"
-
-#~ msgid "Center of the page"
-#~ msgstr "Na środku strony"
-
-#~ msgid "Pen width"
-#~ msgstr "Grubość pisaka"
-
-#~ msgid "Default line thickness"
-#~ msgstr "Domyślna grubość linii"
-
-#~ msgid ""
-#~ "It looks like this project was made using older schematic component "
-#~ "libraries.\n"
-#~ "Some parts may need to be relinked to a different symbol name, and some "
-#~ "symbols\n"
-#~ "may need to be \"rescued\" (cloned and renamed) into a new library.\n"
-#~ "\n"
-#~ "The following changes are recommended to update the project."
-#~ msgstr ""
-#~ "Wygląda na to, że projekt został utworzony z użyciem starszych bibliotek "
-#~ "symboli.\n"
-#~ "Niektóre z symboli mogą wymagać odświeżenia, a niektóre z nich należy "
-#~ "odzyskać\n"
-#~ "tworząc dla nich nową bibliotekę z ich kopiami.\n"
-#~ "\n"
-#~ "Zalecane jest wykonanie poniższych zmian by uaktualnić projekt."
-
-#~ msgid "Action"
-#~ msgstr "Akcja"
-
-#~ msgid ""
-#~ "Stop showing this tool?\n"
-#~ "No changes will be made.\n"
-#~ "\n"
-#~ "This setting can be changed from the \"Component Libraries\" dialog,\n"
-#~ "and the tool can be activated manually from the \"Tools\" menu."
-#~ msgstr ""
-#~ "Czy chcesz by to narzędzie nie ukazywało się ponownie?\n"
-#~ "Żadne zmiany nie zostały wprowadzone.\n"
-#~ "\n"
-#~ "To ustawienie może zostać zmienione z okna dialogowego \"Biblioteki "
-#~ "symboli\".\n"
-#~ "Narzędzie może zostać wywołane ponownie za pomocą menu \"Narzędzia\"."
-
-#~ msgid "Rescue Components"
-#~ msgstr "Odzyskaj komponenty"
-
-#~ msgid "Cached Part:"
-#~ msgstr "Część w pamięci podręcznej:"
-
-#~ msgid "Library Part:"
-#~ msgstr "Ścieżka bibliotek:"
-
-#~ msgid "Search the current &sheet onl&y"
-#~ msgstr "Prze&szukaj tylko bieżący arkusz"
-
-#~ msgid "Couldn't load image from <%s>"
-#~ msgstr "Nie mogę załadować obrazu z <%s>"
-
-#~ msgid "Illegal reference string!  No change"
-#~ msgstr "Pole oznaczenie nie jest poprawne! Bez zmian"
-
-#~ msgid "The reference field cannot be empty!  No change"
-#~ msgstr "Pole oznaczenie nie może być puste! Bez zmian"
-
-#~ msgid "The value field cannot be empty!  No change"
-#~ msgstr "Pole wartość nie może być puste! Bez zmian"
-
-#~ msgid "Could not save backup of file '%s'"
-#~ msgstr "Nie mogę zapisać kopii zapasowej pliku '%s'"
-
-#~ msgid "Failed to create file '%s'"
-#~ msgstr "Błąd przy tworzeniu pliku '%s'"
-
-#~ msgid "Schematic file '%s' is already open."
-#~ msgstr "Plik schematu '%s' jest już otwarty."
-
-#~ msgid "Schematic '%s' does not exist.  Do you wish to create it?"
-#~ msgstr "Plik schematu '%s' nie istnieje. Czy chcesz go utworzyć?"
-
-#~ msgid ""
-#~ "Ready\n"
-#~ "Project dir: '%s'\n"
-#~ msgstr ""
-#~ "Gotowy\n"
-#~ "Folder roboczy: '%s'\n"
-
-#~ msgid ""
-#~ "This operation cannot be undone. Besides, take into account that "
-#~ "hierarchical sheets will not be appended.\n"
-#~ "\n"
-#~ "Do you want to save the current document before proceeding?"
-#~ msgstr ""
-#~ "Ta operacja nie może zostać cofnięta. Należy również mieć na uwadze, że "
-#~ "arkusze hierarchiczne nie zostaną dołączone.\n"
-#~ "\n"
-#~ "Czy chcesz zapisać bieżący schemat przed łączeniem?"
-
-#~ msgid "Directory '%s' is not writable"
-#~ msgstr "Folder '%s' jest oznaczony jako 'Tylko do odczytu'"
-
-#~ msgid "field"
-#~ msgstr "pole"
-
-#~ msgid "Choose Component (%d items loaded)"
-#~ msgstr "Wybór symbolu (wczytano %d elementów)"
-
-#~ msgid "Add Component"
-#~ msgstr "Dodaj symbol"
-
-#~ msgid "Edit Component Value"
-#~ msgstr "Edytuj wartość"
-
-#~ msgid "Edit Component Reference"
-#~ msgstr "Edytuj odnośnik"
-
-#~ msgid "Edit Component Footprint"
-#~ msgstr "Edytuj footprint"
-
-#~ msgid "Edit with Component Editor"
-#~ msgstr "Edytuj za pomocą edytora"
-
-#~ msgid "Copy Component or Label"
-#~ msgstr "Kopiuj komponent lub etykietę"
-
-#~ msgid "Save Block"
-#~ msgstr "Zapisz blok"
-
-#~ msgid "Save Library"
-#~ msgstr "Zapisz bibliotekę"
-
-#~ msgid "Load Schematic"
-#~ msgstr "Załaduj schemat"
-
-#~ msgid "Arc only had %d parameters of the required 8"
-#~ msgstr "Łuk posiada tylko %d parametrów z wymaganych 8"
-
-#~ msgid "Bezier only had %d parameters of the required 4"
-#~ msgstr "Krzywa Beziera posiada tylko %d parametrów z wymaganych 4"
-
-#~ msgid "Bezier count parameter %d is invalid"
-#~ msgstr "%d parametrów krzywej Beziera jest niepoprawnych"
-
-#~ msgid "Bezier point %d X position not defined"
-#~ msgstr "Pozycja punktu X krzywej Beziera %d nie jest ustalona"
-
-#~ msgid "Bezier point %d Y position not defined"
-#~ msgstr "Pozycja punktu Y krzywej Beziera %d nie jest ustalona"
-
-#~ msgid "Circle only had %d parameters of the required 6"
-#~ msgstr "Okrąg posiada tylko %d parematrów z wymaganych 6"
-
-#~ msgid "Undefined"
-#~ msgstr "Nieokreślony"
-
-#~ msgid "Import Component"
-#~ msgstr "Importuj symbol"
-
-#~ msgid ""
-#~ "Unable to import library '%s'.  Error:\n"
-#~ "%s"
-#~ msgstr ""
-#~ "Biblioteka symboli '%s' nie może zostać zaimportowana. Błąd:\n"
-#~ "%s"
-
-#~ msgid "Part library file '%s' is empty."
-#~ msgstr "Plik biblioteki symboli '%s' jest pusty."
-
-#~ msgid "There is no component selected to save."
-#~ msgstr "Nie ma zaznaczonych symboli do zapisania."
-
-#~ msgid "Export Component"
-#~ msgstr "Eksportuj symbol"
-
-#~ msgid "'%s' - OK"
-#~ msgstr "'%s' - OK"
-
-#~ msgid ""
-#~ "This library will not be available until it is loaded by Eeschema.\n"
-#~ "\n"
-#~ "Modify the Eeschema library configuration if you want to include it as "
-#~ "part of this project."
-#~ msgstr ""
-#~ "Uwaga: Nowa biblioteka będzie dostępna tylko wtedy, gdy zostanie wczytana "
-#~ "przez Eeschema.\n"
-#~ "\n"
-#~ "Zmień konfigurację bibliotek Eeschema jeśli chcesz jej używać w tym "
-#~ "projekcie."
-
-#~ msgid "'%s' - Export OK"
-#~ msgstr "'%s' - Eksport OK"
-
-#~ msgid "Error creating '%s'"
-#~ msgstr "Błąd podczas tworzenia '%s'"
-
-#~ msgid "Polyline only had %d parameters of the required 4"
-#~ msgstr "linia łamana posiada tylko %d parametrów z wymaganych 4"
-
-#~ msgid "Polyline count parameter %d is invalid"
-#~ msgstr "Ilość %d składników linii łamanej jest niepoprawna"
-
-#~ msgid "Polyline point %d X position not defined"
-#~ msgstr "Punkt X pozycji %d lini łamanej nie jest ustalona"
-
-#~ msgid "Polyline point %d Y position not defined"
-#~ msgstr "Punkt Y pozycji %d lini łamanej nie jest ustalona"
-
-#~ msgid "Rectangle only had %d parameters of the required 7"
-#~ msgstr "prostokąt posiada tylko %d z wymaganych 7"
-
-#~ msgid "Text only had %d parameters of the required 8"
-#~ msgstr "Tekst posiada tylko %d parameterów z wymaganych 8"
-
-#~ msgid "An error occurred attempting to save component library '%s'."
-#~ msgstr "Wystąpił błąd przy próbie zapisania biblioteki symboli '%s'."
-
-#~ msgid "Part Library Editor: "
-#~ msgstr "Edytor Bibliotek: "
-
-#~ msgid ""
-#~ "The current component is not saved.\n"
-#~ "\n"
-#~ "Discard current changes?"
-#~ msgstr ""
-#~ "Bieżący symbol nie został zapisany.\n"
-#~ "\n"
-#~ "Porzucić zmiany?"
-
-#~ msgid "The selected component is not in the active library."
-#~ msgstr "Wybrany element nie występuje w aktywnej bibliotece."
-
-#~ msgid "Do you want to change the active library?"
-#~ msgstr "Czy chcesz zmienić aktywną bibliotekę?"
-
-#~ msgid "Part name '%s' not found in library '%s'"
-#~ msgstr "Nazwa symbolu '%s' nie została znaleziona w '%s'"
-
-#~ msgid "Include last component changes?"
-#~ msgstr "Dołączyć ostatnie zmiany w symbolu?"
-
-#~ msgid "Part Library Name:"
-#~ msgstr "Nazwa pliku biblioteki symboli:"
-
-#~ msgid "Modify library file '%s' ?"
-#~ msgstr "Czy zmodyfikować plik biblioteki '%s' ?"
-
-#~ msgid "Error occurred while saving library file '%s'"
-#~ msgstr "Błąd podczas zapisu pliku biblioteki '%s'"
-
-#~ msgid "*** ERROR: ***"
-#~ msgstr "*** BŁĄD: ***"
-
-#~ msgid "Error occurred while saving library documentation file <%s>"
-#~ msgstr "Błąd podczas zapisiu pliku dokumentacji biblioteki <%s>"
-
-#~ msgid "Failed to create component document library file <%s>"
-#~ msgstr "Nie można utworzyc pliku dokumentacji biblioteki <%s>"
-
-#~ msgid "Library file '%s' OK"
-#~ msgstr "Plik biblioteki '%s' Zapisano poprawnie"
-
-#~ msgid "Documentation file '%s' OK"
-#~ msgstr "Plik dokumentacji '%s' Zapisano poprawnie"
-
-#~ msgid "Part"
-#~ msgstr "Element "
-
-#~ msgid "Please select a component library."
-#~ msgstr "Proszę wybrać bibliotekę symboli."
-
-#~ msgid "Part library '%s' is empty."
-#~ msgstr "Biblioteka symboli '%s' jest pusta."
-
-#~ msgid "Delete Entry Error"
-#~ msgstr "Błąd przy usuwaniu wpisu"
-
-#~ msgid ""
-#~ "Select one of %d components to delete\n"
-#~ "from library '%s'."
-#~ msgstr ""
-#~ "Wybierz jeden z %d symboli do usunięcia\n"
-#~ "z biblioteki '%s'."
-
-#~ msgid "Delete Part"
-#~ msgstr "Usuń symbol"
-
-#~ msgid "Entry '%s' not found in library '%s'."
-#~ msgstr "Wpis '%s' nie został znaleziony w bibliotece '%s'."
-
-#~ msgid "Delete component '%s' from library '%s' ?"
-#~ msgstr "Usunąć symbol '%s' z biblioteki '%s' ?"
-
-#~ msgid ""
-#~ "The component being deleted has been modified. All changes will be lost. "
-#~ "Discard changes?"
-#~ msgstr ""
-#~ "Symbol który został skasowany został zmodyfikowany. Wszystkie zmiany "
-#~ "zostaną utracone. Porzucić zmiany?"
-
-#~ msgid ""
-#~ "All changes to the current component will be lost!\n"
-#~ "\n"
-#~ "Clear the current component from the screen?"
-#~ msgstr ""
-#~ "Wszelkie zmiany w bieżącym symbolu zostaną utracone!!\n"
-#~ "\n"
-#~ "Usunąć symbol z pola edycji?"
-
-#~ msgid "This new component has no name and cannot be created. Aborted"
-#~ msgstr "Ten nowy symbol nie ma nazwy i nie może zostać utworzony. Przerwano"
-
-#~ msgid "Part '%s' already exists in library '%s'"
-#~ msgstr "Symbol '%s' już istnieje w bibliotece '%s'"
-
-#~ msgid "Part '%s' already exists. Change it?"
-#~ msgstr "Symbol '%s' istnieje. Zmienić go?"
-
-#~ msgid "Part '%s' saved in library '%s'"
-#~ msgstr "Symbol '%s' zapisano w bibliotece '%s'"
-
-#~ msgid "Move Arc"
-#~ msgstr "Przesuń łuk "
-
-#~ msgid "Drag Arc Size"
-#~ msgstr "Przeciągnij rozmiar łuku"
-
-#~ msgid "Delete Arc"
-#~ msgstr "Usuń łuk "
-
-#~ msgid "Move Circle"
-#~ msgstr "Przesuń okrąg "
-
-#~ msgid "Edit Circle Options"
-#~ msgstr "Edycja właściwości okręgu"
-
-#~ msgid "Delete Circle"
-#~ msgstr "Usuń okrąg "
-
-#~ msgid "Edit Rectangle Options"
-#~ msgstr "Edycja właściwości prostokąta"
-
-#~ msgid "Delete Rectangle"
-#~ msgstr "Usuń prostokąt "
-
-#~ msgid "Move Text"
-#~ msgstr "Przesuń tekst "
-
-#~ msgid "Edit Text"
-#~ msgstr "Edytuj tekst"
-
-#~ msgid "Rotate Text"
-#~ msgstr "Obróć tekst"
-
-#~ msgid "Delete Text"
-#~ msgstr "Usuń tekst"
-
-#~ msgid "Move Line"
-#~ msgstr "Przesuń linię "
-
-#~ msgid "Delete Line "
-#~ msgstr "Usuń linię "
-
-#~ msgid "Field Rotate"
-#~ msgstr "Obróć pole"
-
-#~ msgid "Field Edit"
-#~ msgstr "Edytuj pole"
-
-#~ msgid "Move Pin "
-#~ msgstr "Przesuń pin"
-
-#~ msgid "Edit Pin "
-#~ msgstr "Edytuj pin "
-
-#~ msgid "Rotate Pin "
-#~ msgstr "Obróć pin"
-
-#~ msgid "Delete Pin "
-#~ msgstr "Usuń pin "
-
-#~ msgid "Pin Size to selected pins"
-#~ msgstr "Rozmiar pinu dla wybranych pinów"
-
-#~ msgid "Pin Size to Others"
-#~ msgstr "Rozmiar pinu dla innych"
-
-#~ msgid "Pin Name Size to selected pin"
-#~ msgstr "Rozmiar nazwy pinu dla wybranego pinu"
-
-#~ msgid "Pin Name Size to Others"
-#~ msgstr "Rozmiar nazwy pinu dla innych"
-
-#~ msgid "Pin Num Size to selected pin"
-#~ msgstr "Rozmiar numeru pinu dla wybranego pinu"
-
-#~ msgid "Pin Num Size to Others"
-#~ msgstr "Rozmiar numeru pinu dla innych"
-
-#~ msgid "Zoom Block (drag middle mouse)"
-#~ msgstr "Powiększ blok (shift + przeciąganie myszką)"
-
-#~ msgid "Mirror Block ||"
-#~ msgstr "Odbij blok ||"
-
-#~ msgid "Mirror Block --"
-#~ msgstr "Odbij blok --"
-
-#~ msgid "Rotate Block ccw"
-#~ msgstr "Obróć blok (w lewo)"
-
-#~ msgid "Can't save file <%s>"
-#~ msgstr "Nie mogę utworzyć pliku <%s>"
-
-#~ msgid "Save the changes in the library before closing?"
-#~ msgstr "Zapisać zmiany w bibliotece przed zamknięciem?"
-
-#~ msgid ""
-#~ "Library '%s' was modified!\n"
-#~ "Discard changes?"
-#~ msgstr ""
-#~ "Biblioteka '%s' została zmieniona!\n"
-#~ "Porzucić zmiany?"
-
-#~ msgid "No part to save."
-#~ msgstr "Brak symbolu by zapisać."
-
-#~ msgid "Illegal reference. A reference must start by a letter"
-#~ msgstr "Niepoprawne pole oznaczenie. Oznaczenie musi rozpoczynać się literą"
-
-#~ msgid ""
-#~ "The name '%s' conflicts with an existing entry in the component library "
-#~ "'%s'.\n"
-#~ "\n"
-#~ "Do you wish to replace the current component in library with this one?"
-#~ msgstr ""
-#~ "Nazwa '%s' koliduje z istniejącym wpisem w bibliotece symboli '%s'.\n"
-#~ "\n"
-#~ "Czy chcesz zamienić bieżący symbol w bibliotece na obecny?"
-
-#~ msgid "Confirm"
-#~ msgstr "Potwierdzenie"
-
-#~ msgid ""
-#~ "The current component already has an alias named '%s'.\n"
-#~ "\n"
-#~ "Do you wish to remove this alias from the component?"
-#~ msgstr ""
-#~ "Bieżący symbol posiada już alias nazwany '%s'.\n"
-#~ "\n"
-#~ "Czy chcesz usunąć ten alias z tego symbolu?"
-
-#~ msgid ""
-#~ "The new component contains alias names that conflict with entries in the "
-#~ "component library '%s'.\n"
-#~ "\n"
-#~ "Do you wish to remove all of the conflicting aliases from this component?"
-#~ msgstr ""
-#~ "Nowy symbol posiada aliasy, które są w konflikcie z innymi wpisami w "
-#~ "bibliotece '%s'.\n"
-#~ "\n"
-#~ "Czy chcesz usunąć wszystkie konfliktowe aliasy z tego symbolu?"
-
-#~ msgid "Failed to open '%s'"
-#~ msgstr "Nie można otworzyć '%s'"
-
-#~ msgid "'%s' is NOT an Eeschema file!"
-#~ msgstr "'%s' NIE jest plikiem Eeschema!"
-
-#~ msgid ""
-#~ "'%s' was created by a more recent version of Eeschema and may not load "
-#~ "correctly. Please consider updating!"
-#~ msgstr ""
-#~ "'%s' został utworzony w nowszej wersji programu Eeschema i może nie "
-#~ "zostać załadowany poprawnie. Należy rozważyć aktualizację programu!"
-
-#~ msgid ""
-#~ " was created by an older version of Eeschema. It will be stored in the "
-#~ "new file format when you save this file again."
-#~ msgstr ""
-#~ " został stworzony w starszej wersji Eeschema. Plik zostanie zachowany w "
-#~ "nowym formacie, gdy ponownie zostanie zapisany."
-
-#~ msgid "Eeschema file text load error at line %d"
-#~ msgstr "Błąd w tekście w linii %d podczas ładowania pliku"
-
-#~ msgid "Eeschema file undefined object at line %d, aborted"
-#~ msgstr "Niezdefiniowany obiekt w pliku w linii %d, przerwano."
-
-#~ msgid "Eeschema file object not loaded at line %d, aborted"
-#~ msgstr ""
-#~ "Obiekt z pliku Eeschema w linii %d nie został załadowany, przerwano."
-
-#~ msgid "Done Loading <%s>"
-#~ msgstr "Wczytywanie <%s> zakończone "
-
-#~ msgid ""
-#~ "Eeschema file dimension definition error line %d,\n"
-#~ "Abort reading file.\n"
-#~ msgstr ""
-#~ "Błędna definicja rozmiaru w pliku, w linii %d. \n"
-#~ "Przerwano odczyt pliku.\n"
-
-#~ msgid "&New Schematic Project"
-#~ msgstr "Nowy projekt schematu"
-
-#~ msgid ""
-#~ "Clear current schematic hierarchy and start a new schematic root sheet"
-#~ msgstr ""
-#~ "Usuwa obecną hierarchię schematów i rozpoczyna od nowego arkusza "
-#~ "nadrzędnego"
-
-#~ msgid "&Open Schematic Project"
-#~ msgstr "Otwórz projekt schematu"
-
-#~ msgid "Open an existing schematic hierarchy"
-#~ msgstr "Otwórz istniejącą hierarchię schematów"
-
-#~ msgid "Open a recent opened schematic project"
-#~ msgstr "Otwiera listę ostatnio otwieranych schematów"
-
-#~ msgid "App&end Schematic Sheet"
-#~ msgstr "Dołącz arkusz schematu"
-
-#~ msgid "Append schematic sheet to current project"
-#~ msgstr "Dołącz inny projekt schematu do obecnie załadowanego schematu"
-
-#~ msgid "Save all sheets in schematic project"
-#~ msgstr "Zapisz wszystkie arkusze schematów projektu"
-
-#~ msgid "Save &Current Sheet Only"
-#~ msgstr "Zapisz tylko bieżą&cy arkusz"
-
-#~ msgid "Save C&urrent Sheet As"
-#~ msgstr "Zapisz bieżący arkusz jako..."
-
-#~ msgid "Save current schematic sheet as..."
-#~ msgstr "Zapisz bieżący arkusz jako..."
-
-#~ msgid "Pa&ge Settings"
-#~ msgstr "Ustawienia strony"
-
-#~ msgid "Setting for sheet size and frame references"
-#~ msgstr "Ustawienia rozmiaru strony i zawartość tabliczki tytułowej"
-
-#~ msgid "Pri&nt"
-#~ msgstr "Drukuj"
-
-#~ msgid "&Plot"
-#~ msgstr "Rysuj"
-
-#~ msgid "Plot to C&lipboard"
-#~ msgstr "Rysuj i umieść w schowku"
-
-#~ msgid "Plot schematic sheet in HPGL, PostScript or SVG format"
-#~ msgstr "Rysuj schemat w formacie HPGL, Postscript, DXF lub SVG"
-
-#~ msgid "Find and Re&place"
-#~ msgstr "Wyszukaj i zamień"
-
-#~ msgid "Import Footprint Selection"
-#~ msgstr "Importuj dane o footprintach"
-
-#~ msgid "&Component"
-#~ msgstr "Symbol"
-
-#~ msgid "Hierarchical &Sheet"
-#~ msgstr "Arkusz hierarchiczny"
-
-#~ msgid "Component &Libraries"
-#~ msgstr "Biblioteki symboli"
-
-#~ msgid "Configure component libraries and paths"
-#~ msgstr "Konfiguruje listę bibliotek i ścieżki dostępu do nich"
-
-#~ msgid "Set &Colors Scheme"
-#~ msgstr "Wybierz schemat kolorów"
-
-#~ msgid "Set color preferences"
-#~ msgstr "Ustawienia kolorów"
-
-#~ msgid "Schematic Editor &Options"
-#~ msgstr "Opcje edytora schematów"
-
-#~ msgid "Set Eeschema preferences"
-#~ msgstr "Ustawienia Eeschema"
-
-#~ msgid "&Save Preferences"
-#~ msgstr "&Zapisz ustawienia"
-
-#~ msgid "Load Prefe&rences"
-#~ msgstr "Wczytaj ustawienia"
-
-#~ msgid "&Rescue Old Components"
-#~ msgstr "Odzyskaj poprzednie komponenty"
-
-#~ msgid "Find old components in the project and rename/rescue them"
-#~ msgstr ""
-#~ "Wyszukuje poprzednie wersje komponentów w pamięci podręcznej oraz "
-#~ "odzyskuje je tworząc nową bibliotekę"
-
-#~ msgid "&Annotate Schematic"
-#~ msgstr "Numeruj schemat"
-
-#~ msgid "Generate &Netlist File"
-#~ msgstr "Generowanie listy sieci"
-
-#~ msgid "Generate the component netlist file"
-#~ msgstr "Generuje listę sieci w celu dalszego jej przetwarzania"
-
-#~ msgid "Generate Bill of &Materials"
-#~ msgstr "Generuj listę &materiałową"
-
-#~ msgid "A&ssign Component Footprint"
-#~ msgstr "Przypisz footprinty komponentom"
-
-#~ msgid "&Layout Printed Circuit Board"
-#~ msgstr "Stwórz obwód drukowany"
-
-#~ msgid "Select working library"
-#~ msgstr "Wybierz bibliotekę roboczą"
-
-#~ msgid "&Save Current Library\tCtrl+S"
-#~ msgstr "Zapi&sz bieżącą bibliotekę\tCtrl+S"
-
-#~ msgid "Save Current Library &As"
-#~ msgstr "Zapisz bieżącą bibliotekę j&ako"
-
-#~ msgid "Save current active library as..."
-#~ msgstr "Zapisz bieżącą aktywną bibliotekę jako..."
-
-#~ msgid "Create &PNG File from Screen"
-#~ msgstr "Utwórz plik PNG ze zrzutem ekranu"
-
-#~ msgid "Create a PNG file from the component displayed on screen"
-#~ msgstr "Utwórz plik PNG na podstawie symbolu znajdującego się na ekranie"
-
-#~ msgid "Create S&VG File"
-#~ msgstr "Utwórz plik S&VG"
-
-#~ msgid "Create a SVG file from the current loaded component"
-#~ msgstr "Utwórz plik SVG z bieżąco wczytanego symbolu"
-
-#~ msgid "Component Editor &Options"
-#~ msgstr "Opcje Edytora Bibliotek"
-
-#~ msgid "Set Component Editor default values and options"
-#~ msgstr "Ustawia domyślne wartości i opcje Edytora Bibliotek"
-
-#~ msgid ""
-#~ "Exporting the netlist requires a completely\n"
-#~ "annotated schematic."
-#~ msgstr ""
-#~ "Eksport listy sieci wymaga by elementy na schemacie\n"
-#~ "zostały w pełni ponumerowane."
-
-#~ msgid "Edit Label"
-#~ msgstr "Edytuj etykietę"
-
-#~ msgid "Edit Global Label"
-#~ msgstr "Edytuj etykietę globalną"
-
-#~ msgid "Edit Hierarchical Label"
-#~ msgstr "Edytuj etykietę hierarchiczną"
-
-#~ msgid "Edit Image"
-#~ msgstr "Edytuj obraz"
-
-#~ msgid "Edit Reference"
-#~ msgstr "Edytuj oznaczenie"
-
-#~ msgid "Edit Value"
-#~ msgstr "Edytuj wartość"
-
-#~ msgid "Edit Footprint Field"
-#~ msgstr "Edytuj pole footprintu"
-
-#~ msgid "Edit Field"
-#~ msgstr "Edytuj pole"
-
-#~ msgid "Move Component %s"
-#~ msgstr "Przesuń symbol %s"
-
-#~ msgid "Drag Component"
-#~ msgstr "Przeciągnij symbol"
-
-#~ msgid "Mirror --"
-#~ msgstr "Odbij poziomo --"
-
-#~ msgid "Mirror ||"
-#~ msgstr "Odbij pionowo ||"
-
-#~ msgid "Orient Component"
-#~ msgstr "Zorientuj symbol"
-
-#~ msgid "Copy Component"
-#~ msgstr "Kopiuj symbol"
-
-#~ msgid "Delete Component"
-#~ msgstr "Usuń symbol"
-
-#~ msgid "Doc"
-#~ msgstr "Dokument"
-
-#~ msgid "Edit Component"
-#~ msgstr "Edytuj symbol"
-
-#~ msgid "Move Global Label"
-#~ msgstr "Przesuń etykietę globalną"
-
-#~ msgid "Drag Global Label"
-#~ msgstr "Przeciągnij etykietę globalną"
-
-#~ msgid "Copy Global Label"
-#~ msgstr "Kopiuj etykietę globalną"
-
-#~ msgid "Rotate Global Label"
-#~ msgstr "Obróć etykietę globalną"
-
-#~ msgid "Delete Global Label"
-#~ msgstr "Usuń etykietę globalną"
-
-#~ msgid "Move Hierarchical Label"
-#~ msgstr "Przesuń etykietę hierarchiczną"
-
-#~ msgid "Drag Hierarchical Label"
-#~ msgstr "Przeciągnij etykietę hierarchiczną"
-
-#~ msgid "Copy Hierarchical Label"
-#~ msgstr "Kopiuj etykietę hierarchiczną"
-
-#~ msgid "Rotate Hierarchical Label"
-#~ msgstr "Obróć etykietę hierarchiczną"
-
-#~ msgid "Delete Hierarchical Label"
-#~ msgstr "Usuń etykietę hierarchiczną"
-
-#~ msgid "Move Label"
-#~ msgstr "Przesuń etykietę"
-
-#~ msgid "Drag Label"
-#~ msgstr "Przeciągnij etykietę"
-
-#~ msgid "Copy Label"
-#~ msgstr "Kopiuj etykietę"
-
-#~ msgid "Rotate Label"
-#~ msgstr "Obróć etykietę"
-
-#~ msgid "Delete Label"
-#~ msgstr "Usuń etykietę"
-
-#~ msgid "Copy Text"
-#~ msgstr "Kopiuj tekst"
-
-#~ msgid "Move Sheet"
-#~ msgstr "Przesuń arkusz"
-
-#~ msgid "Drag Sheet"
-#~ msgstr "Przeciągnij arkusz"
-
-#~ msgid "Rotate Sheet CW"
-#~ msgstr "Obróć arkusz (w prawo)"
-
-#~ msgid "Rotate Sheet CCW"
-#~ msgstr "Obróć arkusz (w lewo)"
-
-#~ msgid "Orient Sheet"
-#~ msgstr "Zorientuj arkusz"
-
-#~ msgid "Place Sheet"
-#~ msgstr "Dodaj arkusz"
-
-#~ msgid "Edit Sheet"
-#~ msgstr "Edytuj arkusz"
-
-#~ msgid "Resize Sheet"
-#~ msgstr "Zmień wielkość arkusza"
-
-#~ msgid "Delete Sheet"
-#~ msgstr "Usuń arkusz"
-
-#~ msgid "Move Sheet Pin"
-#~ msgstr "Przesuń pin arkusza"
-
-#~ msgid "Edit Sheet Pin"
-#~ msgstr "Edytuj pin arkusza"
-
-#~ msgid "Delete Sheet Pin"
-#~ msgstr "Usuń pin arkusza"
-
-#~ msgid "Move Image"
-#~ msgstr "Przesuń obraz"
-
-#~ msgid "Rotate Image"
-#~ msgstr "Obróć obraz"
-
-#~ msgid "Delete Image"
-#~ msgstr "Usuń obraz"
-
-#~ msgid "This position is already occupied by another pin. Continue?"
-#~ msgstr "Ta pozycja jest zajmowana przez inny pin. Kontynuować?"
-
-#~ msgid " in part %c"
-#~ msgstr " w elemencie %c"
-
-#~ msgid "Plot: '%s' OK.\n"
-#~ msgstr "Rysunek: '%s' OK.\n"
-
-#~ msgid "Unable to create file '%s'.\n"
-#~ msgstr "Nie mogę utworzyć pliku '%s'.\n"
-
-#~ msgid "Cannot create file '%s'.\n"
-#~ msgstr "Nie mogę utworzyć pliku '%s'.\n"
-
-#~ msgid "Rescue %s as %s"
-#~ msgstr "Odzyskaj %s jako %s"
-
-#~ msgid "Component %s, %s"
-#~ msgstr "Symbol %s, %s"
-
-#~ msgid "%s Graphic Line from (%s,%s) to (%s,%s) "
-#~ msgstr "Linia (grafika) %s z (%s,%s) do (%s,%s) "
-
-#~ msgid "Schematic sheets can only be nested %d levels deep."
-#~ msgstr "Arkusze schematów mogą być zagnieżdżone tylko %d krotnie."
-
-#~ msgid "No tool selected"
-#~ msgstr "Narzędzie nie zostało wybrane"
-
-#~ msgid "Descend or ascend hierarchy"
-#~ msgstr "Hierarchia opadająca lub wznosząca"
-
-#~ msgid ""
-#~ "Save the changes in\n"
-#~ "'%s'\n"
-#~ "before closing?"
-#~ msgstr ""
-#~ "Zapisać zmiany w\n"
-#~ "'%s'\n"
-#~ "przed zamknięciem?"
-
-#~ msgid "Schematic file '%s' already exists, use Open instead"
-#~ msgstr "Plik '%s' już istnieje. Użyj polecenia Otwórz"
-
-#~ msgid "Error: not a component or no component"
-#~ msgstr "Błąd: To nie jest symbol albo brak symboli"
-
-#~ msgid "No component libraries are loaded."
-#~ msgstr "Nie są załadowane żadne biblioteki."
-
-#~ msgid "Select Component"
-#~ msgstr "Wybierz symbol"
-
-#~ msgid "A file named '%s' already exists in the current schematic hierarchy."
-#~ msgstr "Plik o nazwie '%s' już istnieje w bieżącej hierarchii schematu."
-
-#~ msgid "A file named '%s' already exists."
-#~ msgstr "Plik o nazwie '%s' już istnieje."
-
-#~ msgid "A file named <%s> already exists in the current schematic hierarchy."
-#~ msgstr "Plik o nazwie <%s> już istnieje w bieżącej hierarchii schematu."
-
-#~ msgid "A file named <%s> already exists."
-#~ msgstr "Plik o nazwie <%s> już istnieje."
-
-#~ msgid "Import Symbol Drawings"
-#~ msgstr "Importuj rysunki symboli"
-
-#~ msgid "Error '%s' occurred loading part file '%s'."
-#~ msgstr "Wsystąpił błąd '%s' podczas ładowania biblioteki symboli '%s'."
-
-#~ msgid "No parts found in part file '%s'."
-#~ msgstr "Nie znaleziono symboli w pliku symboli '%s'."
-
-#~ msgid "More than one part in part file '%s'."
-#~ msgstr "W pliku symboli '%s' znajduje się więcej niż jeden element."
-
-#~ msgid "Export Symbol Drawings"
-#~ msgstr "Eksportuj rysunki symboli"
-
-#~ msgid "Saving symbol in '%s'"
-#~ msgstr "Zapisuję symbol w '%s'"
-
-#~ msgid "An error occurred attempting to save symbol file '%s'"
-#~ msgstr "Wystąpił błąd przy próbie zapisania pliku symboli '%s'"
-
-#~ msgid "Move part anchor"
-#~ msgstr "Przesuń zakotwiczenie elelementu"
-
-#~ msgid "Save current library to disk"
-#~ msgstr "Zapisz bieżącą bibliotekę na dysk"
-
-#~ msgid "Delete component in current library"
-#~ msgstr "Usuń symbol z bieżącej biblioteki"
-
-#~ msgid "Create a new component"
-#~ msgstr "Utwórz nowy symbol"
-
-#~ msgid "Load component to edit from the current library"
-#~ msgstr "Wczytaj symbol z bieżącej bibloteki w celu edycji"
-
-#~ msgid "Create a new component from the current one"
-#~ msgstr "Stwórz nowy symbol na podstawie bieżącego"
-
-#~ msgid "Update current component in current library"
-#~ msgstr "Zaktualizuj symbol w bieżącej bibliotece"
-
-#~ msgid "Import component"
-#~ msgstr "Importuj symbol"
-
-#~ msgid "Export component"
-#~ msgstr "Eksportuj symbol"
-
-#~ msgid "Save current component to new library"
-#~ msgstr "Zapisz bieżący symbol w nowej bibliotece"
-
-#~ msgid "Redo the last command"
-#~ msgstr "Ponów ostatnio cofniętą operację"
-
-#~ msgid "Edit component properties"
-#~ msgstr "Edytuj właściwości symbolu"
-
-#~ msgid "Add and remove fields and edit field properties"
-#~ msgstr "Dodaj lub usuń pola i edytuj ich właściwości"
-
-#~ msgid "Test for duplicate and off grid pins"
-#~ msgstr ""
-#~ "Przetestuj w poszukiwaniu zduplikowanych pinów i znajdujących się poza "
-#~ "siatką"
-
-#~ msgid "Show as \"De Morgan\" normal part"
-#~ msgstr "Pokaż jako normalny element \"De Morgan\""
-
-#~ msgid "Show as \"De Morgan\" convert part"
-#~ msgstr "Pokaż jako skonwertowany element \"De Morgan\""
-
-#~ msgid "Show the associated datasheet or document"
-#~ msgstr "Pokazuje załączoną notę katalogową lub dokumentację"
-
-#~ msgid "Edit pins per part or body style (Use carefully!)"
-#~ msgstr "Edytuj piny element po elemencie lub wg stylu (Używaj ostrożnie!)"
-
-#~ msgid "New schematic project"
-#~ msgstr "Nowy projekt schematu"
-
-#~ msgid "Open schematic project"
-#~ msgstr "Otwórz projekt schematu"
-
-#~ msgid "Save schematic project"
-#~ msgstr "Zapisz projekt schematu"
-
-#~ msgid "Cut selected item"
-#~ msgstr "Wytnij zaznaczony element"
-
-#~ msgid "Copy selected item"
-#~ msgstr "Kopiuj zaznaczony element"
-
-#~ msgid "Run CvPcb to associate components and footprints"
-#~ msgstr "Uruchom CvPcb - Przypisz footprinty komponentom ze schematu"
-
-#~ msgid "Ascend/descend hierarchy"
-#~ msgstr "Hierarchia wznosząca lub opadająca"
-
-#~ msgid "Select component to browse"
-#~ msgstr "Wybierz symbol do przeglądania"
-
-#~ msgid "Display previous component"
-#~ msgstr "Pokaż poprzedni symbol"
-
-#~ msgid "Display next component"
-#~ msgstr "Pokaż następny symbol"
-
-#~ msgid "View component documents"
-#~ msgstr "Pokaż dokumentację symbolu"
-
-#~ msgid "Insert component in schematic"
-#~ msgstr "Wstaw symbol do schematu"
-
-#~ msgid "Set Current Library"
-#~ msgstr "Ustaw bieżącą bibliotekę"
-
-#~ msgid "Close schematic component viewer"
-#~ msgstr "Zamknij przeglądarkę symboli"
-
-#~ msgid "Layer %d (%s, %s, %s)"
-#~ msgstr "Warstwa %d (%s, %s, %s)"
-
-#~ msgid "Layer %d (%s, %s)"
-#~ msgstr "Warstwa %d (%s, %s)"
-
-#~ msgid "Layer %d *"
-#~ msgstr "Warstwa %d *"
-
-#~ msgid "D Code"
-#~ msgstr "D Code"
-
-#~ msgid "Render"
-#~ msgstr "Pokaż"
-
-#~ msgid "Layers selection:"
-#~ msgstr "Wybór warstw:"
-
-#~ msgid "fit in page"
-#~ msgstr "Dopasuj do strony"
-
-#~ msgid "Approx. Scale 1"
-#~ msgstr "Przybliżona skala 1"
-
-#~ msgid "Accurate Scale 1"
-#~ msgstr "Dokładna skala 1"
-
-#~ msgid "Approx. Scale:"
-#~ msgstr "Przybliżona skala:"
-
-#~ msgid "X Scale Adjust"
-#~ msgstr "Dostosuj skalę X"
-
-#~ msgid "Y Scale Adjust"
-#~ msgstr "Dostosuj skalę Y"
-
-#~ msgid "Full size. Do not show page limits"
-#~ msgstr "Pełny rozmiar. Nie pokazuj granic strony"
-
-#~ msgid "Small cross"
-#~ msgstr "Mały krzyż"
-
-#~ msgid "Full screen cursor"
-#~ msgstr "Kursor pełnoekranowy"
-
-#~ msgid "Files not found"
-#~ msgstr "Nie znaleziono plików"
-
-#~ msgid "Tool definition <%c> not supported"
-#~ msgstr "Definicja narzędzia <%c> nie jest obsługiwana"
-
-#~ msgid "Tool <%d> not defined"
-#~ msgstr "Narzędzie <%d> nie zostało zdefiniowane"
-
-#~ msgid "Board file name:"
-#~ msgstr "Nazwa pliku płytki:"
-
-#~ msgid "Cannot create file '%s'"
-#~ msgstr "Nie mogę utworzyć pliku '%s'"
-
-#~ msgid "Layer %d not in use"
-#~ msgstr "Warstwa %d nie jest używana"
-
-#~ msgid "Image name: '%s'  Layer name: '%s'"
-#~ msgstr "Nazwa obrazu: '%s'  Nazwa warstwy: '%s'"
-
-#~ msgid "Load &Gerber File"
-#~ msgstr "Wczytaj plik &Gerber"
-
-#~ msgid "Load &EXCELLON Drill File"
-#~ msgstr "Wczytaj plik wierceń &EXCELLON"
-
-#~ msgid "Open a recent opened Gerber file"
-#~ msgstr "Otwiera często używany plik Gerber"
-
-#~ msgid "Open a recent opened drill file"
-#~ msgstr "Otwiera często używany plik wierceń"
-
-#~ msgid "E&xport to Pcbnew"
-#~ msgstr "Eksportuj do Pcbnew"
-
-#~ msgid "&Print"
-#~ msgstr "Drukuj"
-
-#~ msgid "List and edit D-codes"
-#~ msgstr "Lista i edycja D-kodów"
-
-#~ msgid "&Clear Layer"
-#~ msgstr "Wy&czyść Warstwę"
-
-#~ msgid "Clear current layer"
-#~ msgstr "Wyczyść bieżącą warstwę"
-
-#~ msgid "&Text Editor"
-#~ msgstr "Edytor &tekstu"
-
-#~ msgid "File <%s> not found"
-#~ msgstr "Nie znaleziono pliku <%s>"
-
-#~ msgid "Too many include files!!"
-#~ msgstr "Dołączono zbyt dużo plików!!!"
-
-#~ msgid "No tool"
-#~ msgstr "Brak narzędzia"
-
-#~ msgid "Tool "
-#~ msgstr "Narzędzie "
-
-#~ msgid ""
-#~ "Show layers in raw mode (could have problems with negative items when "
-#~ "more than one gerber file is shown)"
-#~ msgstr ""
-#~ "Pokaż warstwy w trybie RAW (Mogą być problemy z wyświetlaniem w negatywie "
-#~ "gdy pokazywany jest więcej niż jeden plik Gerber)"
-
-#~ msgid ""
-#~ "Show layers in stacked mode (show negative items without artifacts, "
-#~ "sometimes slow)"
-#~ msgstr ""
-#~ "Pokaż warstwy w trybie nakładkowym (pokazuje elementy w negatywie bez "
-#~ "artefaktów, czasami wolno)"
-
-#~ msgid ""
-#~ "Show layers in transparency mode (show negative items without artifacts, "
-#~ "sometimes slow)"
-#~ msgstr ""
-#~ "Pokaż warstwy w trybie przeźroczystym (pokazuje elementy w negatywie bez "
-#~ "artefaktów, czasami wolno)"
-
-#~ msgid "Do you really want to delete '%s'"
-#~ msgstr "Czy na pewno chcesz usunąć '%s'"
-
-#~ msgid "Eeschema - Electronic schematic editor"
-#~ msgstr "Eeschema - Zaawansowany edytor schematów elektronicznych"
-
-#~ msgid "Schematic library editor"
-#~ msgstr "Edytor bibliotek symboli"
-
-#~ msgid "Pcbnew - Printed circuit board editor"
-#~ msgstr "Pcbnew - Edytor obwodów drukowanych"
-
-#~ msgid "PCB footprint editor"
-#~ msgstr "Edytor Footprintów"
-
-#~ msgid "GerbView - Gerber viewer"
-#~ msgstr "GerbView - Przeglądarka plików Gerber"
-
-#~ msgid ""
-#~ "Bitmap2Component - Convert bitmap images to Eeschema\n"
-#~ "or Pcbnew elements"
-#~ msgstr ""
-#~ "Bitmap2Component - Konwertuje obrazy bitmapowe na elementy\n"
-#~ "dla programu Eeschema lub Pcbnew"
-
-#~ msgid "Templates path"
-#~ msgstr "Ścieżka do szablonów"
-
-#~ msgid "Zip file (*.zip)|*.zip"
-#~ msgstr "Pliki ZIP (*.zip)|*.zip"
-
-#~ msgid ""
-#~ "\n"
-#~ "Open '%s'\n"
-#~ msgstr ""
-#~ "\n"
-#~ "Otwarcie '%s'\n"
-
-#~ msgid "Unzipping project in '%s'\n"
-#~ msgstr "Rozpakowywanie projektu w '%s'\n"
-
-#~ msgid "Extract file '%s'"
-#~ msgstr "Wypakowywyję plik '%s'"
-
-#~ msgid "Archive file <%s>"
-#~ msgstr "Archiwizuję plik <%s>"
-
-#~ msgid ""
-#~ "\n"
-#~ "Zip archive <%s> created (%d bytes)"
-#~ msgstr ""
-#~ "\n"
-#~ "Archiwum ZIP <%s> (%d bajtów) zostało utworzone"
-
-#~ msgid "Text file ("
-#~ msgstr "Plik tekstowy ("
-
-#~ msgid "Load project"
-#~ msgstr "Załaduj projekt"
-
-#~ msgid "Save project"
-#~ msgstr "Zapisz projekt"
-
-#~ msgid "New Prj From Template"
-#~ msgstr "Nowy projekt na bazie szablonu"
-
-#~ msgid "&Open Project"
-#~ msgstr "&Otwórz projekt"
-
-#~ msgid "Open recent schematic project"
-#~ msgstr "Otwiera ostatnio otwierany projekt"
-
-#~ msgid "&New Project"
-#~ msgstr "Utwórz nowy projekt"
-
-#~ msgid "New Project from &Template"
-#~ msgstr "Nowy na bazie szablonu"
-
-#~ msgid "Create a new project from a template"
-#~ msgstr "Tworzy nowy projekt na podstawie szablonu"
-
-#~ msgid "&Archive"
-#~ msgstr "Sp&akuj projekt"
-
-#~ msgid "Archive project files in zip archive"
-#~ msgstr "Spakuj pliki projektu do archiwum Zip"
-
-#~ msgid "&Unarchive"
-#~ msgstr "Rozpak&uj projekt"
-
-#~ msgid "&Open Local File"
-#~ msgstr "Otwórz plik lokalny"
-
-#~ msgid "&Set Text Editor"
-#~ msgstr "Wybierz edytor tekstu"
-
-#~ msgid "Set &PDF Viewer"
-#~ msgstr "Wybierz przeglądarkę PDF"
-
-#~ msgid "Run Library Editor"
-#~ msgstr "Uruchom Edytor bibliotek LibEdit"
-
-#~ msgid "Run Footprint Editor"
-#~ msgstr "Uruchom Edytor footprintów ModEdit"
-
-#~ msgid "Run Pcb Calculator"
-#~ msgstr "Uruchom Kalkulator PCB"
-
-#~ msgid "Run Page Layout Editor"
-#~ msgstr "Uruchom Edytor układu strony"
-
-#~ msgid "Select Preferred Pdf Browser"
-#~ msgstr "Wybierz preferowaną przeglądarkę PDF"
-
-#~ msgid "Problem whilst creating new project from template!"
-#~ msgstr "Wystąpił problem przy tworzniu nowego projektu z szablonu!"
-
-#~ msgid "KiCad project file '%s' not found"
-#~ msgstr "Plik projektu KiCad '%s' nie został znaleziony"
-
-#~ msgid "To proceed, you can use the File menu to start a new project."
-#~ msgstr "Aby kontynuować, można użyć menu Plik by rozpocząć nowy projekt."
-
-#~ msgid "New D&irectory"
-#~ msgstr "Nowy &folder"
-
-#~ msgid "&Edit in a text editor"
-#~ msgstr "&Edytuj w edytorze tekstu"
-
-#~ msgid "&Rename file"
-#~ msgstr "&Zmień nazwę pliku"
-
-#~ msgid "Change filename: '%s'"
-#~ msgstr "Zmień nazwę pliku: '%s'"
-
-#~ msgid "H justification"
-#~ msgstr "Wyrównanie w poziomie"
-
-#~ msgid "V justification"
-#~ msgstr "Wyrównanie w pionie"
-
-#~ msgid "Text Width (mm)"
-#~ msgstr "Szerokość tekstu (mm)"
-
-#~ msgid "Text Height (mm)"
-#~ msgstr "Wysokość tekstu (mm)"
-
-#~ msgid "Max Size X (mm)"
-#~ msgstr "Maks. wielkość X (mm)"
-
-#~ msgid "Max Size Y (mm)"
-#~ msgstr "Maks. wielkość Y (mm)"
-
-#~ msgid "Text Size X (mm)"
-#~ msgstr "Poziomy rozmiar tekstu (mm)"
-
-#~ msgid "Text Size Y (mm)"
-#~ msgstr "Pionowy rozmiar tekstu (mm)"
-
-#~ msgid "Left Margin (mm)"
-#~ msgstr "Lewy margines (mm)"
-
-#~ msgid "Right Margin (mm)"
-#~ msgstr "Prawy margines (mm)"
-
-#~ msgid "Top Margin (mm)"
-#~ msgstr "Górny margines (mm)"
-
-#~ msgid "Bottom Margin (mm)"
-#~ msgstr "Margines dolny (mm)"
-
-#~ msgid "File <%s> loaded"
-#~ msgstr "Plik <%s> został załadowany"
-
-#~ msgid "Append Page Layout Descr File"
-#~ msgstr "Dołącz plik definicji układu strony"
-
-#~ msgid "File <%s> inserted"
-#~ msgstr "Plik <%s> został wstawiony"
-
-#~ msgid "Open file"
-#~ msgstr "Otwórz"
-
-#~ msgid "Unable to write <%s>"
-#~ msgstr "Nie mogę utworzyć <%s>"
-
-#~ msgid "File <%s> written"
-#~ msgstr "Plik <%s> został zapisany"
-
-#~ msgid "Create file"
-#~ msgstr "Utwórz plik"
-
-#~ msgid "Unable to create <%s>"
-#~ msgstr "Nie mogę utworzyć <%s>"
-
-#~ msgid "&New Page Layout Design"
-#~ msgstr "Nowy projekt układu strony"
-
-#~ msgid "Load Page Layout &File"
-#~ msgstr "Wczytaj plik układu strony"
-
-#~ msgid "Load &Default Page Layout"
-#~ msgstr "Wczytaj domyślny układ strony"
-
-#~ msgid "Open &Recent Page Layout File"
-#~ msgstr "Często używane pliki"
-
-#~ msgid "&Save Page Layout Design"
-#~ msgstr "Zapisz projekt układu strony"
-
-#~ msgid "Save Page Layout Design &As"
-#~ msgstr "Zapisz projekt układu strony jako"
-
-#~ msgid "Print Pre&view"
-#~ msgstr "Podgląd wydruku"
-
-#~ msgid "&Close Page Layout Editor"
-#~ msgstr "Zamknij edytor układu strony"
-
-#~ msgid "&BackGround Black"
-#~ msgstr "Tło w kolorze czarnym"
-
-#~ msgid "&BackGround White"
-#~ msgstr "Tło w kolorze białym"
-
-#~ msgid "Add Rectangle"
-#~ msgstr "Dodaj prostokąt"
-
-#~ msgid "Add Bitmap"
-#~ msgstr "Dodaj bitmapę"
-
-#~ msgid "Error writing page layout descr file"
-#~ msgstr "Wystąpił błąd podczas zapisu pliku z projektem układu strony"
-
-#~ msgid "Error when loading file <%s>"
-#~ msgstr "Wystąpił błąd podczas ładowania pliku <%s>"
-
-#~ msgid "Error when loading file '%s'"
-#~ msgstr "Wystąpił błąd podczas ładowania pliku '%s'"
-
-#~ msgid ""
-#~ "Save the changes in\n"
-#~ "<%s>\n"
-#~ "before closing?"
-#~ msgstr ""
-#~ "Zapisać zmiany w\n"
-#~ "<%s>\n"
-#~ "przed zamknięciem?"
-
-#~ msgid "Load a page layout file. Previous data will be deleted"
-#~ msgstr "Wczytaj nowy plik układu strony.  Poprzednie dane zostaną usunięte."
-
-#~ msgid " Origin of coordinates displayed to the status bar"
-#~ msgstr " Początek współrzędnych wyświetlaj w linii statusu"
-
-#~ msgid "10%"
-#~ msgstr "10%"
-
-#~ msgid "5%"
-#~ msgstr "5%"
-
-#~ msgid "2%"
-#~ msgstr "2%"
-
-#~ msgid "1%"
-#~ msgstr "1%"
-
-#~ msgid "0.5%"
-#~ msgstr "0.5%"
-
-#~ msgid "0.25%"
-#~ msgstr "0.25%"
-
-#~ msgid "0.1%"
-#~ msgstr "0.1%"
-
-#~ msgid "0.05%"
-#~ msgstr "0.05%"
-
-#~ msgid "4rd Band"
-#~ msgstr "Czwarty pasek"
-
-#~ msgid ""
-#~ "Unable to write file<%s>\n"
-#~ "Do you want to exit and abandon your change?"
-#~ msgstr ""
-#~ "Nie mogę zapisać pliku <%s>\n"
-#~ "Czy chcesz opuścić program i porzucić zmiany?"
-
-#~ msgid "PCB Calculator data  file (*.%s)|*.%s"
-#~ msgstr "Plik danych kalkulatora PCB (*.%s)|*.%s"
-
-#~ msgid "Select a PCB Calculator data file"
-#~ msgstr "Wybierz plik danych dla kalkulatora PCB"
-
-#~ msgid "Unable to read data file <%s>"
-#~ msgstr "Nie mogę wczytać pliku danych <%s>"
-
-#~ msgid " Vout must be greater than vref"
-#~ msgstr "Vout musi być większe niż Vref"
-
-#~ msgid " Vref set to 0 !"
-#~ msgstr "Vref wynosi 0!"
-
-#~ msgid "Comma separated value files (*.csv)|*.csv"
-#~ msgstr "Plik wartości oddzielonych przecinkiem (*.csv)|*.csv"
-
-#~ msgid "Unable to create file <%s>"
-#~ msgstr "Nie mogę utworzyć pliku <%s>"
-
-#~ msgid "Links"
-#~ msgstr "Łącza"
-
-#~ msgid "Connections"
-#~ msgstr "Połączeń"
-
-#~ msgid "Checking netlist component footprint \"%s:%s:%s\".\n"
-#~ msgstr "Sprawdzam footprint komponentu z listy sieci \"%s:%s:%s\".\n"
-
-#~ msgid "Adding new component \"%s:%s\" footprint \"%s\".\n"
-#~ msgstr "Dodaję nowy komponent \"%s:%s\" o footprincie \"%s\".\n"
-
-#~ msgid ""
-#~ "Cannot add new component \"%s:%s\" due to missing footprint \"%s\".\n"
-#~ msgstr ""
-#~ "Nie mogę dodać nowego komponentu \"%s:%s\" ponieważ brakuje footprintu "
-#~ "\"%s\".\n"
-
-#~ msgid "Replacing component \"%s:%s\" footprint \"%s\" with \"%s\".\n"
-#~ msgstr "Zamieniam footprint komponentu \"%s:%s\" z \"%s\" na \"%s\".\n"
-
-#~ msgid ""
-#~ "Cannot replace component \"%s:%s\" due to missing footprint \"%s\".\n"
-#~ msgstr ""
-#~ "Nie mogę zamienić komponentu \"%s:%s\" ponieważ brakuje footprintu \"%s"
-#~ "\".\n"
-
-#~ msgid "Changing component \"%s:%s\" reference to \"%s\".\n"
-#~ msgstr "Zmieniam odnośnik footprintu \"%s:%s\" na \"%s\".\n"
-
-#~ msgid ""
-#~ "Changing component \"%s:%s\" pin \"%s\" net name from \"%s\" to \"%s\".\n"
-#~ msgstr ""
-#~ "Zmieniam nazwę sieci komponentu \"%s:%s\" pin \"%s\" z \"%s\" na \"%s\".\n"
-
-#~ msgid "Removing unused component \"%s:%s\".\n"
-#~ msgstr "Usuwam nieużywany footprint \"%s:%s\".\n"
-
-#~ msgid "Remove single pad net \"%s\" on \"%s\" pad '%s'\n"
-#~ msgstr "Usunięcie niepołączonej sieci \"%s\" z \"%s\" pole '%s'\n"
-
-#~ msgid "Component '%s' pad '%s' not found in footprint '%s'\n"
-#~ msgstr ""
-#~ "Komponent '%s', pole '%s' nie zostało znalezione w footprincie '%s'\n"
-
-#~ msgid "Unconnected pads"
-#~ msgstr "Pola niepołączone"
-
-#~ msgid "Non Plated"
-#~ msgstr "Bez pokrycia cyną"
-
-#~ msgid "Show non plated holes"
-#~ msgstr "Pokaż otwory nie mające pokrcia cyną"
-
-#~ msgid "Text Front"
-#~ msgstr "Tekst na stroni górnej"
-
-#~ msgid "Text Back"
-#~ msgstr "Tekst na stronie dolniej"
-
-#~ msgid "Show footprint's values"
-#~ msgstr "Pokaż wartości dla footprintów"
-
-#~ msgid "Show footprint's references"
-#~ msgstr "Pokaż oznaczenia footprintów"
-
-#~ msgid "Use a relative path? "
-#~ msgstr "Użyć ścieżki względnej? "
-
-#~ msgid "Plot: '%s' OK."
-#~ msgstr "Rysunek: '%s' OK."
-
-#~ msgid "Unable to create file '%s'."
-#~ msgstr "Nie mogę utworzyć pliku '%s'."
-
-#~ msgid "Technical Layers:"
-#~ msgstr "Warstwy techniczne:"
-
-#~ msgid "Print SVG options:"
-#~ msgstr "Opcje drukowania SVG:"
-
-#~ msgid "Print mode"
-#~ msgstr "Tryb wydruku"
-
-#~ msgid "File option:"
-#~ msgstr "Opcje pliku:"
-
-#~ msgid "remove vias on pads with a through hole"
-#~ msgstr "Usuń przelotki z pól mających otwór na wylot"
-
-#~ msgid "D&elete unconnected tracks"
-#~ msgstr "Usuń niepołączone ścieżki"
-
-#~ msgid "delete track segment having a dangling end"
-#~ msgstr "Usuń segment ścieżki z dyndającą końcówką"
-
-#~ msgid ""
-#~ "You have chosen the \"not connected\" option. This will create insulated "
-#~ "copper islands. Are you sure ?"
-#~ msgstr ""
-#~ "Użyłeś opcji \"Niepołączone\". To spowoduje utworzenie izolowanych "
-#~ "obszarów na płytce. Kontynuować?"
-
-#~ msgid "Minimun thickness of filled areas."
-#~ msgstr "Minimalna szerokość dla wypełnień stref."
-
-#~ msgid "Priority level:"
-#~ msgstr "Priorytet:"
-
-#~ msgid "Reverse numbering on alternate rows or columns"
-#~ msgstr "Odwrotna numeracja przy zmianie rzędu/kolumny"
-
-#~ msgid "Restart numbering"
-#~ msgstr "Zresetuj numerację"
-
-#~ msgid "Numbering start:"
-#~ msgstr "Rozpoczęcie numeracji od:"
-
-#~ msgid "Numbering type:"
-#~ msgstr "Typ numeracji:"
-
-#~ msgid "%s: <b>Track Size</b> &lt; <b>Min Track Size</b><br>"
-#~ msgstr "%s: <b>Szerokość ścieżki</b> &lt; <b>Min. szerokość ścieżki</b><br>"
-
-#~ msgid "%s: <b>Via Diameter</b> &lt; <b>Minimun Via Diameter</b><br>"
-#~ msgstr ""
-#~ "%s: <b>Średnica przelotki</b> &lt; <b>Min. średnica przelotki</b><br>"
-
-#~ msgid "%s: <b>Via Drill</b> &ge; <b>Via Dia</b><br>"
-#~ msgstr ""
-#~ "%s: <b>Średnica otworu przelotki</b> &ge; <b>Średnica przelotki</b><br>"
-
-#~ msgid "%s: <b>Via Drill</b> &lt; <b>Min Via Drill</b><br>"
-#~ msgstr ""
-#~ "%s: <b>Średnica otworu przelotki</b> &lt; <b>Min. średnica otworu "
-#~ "przelotki</b><br>"
-
-#~ msgid "%s: <b>MicroVia Diameter</b> &lt; <b>MicroVia Min Diameter</b><br>"
-#~ msgstr ""
-#~ "%s: <b>Średnica mikroprzelotki</b> &lt; <b>Min. średnica mikroprzelotki</"
-#~ "b><br>"
-
-#~ msgid "%s: <b>MicroVia Drill</b> &ge; <b>MicroVia Dia</b><br>"
-#~ msgstr ""
-#~ "%s: <b>Średnica otworu mikroprzelotki</b> &ge; <b>Średnica "
-#~ "mikroprzelotki</b><br>"
-
-#~ msgid "%s: <b>MicroVia Drill</b> &lt; <b>MicroVia Min Drill</b><br>"
-#~ msgstr ""
-#~ "%s: <b>Średnica otworu mikroprzelotki</b> &lt; <b>Min. średnica otworu "
-#~ "mikroprzelotki</b><br>"
-
-#~ msgid "Membership:"
-#~ msgstr "Lista powiązań:"
-
-#~ msgid "<< Select All"
-#~ msgstr "<< Wybierz wszystkie"
-
-#~ msgid "Select All >>"
-#~ msgstr "Wybierz wszystkie >>"
-
-#~ msgid "Via Options:"
-#~ msgstr "Opcje przelotek:"
-
-#~ msgid "Do not allow blind/buried vias"
-#~ msgstr "Ślepe/zagrzebane przelotki niedozwolone"
-
-#~ msgid "Blind/buried Vias:"
-#~ msgstr "Przelotki ślepe/zagrzebane:"
-
-#~ msgid ""
-#~ "Allows or not blind/buried vias.\n"
-#~ "Do not allow is the usual selection.\n"
-#~ "Note: micro vias are a special type of blind vias and are not managed here"
-#~ msgstr ""
-#~ "Pozwala lub zabrania użycia przelotek ślepych/zagrzebanych.\n"
-#~ "Domyślnie opcja ta jest ustawiona by stawianie takich przelotek było "
-#~ "zabronione.\n"
-#~ "Uwaga: mikroprzelotki to specjalny typ ślepych przelotek i ich ustawienia "
-#~ "są w innym miejscu."
-
-#~ msgid "Do not allow micro vias"
-#~ msgstr "Mikroprzelotki niedozwolone"
-
-#~ msgid "Allow micro vias"
-#~ msgstr "Mikroprzelotki dozwolone"
-
-#~ msgid "Micro Vias:"
-#~ msgstr "Mikroprzelotki:"
-
-#~ msgid ""
-#~ "Allows or do not allow use of micro vias\n"
-#~ "They are very small vias only from an external copper layer to its near "
-#~ "neightbour"
-#~ msgstr ""
-#~ "Pozwala (zabrania) na używanie mikroprzelotek\n"
-#~ "Są to bardzo małe przelotki z zewnętrznej warstwy ścieżek do jej "
-#~ "najbliższego sąsiada"
-
-#~ msgid "Minimum Allowed Values:"
-#~ msgstr "Dopuszczalna wartość minimalna:"
-
-#~ msgid "Min track width"
-#~ msgstr "Minimalna szerokość ścieżki"
-
-#~ msgid "Min via diameter"
-#~ msgstr "Min. średnica przelotki"
-
-#~ msgid "Min via drill dia"
-#~ msgstr "Min. rozmiar otworu przelotki"
-
-#~ msgid "Min uvia diameter"
-#~ msgstr "Min. średnica mikroprzelotki"
-
-#~ msgid "Min uvia drill dia"
-#~ msgstr "Min. średnica otworu mikroprzelotki"
-
-#~ msgid ""
-#~ "Specific via diameters and track widths, which \n"
-#~ "can be used to replace default Netclass values \n"
-#~ "on demand, for arbitrary vias or track segments."
-#~ msgstr ""
-#~ "Określa średnice przelotek i szerokości ścieżek, które mogą być\n"
-#~ "na żądanie użyte do zamiany domyślnych wartości z klas połączeń\n"
-#~ "dla wybranych segmentów ścieżek lub przelotek."
-
-#~ msgid "Text Width"
-#~ msgstr "Szerokość tekstu"
-
-#~ msgid "Text Height"
-#~ msgstr "Wysokość tekstu"
-
-#~ msgid "Text Position X"
-#~ msgstr "Pozycja X tekstu"
-
-#~ msgid "Text Position Y"
-#~ msgstr "Pozycja Y tekstu"
-
-#~ msgid "Tracks and Vias:"
-#~ msgstr "Ścieżki i przelotki:"
-
-#~ msgid "Show vias in sketch mode"
-#~ msgstr "Pokaż tylko zarys przelotek"
-
-#~ msgid "Defined holes"
-#~ msgstr "Otwory zdefiniowane"
-
-#~ msgid "Show Via Holes:"
-#~ msgstr "Pokaż otwory przelotek:"
-
-#~ msgid ""
-#~ "Show or hide via holes.\n"
-#~ "If Defined Holes is selected, only the non default size holes are shown"
-#~ msgstr ""
-#~ "Pokaż lub ukryj otwory przelotek.\n"
-#~ "Jeśli opcja 'Zdefiniowne otowry' jest aktywna, pokazywane są tylko otwory "
-#~ "niestandardowe"
-
-#~ msgid "Routing Help:"
-#~ msgstr "Pomoc w trasowaniu:"
-
-#~ msgid "Show Net Names:"
-#~ msgstr "Pokaż nazwy sieci:"
-
-#~ msgid "Show or hide net names on pads and/or tracks"
-#~ msgstr "Pokazuj lub ukryj nazwy sieci na polach i ścieżkach"
-
-#~ msgid "Show Track Clearance:"
-#~ msgstr "Pokaż prześwit ścieżek:"
-
-#~ msgid ""
-#~ "Show or hide the track and via clearance area.\n"
-#~ "If New track is selected,  track clearance area is shown only when "
-#~ "creating the track."
-#~ msgstr ""
-#~ "Pokazuj lub ukryj obszar prześwitu ścieżek.\n"
-#~ "Jeśli wybrano nową ścieżkę, prześwit jest pokazywany tylko podczasj jej "
-#~ "tworzenia."
-
-#~ msgid "Show text in sketch mode"
-#~ msgstr "Pokaż tylko zarys tekstu"
-
-#~ msgid "Show pads in sketch mode"
-#~ msgstr "Pokaż tylko zarys pól lutowniczych"
-
-#~ msgid "Show pad number"
-#~ msgstr "Pokaż numer pola"
-
-#~ msgid "Other:"
-#~ msgstr "Pozostałe:"
-
-#~ msgid "Show graphic items in sketch mode"
-#~ msgstr "Pokaż tylko zarys elementów graficznych"
-
-#~ msgid "DRC report files (.rpt)|*.rpt"
-#~ msgstr "Plik raportu DRC (.rpt)|*.rpt"
-
-#~ msgid "Min via size"
-#~ msgstr "Min. rozmiar przelotki"
-
-#~ msgid "Min uVia size"
-#~ msgstr "Min. rozmiar mikroprzelotki"
-
-#~ msgid ""
-#~ "Use this attribute for most non SMD components\n"
-#~ "Components with this option are not put in the footprint position list "
-#~ "file"
-#~ msgstr ""
-#~ "Użyj tego atrybutu dla większości komponentów nie będących elementami "
-#~ "SMD.\n"
-#~ "Tylko komponenty z tą opcją są umieszczone na liście położeń footprintów"
-
-#~ msgid ""
-#~ "Use this attribute for SMD components.\n"
-#~ "Only components with this option are put in the footprint position list "
-#~ "file"
-#~ msgstr ""
-#~ "Użyj tego atrybutu dla komponentów SMD.\n"
-#~ "Tylko komponenty z tą opcją są umieszczone na liście położeń footprintów"
-
-#~ msgid ""
-#~ "Use this attribute for \"virtual\" components drawn on board\n"
-#~ "(like a old ISA PC bus connector)"
-#~ msgstr ""
-#~ "Użyj tego atrybutu dla \"wirtualnych\" komponentów rysowanych na płytce "
-#~ "ze ścieżek lub pól lutowniczych\n"
-#~ " (jak na przykład złącza PCI na kartach rozszerzeń, pola kontaktowe, itp.)"
-
-#~ msgid "3D Shape:"
-#~ msgstr "Kształt 3D:"
-
-#~ msgid "Use a path relative to '%s'?"
-#~ msgstr "Użyć ścieżki względnej w stosunku do '%s'?"
-
-#~ msgid "Rotation (in 0.1 degrees):"
-#~ msgstr "Obrót (co 0.1 stopnia):"
-
-#~ msgid "Change Footprint(s)"
-#~ msgstr "Zamień footprint(y)"
-
-#~ msgid "Normal+Insert"
-#~ msgstr "Normalny+Wstawianie"
-
-#~ msgid "Default Path (from KISYS3DMOD environment variable)"
-#~ msgstr "Domyślna ścieżka (ze zmiennej systemowej KISYS3DMOD)"
-
-#~ msgid "3D Scale and Position"
-#~ msgstr "Skala 3D i pozycja"
-
-#~ msgid "Shape Scale:"
-#~ msgstr "Skala kształtu:"
-
-#~ msgid "Shape Offset (inch):"
-#~ msgstr "Przesunięcie kształtu (w calach):"
-
-#~ msgid "Shape Rotation (degrees):"
-#~ msgstr "Obrót kształtu (w stopniach):"
-
-#~ msgid "3D settings"
-#~ msgstr "Ustawienia 3D"
-
-#~ msgid "Use this attribute for most non SMD components"
-#~ msgstr ""
-#~ "Użyj tego atrybutu dla większości komponentów nie montowanych techniką SMD"
-
-#~ msgid ""
-#~ "Use this attribute for \"virtual\" components drawn on board (like a old "
-#~ "ISA PC bus connector)"
-#~ msgstr ""
-#~ "Użyj tego atrybutu dla \"wirtualnych\" komponentów rysowanych na płytce "
-#~ "(jak stare złącze ISA PC)"
-
-#~ msgid ""
-#~ "Error:\n"
-#~ "one of invalid chars <%s> found\n"
-#~ "in <%s>"
-#~ msgstr ""
-#~ "Błąd:\n"
-#~ "Znaleziono jeden z nieprawidłowych znaków <%s>\n"
-#~ "w <%s>"
-
-#~ msgid "Footprint Name in Library"
-#~ msgstr "Nazwa footprintu w bibliotece"
-
-#~ msgid "Offset X"
-#~ msgstr "Przesunięcie X"
-
-#~ msgid "Offset Y"
-#~ msgstr "Przesunięcie Y"
-
-#~ msgid "Component value"
-#~ msgstr "Wartość"
-
-#~ msgid "Component reference"
-#~ msgstr "Odnośnik"
-
-#~ msgid "Change footprint"
-#~ msgstr "Zamień footprint"
-
-#~ msgid "Change footprints"
-#~ msgstr "Zamień footprinty"
-
-#~ msgid "Change footprints having same value"
-#~ msgstr "Zamień footprinty posiadające tą samą wartość"
-
-#~ msgid "Update all footprints of the board"
-#~ msgstr "Uaktualnij footprinty na bieżącej płytce"
-
-#~ msgid "Export Footprint Association File"
-#~ msgstr "Eksportuj plik z przypisaniami footprintów"
-
-#~ msgid "List Footprints"
-#~ msgstr "Wykaz footprintów"
-
-#~ msgid "View Footprints"
-#~ msgstr "Pokaż footprinty"
-
-#~ msgid "Current footprint name (FPID)"
-#~ msgstr "Bieżąca nazwa footprintu (FPID)"
-
-#~ msgid "New footprint name (FPID)"
-#~ msgstr "Nowa nazwa footprintu (FPID)"
-
-#~ msgid "Grid Reference Point:"
-#~ msgstr "Punkt referencyjny siatki:"
-
-#~ msgid "Unable to create file '%s'"
-#~ msgstr "Nie mogę utworzyć pliku '%s'"
-
-#~ msgid "File Name:"
-#~ msgstr "Nazwa pliku:"
-
-#~ msgid "X Ref:"
-#~ msgstr "Ref. X:"
-
-#~ msgid "Y Ref:"
-#~ msgstr "Ref. Y:"
-
-#~ msgid "<%s> found"
-#~ msgstr "Znaleziono <%s>"
-
-#~ msgid "<%s> not found"
-#~ msgstr "Nie znaleziono <%s>"
-
-#~ msgid "Duplicate Nickname: '%s' in rows %d and %d"
-#~ msgstr "Zdublowana nazwa '%s' w rzędach %d i %d"
-
-#~ msgid "Options for Library '%s'"
-#~ msgstr "Opcje biblioteki '%s'"
-
-#~ msgid "Do you want to rebuild connectivity data ?"
-#~ msgstr "Czy chcesz odbudować bazę danych połączeń?"
-
-#~ msgid "Specctra DSN file:"
-#~ msgstr "Plik Specctra DSN:"
-
-#~ msgid "One file for board"
-#~ msgstr "Jednen plik na płytkę"
-
-#~ msgid "Use Netclasses values"
-#~ msgstr "Użyj wartości z klas sieci"
-
-#~ msgid ""
-#~ "Cannot make path relative.  The target volume is different from board "
-#~ "file volume!"
-#~ msgstr ""
-#~ "Nie można utworzyć ścieżki względnej. Wolumin docelowy jest różny od tego "
-#~ "gdzie znajduje się plik z płytką!"
-
-#~ msgid "Drill File Options:"
-#~ msgstr "Opcje pliku wierceń:"
-
-#~ msgid "Mirror y axis"
-#~ msgstr "Odbij w osi y"
-
-#~ msgid ""
-#~ "Not recommanded.\n"
-#~ "Used mostly by users who make themselves the boards."
-#~ msgstr ""
-#~ "Opcja nie zalecana.\n"
-#~ "Używana często przez użytkowników samodzielnie tworzących płytki."
-
-#~ msgid ""
-#~ "Not recommanded.\n"
-#~ "Use it only for board houses which do not accept fully featured headers."
-#~ msgstr ""
-#~ "Opcja nie zalecana.\n"
-#~ "Używana tylko w przypadku wytwórców płytek którzy nie akceptują pełnych "
-#~ "nagłówków plików."
-
-#~ msgid "Merge PTH and NPTH holes into one file"
-#~ msgstr "Połącz otwory PTH i NPTH w jednym pliku"
-
-#~ msgid ""
-#~ "Not recommanded.\n"
-#~ "Use it only for board houses which ask for merged PTH and NPTH into onlu "
-#~ "one file"
-#~ msgstr ""
-#~ "Opcja nie zalecana.\n"
-#~ "Użyj tylko gdy wytwórca płytek zażąda by oba rodzaje otworów znajdowały "
-#~ "się w jednym pliku."
-
-#~ msgid "Info:"
-#~ msgstr "Informacje:"
-
-#~ msgid "Default Vias Drill:"
-#~ msgstr "Domyślny otwór przelotek:"
-
-#~ msgid "Micro Via Drill Value"
-#~ msgstr "Wielkość otworu mikroprzelotki"
-
-#~ msgid "Plated Pads:"
-#~ msgstr "Punkty lut. pokryte:"
-
-#~ msgid "Not Plated Pads:"
-#~ msgstr "Punkty lut. bez pokrycia:"
-
-#~ msgid "Through Vias:"
-#~ msgstr "Przelotki na wylot:"
-
-#~ msgid "Buried Vias:"
-#~ msgstr "Przelotki zagrzebane:"
-
-#~ msgid "Drill File"
-#~ msgstr "Plik wierceń"
-
-#~ msgid "Map File"
-#~ msgstr "Mapa wierceń"
-
-#~ msgid "Report File"
-#~ msgstr "Plik raportu"
-
-#~ msgid ""
-#~ "Activates the display of relative coordinates from relative origin (set "
-#~ "by the space key)\n"
-#~ "to the cursor, in polar coordinates (angle and distance)"
-#~ msgstr ""
-#~ "Włącza wyświetlanie współrzędnych względnych w stosunku od punktu "
-#~ "bazowego (określonego klawiszem spacji)\n"
-#~ "do pozycji kursora w układzie współrzędnych polarnych (kąt/odległość)"
-
-#~ msgid "Selection of units used to display dimensions and positions of items"
-#~ msgstr ""
-#~ "Wybór jednostek miary używanych do pokazywania rozmiarów i pozycji "
-#~ "elementów"
-
-#~ msgid "Main cursor shape selection (small cross or large cursor)"
-#~ msgstr "Wybór kształtu głównego kursora (mały krzyż lub duży kursor)"
-
-#~ msgid "&Maximum links:"
-#~ msgstr "Łącz maksymalnie:"
-
-#~ msgid "Adjust the number of ratsnets shown from cursor to closest pads"
-#~ msgstr ""
-#~ "Ustaw liczbę połączeń wspomagających pokazywanych z pozycji kursora do "
-#~ "najbliższych pól lutowniczych"
-
-#~ msgid ""
-#~ "Delay after the first change to create a backup file of the board on disk."
-#~ msgstr ""
-#~ "Opóźnienie pomiędzy pierwszą zmianą w płytce a zapisem kopii zapasowej na "
-#~ "dysku."
-
-#~ msgid "Ma&ximum undo items:"
-#~ msgstr "Maksymalna głębokość cofania:"
-
-#~ msgid "Context menu and hot key footprint rotation increment."
-#~ msgstr "Krok rotacji footprintów, dla menu obrotu lub klawiszy skrótów."
-
-#~ msgid ""
-#~ "Enable/disable the DRC control.\n"
-#~ "When the DRC control is disabled, all connections are allowed."
-#~ msgstr ""
-#~ "Włącz/Wyłącz kontrolę DRC.\n"
-#~ "Gdy DRC jest wyłączone, wszystkie połączenia są dozwolone!"
-
-#~ msgid "Show (or not) the full rastnest."
-#~ msgstr "Pokaż (ukryj) pełną siatkę połączeń pomocniczych"
-
-#~ msgid "S&how footprint ratsnest"
-#~ msgstr "Pokaż połączenia wspomagające footprintu"
-
-#~ msgid ""
-#~ "Shows (or not) the local ratsnest relative to a footprint, when moving "
-#~ "it.\n"
-#~ "This ratsnest is useful to place a footprint."
-#~ msgstr ""
-#~ "Pokazuje (lub nie) lokalne połączenia wspomagające względem footprintu "
-#~ "podczas jego przesuwania.\n"
-#~ "Połączenia wspomagające są pomocne podczas ustawiania footprintów."
-
-#~ msgid "Enable/disable the automatic track deletion when recreating a track."
-#~ msgstr "Włącz/Wyłącz automatyczne usuwanie starych ścieżek."
-
-#~ msgid ""
-#~ "If enabled, force tracks directions to H, V or 45 degrees, when creating "
-#~ "a track."
-#~ msgstr ""
-#~ "Gdy włączone, wymusza tworzenie ścieżek tylko jako proste lub pod kątem "
-#~ "45 st."
-
-#~ msgid ""
-#~ "If enabled, force segments directions to H, V or 45 degrees, when "
-#~ "creating a segment on technical layers."
-#~ msgstr ""
-#~ "Gdy włączone, wymusza tworzenie segmentów na warstwach technologicznych "
-#~ "tylko jako proste lub pod kątem 45 st."
-
-#~ msgid ""
-#~ "If enabled, uses two track segments, with 45 degrees angle between them "
-#~ "when creating a new track "
-#~ msgstr ""
-#~ "Jeśli włączona, używa dwóch segmentów ścieżek, pochylonych wględem siebie "
-#~ "o 45 st. w trakcie tworzenia nowych ścieżek"
-
-#~ msgid ""
-#~ "control the capture of the pcb cursor when the mouse cursor enters a pad "
-#~ "area"
-#~ msgstr ""
-#~ "Kontrola przechwycenia kursora PCB, gdy wchodzi w obszar pola lutowniczego"
-
-#~ msgid ""
-#~ "Control the capture of the pcb cursor when the mouse cursor enters a track"
-#~ msgstr "Kontrola przechwycenia kursora PCB, gdy wchodzi w obszar ścieżki"
-
-#~ msgid "Use middle mouse &button to pan"
-#~ msgstr "Użyj środkowego klawisza myszy do przesuwania widoku"
-
-#~ msgid "Limi&t panning to scroll size"
-#~ msgstr "Panoramuj tylko do obszaru dającego się przesuwać"
-
-#~ msgid "Allows auto pan when creating a track, or moving an item."
-#~ msgstr ""
-#~ "Zezwalaj na przesuwanie widoku podczas tworzenia ścieżek lub przesuwania "
-#~ "elementów."
-
-#~ msgid "Advanced/Developer"
-#~ msgstr "Zaawansowane/Dla twórców"
-
-#~ msgid "Dump zone geometry to files when filling"
-#~ msgstr "Zapisuj geometrię strefy do pliku podczas jej wypełniania"
-
-#~ msgid "NetClassName"
-#~ msgstr "Nazwa klasy połączeń"
-
-#~ msgid "Set tracks and vias of the current Net to the current value"
-#~ msgstr ""
-#~ "Ustaw rozmiary ścieżek i przelotek bieżącej sieci do wartości bieżących"
-
-#~ msgid "Footprint Filter:"
-#~ msgstr "Filtr footprintów:"
-
-#~ msgid "Pad Editor"
-#~ msgstr "Edytor pól lutowniczych"
-
-#~ msgid "0.1 degree"
-#~ msgstr "0.1 stopni"
-
-#~ msgid ""
-#~ "The graphic item will be on a copper layer. This is very dangerous. Are "
-#~ "you sure?"
-#~ msgstr ""
-#~ "Element graficzny znajdzie się na warstwie ścieżek. To jest bardzo "
-#~ "niebezpieczne. Czy jesteś pewien?"
-
-#~ msgid "Hatched Outline"
-#~ msgstr "Linia kreskowa"
-
-#~ msgid "Full Hatched"
-#~ msgstr "Pełne kreskowanie"
-
-#~ msgid "Top/Front Layer"
-#~ msgstr "Warstwa górna/przednia"
-
-#~ msgid "Bottom/Back Layer"
-#~ msgstr "Warstwa dolna/tylna"
-
-#~ msgid "Layer name may not be empty"
-#~ msgstr "Nazwa warstwy nie może byc pusta"
-
-#~ msgid "'signal' is a reserved layer name"
-#~ msgstr "'signal' jest zastrzeżoną nazwą warstwy"
-
-#~ msgid "Layer name is a duplicate of another"
-#~ msgstr "Nazwa warstwy jest kopią innej nazwy warstwy"
-
-#~ msgid "Text line width"
-#~ msgstr "Grubość linii tekstu"
-
-#~ msgid "General options:"
-#~ msgstr "Opcje główne:"
-
-#~ msgid "Save contents of message window"
-#~ msgstr "Zapisz zawartość okna z wiadomościami"
-
-#~ msgid "File Write Error"
-#~ msgstr "Błąd zapisu pliku"
-
-#~ msgid "Unconnected Tracks"
-#~ msgstr "Niepołączone ścieżki:"
-
-#~ msgid "Keep or delete bad tracks after a netlist change"
-#~ msgstr "Zachowaj lub usuń błędne ścieżki po zmianach w liście sieci"
-
-#~ msgid "Read the current neltist file and list missing and extra footprints"
-#~ msgstr ""
-#~ "Wczytaj bieżącą netlistę i wypisz brakujące lub dodatkowe footprinty"
-
-#~ msgid ""
-#~ "Rebuild the full ratsnest (usefull after a manual pad netname edition)"
-#~ msgstr ""
-#~ "Odbuduj pełne połączenia (użyteczne po ręcznej zmianie nazwy sieci pola "
-#~ "lut.)"
-
-#~ msgid "Save Messages to File"
-#~ msgstr "Zapisz wiadomości do pliku"
-
-#~ msgid "Netlist File:"
-#~ msgstr "Plik listy sieci:"
-
-#~ msgid "Zone Edges Orient"
-#~ msgstr "Orientacja krawędzi strefy"
-
-#~ msgid "Outlines Appearence"
-#~ msgstr "Wygląd obrysów"
-
-#~ msgid "Zone min thickness value"
-#~ msgstr "Minimalna szerokość strefy"
-
-#~ msgid "OK to set footprints orientation to %.1f degrees ?"
-#~ msgstr "Czy ustawić orientację footprintów na %.1f stopni?"
-
-#~ msgid "Bad value for footprints orientation"
-#~ msgstr "Zła wartość orientacji footprintów"
-
-#~ msgid "New orientation (0.1 degree resolution)"
-#~ msgstr "Nowa orientacja (rozdzielczość 0.1 stopnia)"
-
-#~ msgid "Filter to select footprints by reference"
-#~ msgstr "Filtruj, aby wybrać footprinty według oznaczenia"
-
-#~ msgid "Include Locked Footprints"
-#~ msgstr "Dołącz zablokowane footprinty"
-
-#~ msgid "Force locked footprints to be modified"
-#~ msgstr "Wymuś zmianę zablokowanych footprintów"
-
-#~ msgid "0.1 deg"
-#~ msgstr "0,1 st."
-
-#~ msgid "Trapezoid direction:"
-#~ msgstr "Kierunek:"
-
-#~ msgid "Parent footprint orientation"
-#~ msgstr "Nadrzędna orientacja footprintu"
-
-#~ msgid "Board side:"
-#~ msgstr "Strona płytki:"
-
-#~ msgid "Circular hole"
-#~ msgstr "Okrągły otwór"
-
-#~ msgid "Oval hole"
-#~ msgstr "Owalny otwór"
-
-#~ msgid "Technical Layers"
-#~ msgstr "Warstwy techniczne"
-
-#~ msgid "Copper Zones"
-#~ msgstr "Pola miedzi"
-
-#~ msgid ""
-#~ "Warning:\n"
-#~ "This pad is flipped on board.\n"
-#~ "Back and front layers will be swapped."
-#~ msgstr ""
-#~ "Ostrzeżenie:\n"
-#~ "Te pole lutownicze jest obrócone na płytce.\n"
-#~ "Strony dolna i górna będą zamienione."
-
-#~ msgid "Orientation (0.1 deg):"
-#~ msgstr "Orientacja (co 0.1 stopnia):"
-
-#~ msgid "HPGL pen overlay constrained."
-#~ msgstr "Pokrycie pisaka HPGL ograniczone."
-
-#~ msgid "Plot file '%s' created."
-#~ msgstr "Plik rysunkowy '%s' został utworzony."
-
-#~ msgid "Plot pads on silkscreen"
-#~ msgstr "Rysuj pola lutownicze na war. opisowej"
-
-#~ msgid ""
-#~ "Enable plotting of pads on silkscreen layers\n"
-#~ "When disabled, pads are never plotted on silkscreen layers\n"
-#~ "When enabled, pads are plotted only if they appear on silkscreen layers"
-#~ msgstr ""
-#~ "Włącza/wyłącza wydruk/rysowanie pól lutowniczych na warstwach opisowych\n"
-#~ "Gdy wyłączone, pola lutownicze nie są nigdy rysowane na warstwach "
-#~ "opisowych\n"
-#~ "Gdy włączone, pola lutownicze są rysowane tylko jesli występują na "
-#~ "warstwach opisowych"
-
-#~ msgid "Exclude contents of the pcb edge layer from all other layers"
-#~ msgstr "Wyłącz zawartość warstwy krawędzi PCB na pozostałych warstwach"
-
-#~ msgid "Default line width"
-#~ msgstr "Domyślna szerokość linii"
-
-#~ msgid "Current solder mask settings:"
-#~ msgstr "Bieżące ustawienia soldermaski:"
-
-#~ msgid "Use conventional Protel Gerber extensions - .GBL, .GTL, etc..."
-#~ msgstr ""
-#~ "Użyj sugerowanych przez Protel rozszerzeń dla plików Gerber - .GBL, .GTL, "
-#~ "itd..."
-
-#~ msgid "Include extended attributes"
-#~ msgstr "Dołącz atrybuty z listy rozszerzonej"
-
-#~ msgid ""
-#~ "Include extended attributes (X2 Gerber files format) in the Gerber file"
-#~ msgstr ""
-#~ "Użyj rozszerzonych atrybutów (pliki w formacie X2 Gerber) w pliku Gerber"
-
-#~ msgid "4.5 (unit mm)"
-#~ msgstr "4.5 (w mm)"
-
-#~ msgid "4.6 (unit mm)"
-#~ msgstr "4.6 (w mm)"
-
-#~ msgid "Pen overlay"
-#~ msgstr "Pokrycie pisaka"
-
-#~ msgid "Set plot overlay for filling"
-#~ msgstr "Ustaw pokrycie rysunku do wypełnienia"
-
-#~ msgid "move item"
-#~ msgstr "Przesuń element"
-
-#~ msgid "interactive drag"
-#~ msgstr "Przeciągnij interaktywnie"
-
-#~ msgid "Automatic neckdown"
-#~ msgstr "Automatycznie zwężaj"
-
-#~ msgid "Exclude Edges_Pcb Layer"
-#~ msgstr "Pomiń warstwę krawędzi PCB"
-
-#~ msgid "Pads Drill Opt"
-#~ msgstr "Opcje wiercenia pól lutowniczych"
-
-#~ msgid "1 Page per Layer"
-#~ msgstr "1 strona na warstwę"
-
-#~ msgid "http://github.com/KiCad"
-#~ msgstr "http://github.com/KiCad"
-
-#~ msgid ""
-#~ "Error:\n"
-#~ "'%s'\n"
-#~ "while downloading library:\n"
-#~ "'%s'"
-#~ msgstr ""
-#~ "Błąd:\n"
-#~ "'%s'\n"
-#~ "podczas pobierania biblioteki:\n"
-#~ "'%s'"
-
-#~ msgid "Compile ratsnest...\n"
-#~ msgstr "Kompilacja połączeń wspomagających...\n"
-
-#~ msgid "NETCLASS: '%s' has Clearance:%s which is less than global:%s"
-#~ msgstr ""
-#~ "Klasy połączeń: '%s' posiada prześwit:%s który jest mniejszy niż domyślny:"
-#~ "%s"
-
-#~ msgid "NETCLASS: '%s' has TrackWidth:%s which is less than global:%s"
-#~ msgstr ""
-#~ "Klasy połączeń: '%s' posiada szerokość:%s która jest mniejsza niż "
-#~ "domyślna:%s"
-
-#~ msgid "NETCLASS: '%s' has Via Dia:%s which is less than global:%s"
-#~ msgstr ""
-#~ "Klasy połączeń: przelotka '%s' posiada średnicę:%s która jest mniejsza "
-#~ "niż domyślna:%s"
-
-#~ msgid "NETCLASS: '%s' has Via Drill:%s which is less than global:%s"
-#~ msgstr ""
-#~ "Klasy połączeń: przelotka '%s' posiada otwór:%s który jest mniejszy niż "
-#~ "domyślny:%s"
-
-#~ msgid "NETCLASS: '%s' has uVia Dia:%s which is less than global:%s"
-#~ msgstr ""
-#~ "Klasy połączeń: mikroprzelotka '%s' posiada średnicę:%s która jest "
-#~ "mniejsza niż domyślna:%s"
-
-#~ msgid "NETCLASS: '%s' has uVia Drill:%s which is less than global:%s"
-#~ msgstr ""
-#~ "Klasy połączeń: mikroprzelotka '%s' posiada otwór:%s który jest mniejszy "
-#~ "niż domyślny:%s"
-
-#~ msgid "<package> name: '%s' duplicated in eagle <library>: '%s'"
-#~ msgstr ""
-#~ "Nazwa footprintu '%s' została zduplikowana w bibliotece programu Eagle: "
-#~ "'%s'"
-
-#~ msgid "No '%s' package in library '%s'"
-#~ msgstr "Nie ma obudowy '%s' w bibliotece '%s'"
-
-#~ msgid "File '%s' is not readable."
-#~ msgstr "Nie jest możliwe odczytanie pliku '%s'."
-
-#~ msgid "IPC-D-356 Test Files (.d356)|*.d356"
-#~ msgstr "Pliki testowe IPC-D-356 (.d356)|*.d356"
-
-#~ msgid "GenCAD 1.4 board files (.cad)|*.cad"
-#~ msgstr "Pliki płytek GenCAD 1.4 (.cad)|*.cad"
-
-#~ msgid ""
-#~ "Unable to calculate the board outlines;\n"
-#~ "fall back to using the board boundary box."
-#~ msgstr ""
-#~ "Nie można obliczyć obrysu płytki.\n"
-#~ "Użyte zostanie pole obliczone na podstawie zawartości płytki."
-
-#~ msgid ""
-#~ "VRML Export Failed:\n"
-#~ "Could not add holes to contours."
-#~ msgstr ""
-#~ "Eksportowanie do VRML się nie powiodło:\n"
-#~ "Nie można dodać otworów do konturów."
-
-#~ msgid "Unable to create '%s'."
-#~ msgstr "Nie mogę utworzyć '%s'."
-
-#~ msgid "Place file: '%s'."
-#~ msgstr "Plik położeń footprintów: '%s'."
-
-#~ msgid "Front side (top side) place file: '%s'."
-#~ msgstr "Plik położeń footprintów, strona elementów (górna): '%s'."
-
-#~ msgid "Componment Placement File generation OK."
-#~ msgstr "Plik położeń footprintów został poprawnie wygenerowany."
-
-#~ msgid "Back side (bottom side) place file: '%s'."
-#~ msgstr "Plik położeń footprintów, strona ścieżek (dolna): '%s'."
-
-#~ msgid ""
-#~ "Footprint report file created:\n"
-#~ "'%s'"
-#~ msgstr ""
-#~ "Utworzono plik raportu o footprintach:\n"
-#~ "'%s'"
-
-#~ msgid "Unable to create '%s'"
-#~ msgstr "Nie mogę utworzyć '%s'"
-
-#~ msgid "Recovery file '%s' not found."
-#~ msgstr "Plik odtworzeniowy '%s' nie został znaleziony."
-
-#~ msgid "OK to load recovery or backup file '%s'"
-#~ msgstr ""
-#~ "Nacisnij OK by załadować dane odtworzeniowe lub plik kopii zapasowej '%s'"
-
-#~ msgid "PCB file '%s' is already open."
-#~ msgstr "Plik PCB '%s' jest już otwarty."
-
-#~ msgid "Board '%s' does not exist.  Do you wish to create it?"
-#~ msgstr "Płytka '%s' nie istnieje. Czy chcesz ją utworzyć?"
-
-#~ msgid "Warning: unable to create backup file '%s'"
-#~ msgstr "Ostrzeżenie: Nie można utworzyć pliku kopii zapasowej '%s'"
-
-#~ msgid "No access rights to write to file '%s'"
-#~ msgstr "Brak uprawnień do zapisu do pliku '%s'"
-
-#~ msgid ""
-#~ "Error saving board file '%s'.\n"
-#~ "%s"
-#~ msgstr ""
-#~ "Błąd podczas zapisywania płytki '%s'.\n"
-#~ "%s"
-
-#~ msgid "Failed to create '%s'"
-#~ msgstr "Błąd przy tworzeniu '%s'"
-
-#~ msgid "Backup file: '%s'"
-#~ msgstr "Plik kopii zapasowej: '%s'"
-
-#~ msgid "Wrote board file: '%s'"
-#~ msgstr "Zapisuję plik płytki: '%s'"
-
-#~ msgid ""
-#~ "Board copied to:\n"
-#~ "'%s'"
-#~ msgstr ""
-#~ "PCB skopiowane do:\n"
-#~ "'%s'"
-
-#~ msgid "Select the wizard script to load and run"
-#~ msgstr "Wybierz skrypt kreatora do uruchomienia"
-
-#~ msgid "Export the footprint to the editor"
-#~ msgstr "Eksportuje footprint do edytora footprintów"
-
-#~ msgid ""
-#~ "malformed URL:\n"
-#~ "'%s'"
-#~ msgstr ""
-#~ "Nie mogę rozpoznać adresu URL:\n"
-#~ "'%s'"
-
-#~ msgid ""
-#~ "Footprint\n"
-#~ "'%s'\n"
-#~ "is not in the writable portion of this Github library\n"
-#~ "'%s'"
-#~ msgstr ""
-#~ "Footprint\n"
-#~ "'%s'\n"
-#~ "nie jest w zapisywalnej części tej biblioteki GitHub\n"
-#~ "'%s'"
-
-#~ msgid ""
-#~ "option '%s' for Github library '%s' must point to a writable directory "
-#~ "ending with '.pretty'."
-#~ msgstr ""
-#~ "opcja '%s' dla biblioteki GitHub '%s' musi wskazywać na zapisywalny "
-#~ "katalog zakończony przez '.pretty'."
-
-#~ msgid ""
-#~ "Unable to parse URL:\n"
-#~ "'%s'"
-#~ msgstr ""
-#~ "Nie mogę rozpoznać adresu URL:\n"
-#~ "'%s'"
-
-#~ msgid ""
-#~ "%s\n"
-#~ "Cannot get/download Zip archive: '%s'\n"
-#~ "for library path: '%s'.\n"
-#~ "Reason: '%s'"
-#~ msgstr ""
-#~ "%s\n"
-#~ "Nie mogę pobrać archiwum Zip: '%s'\n"
-#~ "dla ścieżki biblioteki: '%s'.\n"
-#~ "Powód: '%s'"
-
-#~ msgid "Exception '%s' in avhttp while open()-ing URI:'%s'"
-#~ msgstr "Wyjątek '%s' w avhttp podczas funkcji open() z URI:'%s'"
-
-#~ msgid ""
-#~ "%s\n"
-#~ "Cannot get/download data from: '%s'\n"
-#~ "Reason: '%s'"
-#~ msgstr ""
-#~ "%s\n"
-#~ "Nie mogę pobrać danych z: '%s'\n"
-#~ "Powód: '%s'"
-
-#~ msgid "footprint library path '%s' does not exist"
-#~ msgstr "ścieżka do biblioteki '%s' nie istnieje"
-
-#~ msgid "library <%s> has no footprint '%s' to delete"
-#~ msgstr "biblioteka <%s> nie posiada footprintu '%s' by go usunąć"
-
-#~ msgid "Library '%s' is read only"
-#~ msgstr "Biblioteka '%s' jest oznaczona jako tylko do odczytu"
-
-#~ msgid "user does not have permission to delete directory '%s'"
-#~ msgstr "użytkownik nie ma wystarczających uprawnień by usunąć folder '%s'"
-
-#~ msgid "library directory '%s' has unexpected sub-directories"
-#~ msgstr "folder z biblioteką '%s' zawiera niepożądane podfoldery"
-
-#~ msgid "unexpected file '%s' was found in library path '%s'"
-#~ msgstr "został znaleziony niepożądany plik '%s' w ścieżce bibliotek '%s'"
-
-#~ msgid "footprint library '%s' cannot be deleted"
-#~ msgstr "biblioteka footprintów '%s' nie może zostać usunięta"
-
-#~ msgid "Filter Net Names"
-#~ msgstr "Filtruj nazwy sieci"
-
-#~ msgid "Net Filter"
-#~ msgstr "Filtr sieci"
-
-#~ msgid "Select Net"
-#~ msgstr "Wybierz sieć"
-
-#~ msgid "Save Board"
-#~ msgstr "Zapisz płytkę"
-
-#~ msgid "Save Board As"
-#~ msgstr "Zapisz PCB jako"
-
-#~ msgid "Load Board"
-#~ msgstr "Załaduj PCB"
-
-#~ msgid "Switch to Default Canvas"
-#~ msgstr "Przełącz w tryb normalny"
-
-#~ msgid "Switch to OpenGL Canvas"
-#~ msgstr "Przełącz w tryb OpenGL"
-
-#~ msgid "Switch to Cairo Canvas"
-#~ msgstr "Przełącz w tryb Cairo"
-
-#~ msgid "Record Macro 0"
-#~ msgstr "Nagraj makro 0"
-
-#~ msgid "Call Macro 0"
-#~ msgstr "Wywołaj makro 0"
-
-#~ msgid "Record Macro 1"
-#~ msgstr "Nagraj makro 1"
-
-#~ msgid "Call Macro 1"
-#~ msgstr "Wywołaj makro 1"
-
-#~ msgid "Record Macro 2"
-#~ msgstr "Nagraj makro 2"
-
-#~ msgid "Call Macro 2"
-#~ msgstr "Wywołaj makro 2"
-
-#~ msgid "Record Macro 3"
-#~ msgstr "Nagraj makro 3"
-
-#~ msgid "Call Macro 3"
-#~ msgstr "Wywołaj makro 3"
-
-#~ msgid "Record Macro 4"
-#~ msgstr "Nagraj makro 4"
-
-#~ msgid "Call Macro 4"
-#~ msgstr "Wywołaj makro 4"
-
-#~ msgid "Record Macro 5"
-#~ msgstr "Nagraj makro 5"
-
-#~ msgid "Call Macro 5"
-#~ msgstr "Wywołaj makro 5"
-
-#~ msgid "Record Macro 6"
-#~ msgstr "Nagraj makro 6"
-
-#~ msgid "Call Macro 6"
-#~ msgstr "Wywołaj makro 6"
-
-#~ msgid "Record Macro 7"
-#~ msgstr "Nagraj makro 7"
-
-#~ msgid "Call Macro 7"
-#~ msgstr "Wywołaj makro 7"
-
-#~ msgid "Record Macro 8"
-#~ msgstr "Nagraj makro 8"
-
-#~ msgid "Call Macro 8"
-#~ msgstr "Wywołaj makro 8"
-
-#~ msgid "Record Macro 9"
-#~ msgstr "Nagraj makro 9"
-
-#~ msgid "Call Macro 9"
-#~ msgstr "Wywołaj makro 9"
-
-#~ msgid "Recording macro %d"
-#~ msgstr "Nagrywanie makra %d"
-
-#~ msgid "Macro %d recorded"
-#~ msgstr "Makro %d zostało nagrane"
-
-#~ msgid "Call macro %d"
-#~ msgstr "Wywołaj makro %d"
-
-#~ msgid "Add key [%c] in macro %d"
-#~ msgstr "Przypisz klawisz [%c] do makra %d"
-
-#~ msgid "Place DXF origin (0,0) point:"
-#~ msgstr "Punkt początkowy (0, 0) dla DXF:"
-
-#~ msgid "Plugin '%s' does not implement the '%s' function."
-#~ msgstr "Wtyczka '%s' nie posiada zaimplementowanej funkcji '%s'."
-
-#~ msgid "Plugin type '%s' is not found."
-#~ msgstr "Wtyczka typu '%s' nie została znaleziona."
-
-#~ msgid ""
-#~ "invalid footprint ID in\n"
-#~ "file: <%s>\n"
-#~ "line: %d\n"
-#~ "offset: %d"
-#~ msgstr ""
-#~ "niepoprawny ID w\n"
-#~ "plik: <%s>\n"
-#~ "linia: %d:\n"
-#~ "przesunięcie: %d"
-
-#~ msgid "Cannot create footprint library path '%s'"
-#~ msgstr "Nie można utworzyć ścieżki '%s' do biblioteki footprintów"
-
-#~ msgid "Footprint library path '%s' is read only"
-#~ msgstr "Biblioteka '%s' jest oznaczona jako tylko do odczytu"
-
-#~ msgid "Cannot rename temporary file '%s' to footprint library file '%s'"
-#~ msgstr ""
-#~ "Nie mogę zmienić nazwy pliku tymczasowego '%s' na nazwę pliku biblioteki "
-#~ "'%s'"
-
-#~ msgid "Footprint library path '%s' does not exist"
-#~ msgstr "Ścieżka do biblioteki '%s' nie istnieje"
-
-#~ msgid "library '%s' has no footprint '%s' to delete"
-#~ msgstr "biblioteka '%s' nie posiada footprintu '%s' by go usunąć"
-
-#~ msgid "user does not have write permission to delete file '%s' "
-#~ msgstr "użytkownik nie ma wystarczających uprawnień do usunięcia pliku '%s'"
-
-#~ msgid "cannot overwrite library path '%s'"
-#~ msgstr "nie mogę nadpisać biblioteki '%s'"
-
-#~ msgid ""
-#~ "Left click to select, middle click for color change, right click for menu"
-#~ msgstr ""
-#~ "Kliknij lewym by zaznaczyć, środkowym by zmienić kolor, prawym by wywołać "
-#~ "menu"
-
-#~ msgid "Middle click for color change"
-#~ msgstr "Zmiana koloru środkowym klawiszem"
-
-#~ msgid "Cannot parse time stamp in component section of netlist."
-#~ msgstr ""
-#~ "Nie mogę przetworzyć odcisku czasowego w sekcji komponentów listy sieci."
-
-#~ msgid "Cannot parse footprint name in component section of netlist."
-#~ msgstr ""
-#~ "Nie mogę przetworzyć nazwy footprintu w seckcji komponentów listy sieci."
-
-#~ msgid "Cannot parse reference designator in component section of netlist."
-#~ msgstr "Nie mogę przetworzyć odnośnika w sekcji komponentów listy sieci."
-
-#~ msgid "Cannot parse value in component section of netlist."
-#~ msgstr "Nie mogę przetworzyć wartości w sekcji komponentów listy sieci."
-
-#~ msgid "Cannot parse pin name in component net section of netlist."
-#~ msgstr "Nie mogę przetworzyć nazwy pinu w seckcji komponentów listy sieci."
-
-#~ msgid "Cannot parse net name in component net section of netlist."
-#~ msgstr "Nie mogę przetworzyć nazwy sieci w sekcji komponentów listy sieci."
-
-#~ msgid "Cannot find component '%s' in footprint filter section of netlist."
-#~ msgstr ""
-#~ "Nie mogę odnależć komponentu '%s' w sekcji filtrów footprintów listy "
-#~ "sieci."
-
-#~ msgid ""
-#~ "File '%s' is format version: %d.\n"
-#~ "I only support format version <= %d.\n"
-#~ "Please upgrade Pcbnew to load this file."
-#~ msgstr ""
-#~ "Plik '%s' jest w formacie pochodzącym z wersji: %d.\n"
-#~ "Ta wersja wspiera tylko formaty <= %d.\n"
-#~ "Proszę uaktualnić Pcbnew by móc załadować ten plik."
-
-#~ msgid "Unknown sheet type '%s' on line:%d"
-#~ msgstr "Nieznany typ arkusza '%s' w lini:%d"
-
-#~ msgid "Unknown padshape '%c=0x%02x' on line: %d of footprint: '%s'"
-#~ msgstr ""
-#~ "Nieznany kształt pola lutowniczego '%c=0x%02x' w lini: %d footprintu: '%s'"
-
-#~ msgid "duplicate NETCLASS name '%s'"
-#~ msgstr "zduplikowana nazwa Klasy Sieci '%s'"
-
-#~ msgid ""
-#~ "invalid float number in file: '%s'\n"
-#~ "line: %d, offset: %d"
-#~ msgstr ""
-#~ "niepoprawna liczba typu float w pliku: '%s'\n"
-#~ "linia: %d, przesunięcie: %d"
-
-#~ msgid ""
-#~ "missing float number in file: '%s'\n"
-#~ "line: %d, offset: %d"
-#~ msgstr ""
-#~ "brak liczby typu float w pliku: '%s'\n"
-#~ "linia: %d, przesunięcie: %d"
-
-#~ msgid "Unable to open file '%s'"
-#~ msgstr "Nie mogę otworzyć pliku '%s'"
-
-#~ msgid "File '%s' is empty or is not a legacy library"
-#~ msgstr "Plik '%s' jest pusty lub nie jest plikiem biblioteki starszego typu"
-
-#~ msgid "Legacy library file '%s' is read only"
-#~ msgstr ""
-#~ "Plik biblioteki starszego typu '%s' jest oznaczony jako 'Tylko do "
-#~ "odczytu'."
-
-#~ msgid "Unable to open or create legacy library file '%s'"
-#~ msgstr "Nie mogę otworzyć ani utworzyć biblioteki starszego typu '%s'"
-
-#~ msgid "Unable to rename tempfile '%s' to library file '%s'"
-#~ msgstr ""
-#~ "Nie mogę zmienić nazwy pliku tymczasowego '%s' na nazwę pliku biblioteki "
-#~ "'%s'"
-
-#~ msgid "library '%s' already exists, will not create a new"
-#~ msgstr "biblioteka '%s' już istnieje, nie można stworzyć nowej"
-
-#~ msgid "library '%s' cannot be deleted"
-#~ msgstr "biblioteka '%s' nie może zostać usunięta"
-
-#~ msgid "Library '%s' exists, OK to replace ?"
-#~ msgstr "Biblioteka '%s' już istnieje. Czy mam ją zastąpić?"
-
-#~ msgid "OK to delete footprint %s in library '%s'"
-#~ msgstr "Kliknij OK by usunąć footprint %s z biblioteki '%s'"
-
-#~ msgid "File '%s' not found"
-#~ msgstr "Nie znaleziono pliku '%s'"
-
-#~ msgid "Unable to find or load footprint %s from lib path '%s'"
-#~ msgstr ""
-#~ "Nie mogę znaleźć lub załadować footprintu %s ze ścieżki bibliotek '%s'"
-
-#~ msgid "Unable to find or load footprint from path '%s'"
-#~ msgstr "Nie mogę znaleźć lub załadować footprintu ze ścieżki '%s'"
-
-#~ msgid ""
-#~ "The footprint library '%s' could not be found in any of the search paths."
-#~ msgstr ""
-#~ "Nie można odnaleźć biblioteki footprintów '%s' w żadnej ze ścieżek "
-#~ "wyszukiwania."
-
-#~ msgid "Library '%s' is read only, not writable"
-#~ msgstr "Biblioteka '%s' jest oznaczona jako 'Tylko do odczytu'"
-
-#~ msgid "Footprint exported to file '%s'"
-#~ msgstr "Footprint wyeksportowano do pliku '%s'"
-
-#~ msgid "Footprint %s deleted from library '%s'"
-#~ msgstr "Footprint %s usunięty z biblioteki '%s'"
-
-#~ msgid "Footprint %s already exists in library '%s'"
-#~ msgstr "Footprint %s już istnieje w bibliotece '%s'"
-
-#~ msgid "Legacy foot print export files (*.emp)|*.emp"
-#~ msgstr "Pliki eksportu footprintów programu KiCad (*.emp)|*.emp"
-
-#~ msgid "GPcb foot print files (*)|*"
-#~ msgstr "Pliki footprintów GPcb (*)|*"
-
-#~ msgid ""
-#~ "Error:\n"
-#~ "one of invalid chars '%s' found\n"
-#~ "in '%s'"
-#~ msgstr ""
-#~ "Błąd:\n"
-#~ "Znaleziono jeden z nieprawidłowych znaków '%s'\n"
-#~ "w '%s'"
-
-#~ msgid "Component [%s] replaced in '%s'"
-#~ msgstr "Symbol [%s] zastąpiony przez '%s'"
-
-#~ msgid "Component [%s] added in  '%s'"
-#~ msgstr "Symbol [%s] dodany do '%s'"
-
-#~ msgid "Footprint '%s' saved"
-#~ msgstr "Footprint \"%s\" został zapisany"
-
-#~ msgid "Footprint library '%s' saved as '%s'."
-#~ msgstr "Bibliotekę '%s' zapisano jako '%s'."
-
-#~ msgid "Set Acti&ve Library"
-#~ msgstr "Ustaw aktywną bibliotekę"
-
-#~ msgid "&New Footprint"
-#~ msgstr "Nowy footprint"
-
-#~ msgid "&Import Footprint From File"
-#~ msgstr "Importuj footprint z pliku"
-
-#~ msgid "Import footprint from an existing file"
-#~ msgstr "Importuj footprint z istniejącego pliku"
-
-#~ msgid "Load Footprint From Current Li&brary"
-#~ msgstr "Załaduj footprint z bieżącej biblioteki"
-
-#~ msgid "Open a footprint from library"
-#~ msgstr "Otwórz footprint z biblioteki"
-
-#~ msgid "Load Footprint From &Current Board"
-#~ msgstr "Wczytaj footprint z bieżącej płytki"
-
-#~ msgid "Load a footprint from the current board"
-#~ msgstr "Wczytuje footprint z bieżącej płytki do edytora"
-
-#~ msgid "&Load Footprint"
-#~ msgstr "Załaduj footprint"
-
-#~ msgid "Load footprint"
-#~ msgstr "Ładuje footprint"
-
-#~ msgid "Save &Current Library As..."
-#~ msgstr "Zapisz bieżącą bibliotekę jako ..."
-
-#~ msgid "Save entire current library under a new name."
-#~ msgstr "Zapisuje całą, bieżącą bibliotekę pod nową nazwą."
-
-#~ msgid "&Save Footprint in Active Library"
-#~ msgstr "Zapi&sz footprint w aktywnej bibliotece"
-
-#~ msgid "S&ave Footprint in New Library"
-#~ msgstr "Zapisz footprint w nowej bibliotece"
-
-#~ msgid "Create a new library and save current footprint into it"
-#~ msgstr "Utwórz nową bibliotekę i zapisz w niej bieżący footprint"
-
-#~ msgid "&Export Footprint"
-#~ msgstr "Eksportuj footprint"
-
-#~ msgid "Save currently loaded footprint into file"
-#~ msgstr "Zapisuje obecnie załadowany footprint do pliku"
-
-#~ msgid "&Import DXF File"
-#~ msgstr "Importuj plik DXF"
-
-#~ msgid "Import a 2D Drawing DXF file to Pcbnew on the Drawings layer"
-#~ msgstr "Importuj plik DXF z rysunkiem 2D na warstwę Rysunkową"
-
-#~ msgid "Delete objects with eraser"
-#~ msgstr "Usuwa obiekty za pomocą narzędzia gumki"
-
-#~ msgid "Edit &Properties"
-#~ msgstr "Edytuj parametry"
-
-#~ msgid "&User Grid Size"
-#~ msgstr "Rozmiar siatki &użytkownika"
-
-#~ msgid "Adjust user grid"
-#~ msgstr "Dostosuj siatkę użytkownika"
-
-#~ msgid "&Size and Width"
-#~ msgstr "Rozmiar i szerokość grafiki"
-
-#~ msgid "Adjust width for texts and drawings"
-#~ msgstr "Dostosuj szerokość dla tekstów i rysunków"
-
-#~ msgid "&Pad Setting"
-#~ msgstr "Właściwości pól lutowniczych"
-
-#~ msgid "&Switch Canvas to Default"
-#~ msgstr "Przełącz na tryb domyślny"
-
-#~ msgid "Switch the canvas implementation to default"
-#~ msgstr "Przełącza do domyślnego trybu wyświetlania obszaru roboczego"
-
-#~ msgid "Switch Canvas to Open&GL"
-#~ msgstr "Przełącz w tryb OpenGL"
-
-#~ msgid "Switch the canvas implementation to OpenGL"
-#~ msgstr "Przełącza do tybu wyświetlania obszaru roboczego z pomocą OpenGL"
-
-#~ msgid "Switch Canvas to &Cairo"
-#~ msgstr "Przełącz na tryb Cairo"
-
-#~ msgid "Switch the canvas implementation to Cairo"
-#~ msgstr "Przełącza do trybu wyświetlania obszaru roboczego z pomocą Cairo"
-
-#~ msgid "Add graphic line or polygon"
-#~ msgstr "Dodaj linię lub wielokąt (grafika)"
-
-#~ msgid "&Footprint Libraries Wizard"
-#~ msgstr "Kreator Tabeli Bibliotek"
-
-#~ msgid "Footprint Li&braries Manager"
-#~ msgstr "Zarządzanie bibliotekami footprintów"
-
-#~ msgid "&Settings"
-#~ msgstr "U&stawienia"
-
-#~ msgid "Change the footprint editor settings."
-#~ msgstr "Zmień ustawienia edytora footprintów."
-
-#~ msgid "Di&mensions"
-#~ msgstr "Wy&miary"
-
-#~ msgid "Clear current board and initialize a new one"
-#~ msgstr "Usuwa stary projekt PCB i tworzy nowy"
-
-#~ msgid "&Open"
-#~ msgstr "&Otwórz "
-
-#~ msgid "Delete current board and load new board"
-#~ msgstr "Usuń starą płytkę i otwórz nową"
-
-#~ msgid "Open a recent opened board"
-#~ msgstr "Otwórz istniejącą płytkę"
-
-#~ msgid "&Append Board"
-#~ msgstr "&Dołącz płytkę"
-
-#~ msgid ""
-#~ "Append another Pcbnew board to the current loaded board. Available only "
-#~ "when Pcbnew runs in stand alone mode"
-#~ msgstr ""
-#~ "Dołącza inną płytkę z programu Pcbnew do obecnie załadowanej płytki. "
-#~ "Polecenie dostępne tylko gdy Pcbnew został uruchomiony spoza projektu."
-
-#~ msgid "Save the current board as..."
-#~ msgstr "Zapisz bieżącą płytkę jako..."
-
-#~ msgid "Save a copy of the current board as..."
-#~ msgstr "Zapisz kopię bieżącej płytki jako..."
-
-#~ msgid "Revert to Las&t"
-#~ msgstr "Przywróć do poprzedniej wersji"
-
-#~ msgid "Footprint &Position (.pos) File"
-#~ msgstr "Plik położeń footprintów (.pos)"
-
-#~ msgid "&Drill (.drl) File"
-#~ msgstr "Plik &wierceń (.drl)"
-
-#~ msgid "&Footprint (.rpt) Report"
-#~ msgstr "Raport &ilościowy footprintów (.rpt)"
-
-#~ msgid "Create a report of all footprints on the current board"
-#~ msgstr "Generuj raport o wykorzystaniu footprintów na bieżącym PCB"
-
-#~ msgid "IPC-D-356 Netlist File"
-#~ msgstr "Plik listy sieci IPC-D-356"
-
-#~ msgid "&BOM File"
-#~ msgstr "Plik materiałowy"
-
-#~ msgid "Create a bill of materials from schematic"
-#~ msgstr "Utwórz listę materiałową ze schematu"
-
-#~ msgid "&Specctra Session"
-#~ msgstr "Sesja &Specctra"
-
-#~ msgid "Import a routed \"Specctra Session\" (*.ses) file"
-#~ msgstr "Importuj plik \"Specctra Session\" (*.ses)"
-
-#~ msgid "&DXF File"
-#~ msgstr "Plik DXF"
-
-#~ msgid "&Specctra DSN"
-#~ msgstr "&Specctra DSN"
-
-#~ msgid "Export the current board to a \"Specctra DSN\" file"
-#~ msgstr "Eksportuj bieżącą płytkę do pliku \"Specctra DSN\""
-
-#~ msgid "&GenCAD"
-#~ msgstr "&GenCAD"
-
-#~ msgid "&VRML"
-#~ msgstr "&VRML"
-
-#~ msgid "Export a VRML board representation"
-#~ msgstr "Eksportuj postać VRML płytki"
-
-#~ msgid "I&DFv3"
-#~ msgstr "IDFv3"
-
-#~ msgid "IDFv3 board and component export"
-#~ msgstr "Eksportuje kształt płytki do pliku w formacie IDFv3"
-
-#~ msgid "&Component (.cmp) File"
-#~ msgstr "Plik łącz komponentów (.cmp)"
-
-#~ msgid ""
-#~ "Export component file (*.cmp) for Eeschema footprint field back-annotation"
-#~ msgstr ""
-#~ "Eksportuje plik komponentów (*.cmp) dla programu Eeschema w celu "
-#~ "numeracji wstecznej"
-
-#~ msgid "Page s&ettings"
-#~ msgstr "Ustawi&enia strony"
-
-#~ msgid "Export SV&G"
-#~ msgstr "Eksportuj SV&G"
-
-#~ msgid "Export a board file in Scalable Vector Graphics format"
-#~ msgstr "Eksportuje schemat do pliku w formacie SVG"
-
-#~ msgid "P&lot"
-#~ msgstr "Rysuj"
-
-#~ msgid "&Archive Footprints in a Project Library"
-#~ msgstr "Archiwizuj footprinty w bibliotece projektu"
-
-#~ msgid ""
-#~ "Archive footprints in an existing library in footprint Lib table(do not "
-#~ "remove other footprints in this lib)"
-#~ msgstr ""
-#~ "Archiwizuje footprinty w istniejącej bibliotece znajdującej się w tabeli "
-#~ "bibliotek (nie usuwa innych footprintów w tej bibliotece)"
-
-#~ msgid "&Create Library and Archive Footprints"
-#~ msgstr "Utwórz bibliotekę i zarchiwizuj footprinty"
-
-#~ msgid ""
-#~ "Archive all footprints in a new library\n"
-#~ "(if this library already exists, it will be deleted)"
-#~ msgstr ""
-#~ "Archiwizuje wszystkie footprinty w nowej bibliotece\n"
-#~ "(jeśli biblioteka już istnieje, zostanie ona usunięta)"
-
-#~ msgid "Archive or add footprints in a library file"
-#~ msgstr "Archiwizuje lub dodaje footprinty do pliku biblioteki"
-
-#~ msgid "&Global Deletions"
-#~ msgstr "Usuwanie &globalne"
-
-#~ msgid "Delete tracks, footprints, texts... on board"
-#~ msgstr "Usuń ścieżki, footprinty, teksty... na płytce"
-
-#~ msgid "&Cleanup Tracks and Vias"
-#~ msgstr "Wy&czyść ścieżki i przelotki"
-
-#~ msgid ""
-#~ "Clean stubs, vias, delete break points, or unconnected tracks to pads and "
-#~ "vias"
-#~ msgstr ""
-#~ "Oczyszcza samotne odcinki, przelotki, usuwa punkty przerw lub "
-#~ "niepołączone ścieżki do pól i przelotek"
-
-#~ msgid "&Swap Layers"
-#~ msgstr "&Zamień warstwy"
-
-#~ msgid "Set Footp&rint Field Sizes"
-#~ msgstr "Ustaw domyślny &rozmiar pól footprintów"
-
-#~ msgid "Set text size and width of footprint fields."
-#~ msgstr "Ustala rozmiar i szerokość wszystkich pól footprintów na płytce."
-
-#~ msgid "View a list of nets with names and id's"
-#~ msgstr "Lista sieci (nazwy i identyfikatory)"
-
-#~ msgid "&Track"
-#~ msgstr "Ścieżka"
-
-#~ msgid "Add tracks and vias"
-#~ msgstr "Dodaj ścieżki i przelotki"
-
-#~ msgid "La&yer alignment target"
-#~ msgstr "Dodaj element poz&ycjonujący warstwy"
-
-#~ msgid "Interactively route a single track"
-#~ msgstr "Router interaktywny dla pojedynczych ścieżek"
-
-#~ msgid "Interactively route a differential pair"
-#~ msgstr "Router interaktywny dla par różnicowych"
-
-#~ msgid "&3D Shapes Libraries Downloader"
-#~ msgstr "Pobieranie bibliotek modeli 3D"
-
-#~ msgid "Download from Github the 3D shape libraries with wizard"
-#~ msgstr ""
-#~ "Dodaje biblioteki modeli 3D z serwerów GitHub za pomocą prostego kreatora"
-
-#~ msgid "Hide La&yers Manager"
-#~ msgstr "Ukryj menadżera warstw"
-
-#~ msgid "Hide Microwa&ve Toolbar"
-#~ msgstr "Schowaj pasek narzędzi mikrofalowych"
-
-#~ msgid "Show Microwave Toolbar"
-#~ msgstr "Pokaż pasek narzędzi mikrofalowych"
-
-#~ msgid "&General"
-#~ msgstr "&Główne"
-
-#~ msgid "&Display"
-#~ msgstr "&Wyświetlanie"
-
-#~ msgid "Select how items (pads, tracks texts ... ) are displayed"
-#~ msgstr "Wybierz sposób wyświetlania elementów"
-
-#~ msgid "&Interactive Routing"
-#~ msgstr "Router interaktywny"
-
-#~ msgid "Configure the interactive router."
-#~ msgstr "Konfiguruje ustawienia interaktywnego routera."
-
-#~ msgid "G&rid"
-#~ msgstr "Siatka"
-
-#~ msgid "Adjust user grid dimensions"
-#~ msgstr "Dostosuj siatkę użytkownika"
-
-#~ msgid "Te&xts and Drawings"
-#~ msgstr "Teksty i rysunki"
-
-#~ msgid "&Pads"
-#~ msgstr "&Pola lutownicze"
-
-#~ msgid "Pads &Mask Clearance"
-#~ msgstr "Prześwit &maski pól lutowniczych"
-
-#~ msgid "Adjust the global clearance between pads and the solder resist mask"
-#~ msgstr "Ustaw globalne ustawienia prześwitów pól lut. i maski lutowniczej"
-
-#~ msgid "&Differential Pairs"
-#~ msgstr "Pary różnicowe"
-
-#~ msgid "Define the global gap/width for differential pairs."
-#~ msgstr "Określa globalną wartość przerwy/szerokości dla par różnicowych"
-
-#~ msgid "Save dimension preferences"
-#~ msgstr "Zapisz ustawienia rozmiarów"
-
-#~ msgid "&Save macros"
-#~ msgstr "Zapi&sz makra"
-
-#~ msgid "Save macros to file"
-#~ msgstr "Zapisuje makra do pliku"
-
-#~ msgid "&Read macros"
-#~ msgstr "Odczytaj mak&ra"
-
-#~ msgid "Read macros from file"
-#~ msgstr "Wczytuje makra z pliku"
-
-#~ msgid "Ma&cros"
-#~ msgstr "Makro"
-
-#~ msgid "Macros save/read operations"
-#~ msgstr "Zapis/odczyt makr"
-
-#~ msgid "&Netlist"
-#~ msgstr "Lista sieci"
-
-#~ msgid "Read the netlist and update board connectivity"
-#~ msgstr "Wczytaj listę sieci i uaktualnij brakujące połączenia"
-
-#~ msgid "&Layer Pair"
-#~ msgstr "Para warstw"
-
-#~ msgid "Change the active layer pair"
-#~ msgstr "Zmień aktywną parę warstw"
-
-#~ msgid "&DRC"
-#~ msgstr "&DRC"
-
-#~ msgid "Fast access to the web based FreeROUTE advanced router"
-#~ msgstr "Szybki dostęp do zaawansowanego routera FreeRoute"
-
-#~ msgid "&Design Rules"
-#~ msgstr "Reguły projektowe"
-
-#~ msgid "Open the design rules editor"
-#~ msgstr "Otwórz edytor reguł projektowych"
-
-#~ msgid "&Layers Setup"
-#~ msgstr "&Opcje warstw"
-
-#~ msgid "Display the KiCad About dialog"
-#~ msgstr "Wyświetla okno z informacjami o programie KiCad"
-
-#~ msgid "D&imensions"
-#~ msgstr "Wym&iary"
-
-#~ msgid "Pad settings"
-#~ msgstr "Właściwości pól lutowniczych"
-
-#~ msgid "Copy Block (shift + drag mouse)"
-#~ msgstr "Kopiuj blok (shift + przeciąganie myszką)"
-
-#~ msgid "Move Block Exactly"
-#~ msgstr "Przesuń blok dokładnie"
-
-#~ msgid "Move Exactly"
-#~ msgstr "Przesuń dokładnie"
-
-#~ msgid "Edit Pad"
-#~ msgstr "Edytuj pole"
-
-#~ msgid "New Pad Settings"
-#~ msgstr "Nowe ustawienia pola lutowniczego"
-
-#~ msgid "Export Pad Settings"
-#~ msgstr "Eksportuj ustawienia pola lutowniczego"
-
-#~ msgid "Move Pad Exactly"
-#~ msgstr "Przesuń pole dokładnie"
-
-#~ msgid "Create Pad Array"
-#~ msgstr "Utwórz szyk pól"
-
-#~ msgid "Global Pad Settings"
-#~ msgstr "Globalne ustawienia pól lutowniczych"
-
-#~ msgid "Duplicate Text"
-#~ msgstr "Powiel tekst"
-
-#~ msgid "Create Text Array"
-#~ msgstr "Utwórz szyk tekstów"
-
-#~ msgid "Move Text Exactly"
-#~ msgstr "Przesuń tekst dokładnie"
-
-#~ msgid "End edge"
-#~ msgstr "Zakończ krawędź"
-
-#~ msgid "Move Edge"
-#~ msgstr "Przesuń krawędź"
-
-#~ msgid "Duplicate Edge"
-#~ msgstr "Powiel krawędź"
-
-#~ msgid "Move Edge Exactly"
-#~ msgstr "Przesuń krawędź dokładnie"
-
-#~ msgid "Create Edge Array"
-#~ msgstr "Utwórz szyk krawędzi"
-
-#~ msgid "Place edge"
-#~ msgstr "Dodaj krawędź"
-
-#~ msgid "Delete Edge"
-#~ msgstr "Usuń krawędź"
-
-#~ msgid "Change Body Items Layer"
-#~ msgstr "Zmień warstwę elementów"
-
-#~ msgid "Set Line Width"
-#~ msgstr "Ustaw szerokość linii"
-
-#~ msgid "Library is not set, the footprint could not be saved."
-#~ msgstr ""
-#~ "Biblioteka robocza nie została wybrana, footprint nie może zostać "
-#~ "zapisany."
-
-#~ msgid "Footprint Editor "
-#~ msgstr "Edytor Footprintów"
-
-#~ msgid "(no active library)"
-#~ msgstr " (brak aktywnej biblioteki)"
-
-#~ msgid "Footprint Editor (active library: "
-#~ msgstr "Edytor Footprintów (aktywna biblioteka: "
-
-#~ msgid "Search for footprint"
-#~ msgstr "Szukaj footprintu"
-
-#~ msgid "Gap"
-#~ msgstr "Odstęp"
-
-#~ msgid "Stub"
-#~ msgstr "Odcinek"
-
-#~ msgid "Arc Stub"
-#~ msgstr "Wycinek łuku"
-
-#~ msgid "No footprint defined for component '%s'.\n"
-#~ msgstr "Dla komponentu '%s' nie został zdefiniowany footprint.\n"
-
-#~ msgid ""
-#~ "* Warning: component '%s': board footprint '%s', netlist footprint '%s'\n"
-#~ msgstr ""
-#~ "*** OSTRZEŻENIE: Komponent '%s', posiada footprint '%s', choć według "
-#~ "listy sieci powinien posiadać '%s' ***\n"
-
-#~ msgid "Component '%s' footprint ID '%s' is not valid.\n"
-#~ msgstr ""
-#~ "Komponent '%s', identyfikator footprintu '%s' nie jest prawidłowy.\n"
-
-#~ msgid ""
-#~ "Component '%s' footprint '%s' was not found in any libraries in the "
-#~ "footprint library table.\n"
-#~ msgstr ""
-#~ "Komponent '%s', footprint '%s' nie został znaleziony w żadnej z bibliotek "
-#~ "znajdującej się w tabeli bibliotek.\n"
-
-#~ msgid ""
-#~ "invalid footprint ID in\n"
-#~ "file: <%s>\n"
-#~ "line: %d"
-#~ msgstr ""
-#~ "niepoprawny ID footprintu w\n"
-#~ "plik: <%s>\n"
-#~ "linia: %d"
-
-#~ msgid "Tracks on Copper layers only "
-#~ msgstr "Ścieżki tylko na warstwach ścieżek"
-
-#~ msgid "Move Drawing"
-#~ msgstr "Przesuń rysunek"
-
-#~ msgid "Duplicate Drawing"
-#~ msgstr "Powiel rysunek"
-
-#~ msgid "Move Drawing Exactly"
-#~ msgstr "Przesuń rysunek dokładnie"
-
-#~ msgid "Create Drawing Array"
-#~ msgstr "Utwórz szyk rysunków"
-
-#~ msgid "Edit Drawing"
-#~ msgstr "Edytuj rysunek"
-
-#~ msgid "Edit Dimension"
-#~ msgstr "Edytuj wymiar"
-
-#~ msgid "Move Dimension Text"
-#~ msgstr "Przesuń tekst wymiarowania"
-
-#~ msgid "Duplicate Dimension"
-#~ msgstr "Powiel wymiar"
-
-#~ msgid "Move Dimension Exactly"
-#~ msgstr "Przesuń wymiar dokładnie"
-
-#~ msgid "Delete Dimension"
-#~ msgstr "Usuń wymiar"
-
-#~ msgid "Move Target"
-#~ msgstr "Przesuń element pozycjonujący"
-
-#~ msgid "Move Target Exactly"
-#~ msgstr "Przesuń element pozycjonujący dokładnie"
-
-#~ msgid "Duplicate Target"
-#~ msgstr "Powiel element pozycjonujący"
-
-#~ msgid "Create Target Array"
-#~ msgstr "Utwórz szyk elementów pozycjonujących"
-
-#~ msgid "Edit Target"
-#~ msgstr "Edytuj element pozycjonujący"
-
-#~ msgid "Delete Target"
-#~ msgstr "Usuń element pozycjonujący"
-
-#~ msgid "Select Working Layer"
-#~ msgstr "Wybierz warstwę roboczą"
-
-#~ msgid "Select Layer Pair for Vias"
-#~ msgstr "Wybierz parę warstw dla przelotek"
-
-#~ msgid "Orient All Footprints"
-#~ msgstr "Zorientuj wszystkie footprinty"
-
-#~ msgid "Select Layer Pair"
-#~ msgstr "Wybierz parę warstw"
-
-#~ msgid "Flip Block"
-#~ msgstr "Odbij blok"
-
-#~ msgid "Rotate Block"
-#~ msgstr "Obróć blok"
-
-#~ msgid "Move Node"
-#~ msgstr "Przesuń gałąź"
-
-#~ msgid "Duplicate Track"
-#~ msgstr "Powiel ścieżkę"
-
-#~ msgid "Move Track Exactly"
-#~ msgstr "Przesuń ścieżkę dokładnie"
-
-#~ msgid "Create Track Array"
-#~ msgstr "Utwórz szyk ścieżek"
-
-#~ msgid "Select Layer and Place Through Via"
-#~ msgstr "Wybierz warstwę i wstaw przelotkę na wylot"
-
-#~ msgid "Select Layer and Place Blind/Buried Via"
-#~ msgstr "Wybierz warstwę i wstaw przelotkę ślepą/zagrzebaną"
-
-#~ msgid "Edit All Tracks and Vias"
-#~ msgstr "Edycja rozmiarów wszystkich ścieżek i przelotek"
-
-#~ msgid "Move Corner"
-#~ msgstr "Przesuń narożnik"
-
-#~ msgid "Delete Corner"
-#~ msgstr "Usuń narożnik"
-
-#~ msgid "Duplicate Zone Onto Layer"
-#~ msgstr "Powiel strefę na inną warstwę"
-
-#~ msgid "Move Zone Exactly"
-#~ msgstr "Przesuń strefę dokładnie"
-
-#~ msgid "Edit Zone Properties"
-#~ msgstr "Edytuj parametry strefy"
-
-#~ msgid "Rotate +"
-#~ msgstr "Obróć +"
-
-#~ msgid "Rotate -"
-#~ msgstr "Obróć -"
-
-#~ msgid "Edit Parameters"
-#~ msgstr "Edycja parametrów"
-
-#~ msgid "Delete Footprint"
-#~ msgstr "Usuń footprint"
-
-#~ msgid "Move Footprint Exactly"
-#~ msgstr "Przesuń footprint dokładnie"
-
-#~ msgid "Create Footprint Array"
-#~ msgstr "Utwórz szyk z footprintów"
-
-#~ msgid "Exchange Footprint(s)"
-#~ msgstr "Zamień footprint(y)"
-
-#~ msgid "Copy Current Settings to this Pad"
-#~ msgstr "Kopiuj ustawienia bieżącego pola do tego pola"
-
-#~ msgid "Copy this Pad Settings to Current Settings"
-#~ msgstr "Kopiuj ustawienia tego pola do bieżących ustawień pola"
-
-#~ msgid "Edit All Pads"
-#~ msgstr "Edytuj wszystkie pola lutownicze"
-
-#~ msgid ""
-#~ "Copy this pad's settings to all pads in this footprint (or similar "
-#~ "footprints)"
-#~ msgstr ""
-#~ "Kopiuj ustawienia tego pola lut. do wszystkich pól lut. tego footprintu "
-#~ "(lub podobnych fooprintów)"
-
-#~ msgid ""
-#~ "invalid floating point number in\n"
-#~ "file: <%s>\n"
-#~ "line: %d\n"
-#~ "offset: %d"
-#~ msgstr ""
-#~ "niepoprawna liczba typu float w\n"
-#~ "pliku: <%s>\n"
-#~ "linia: %d\n"
-#~ "przesunięcie: %d"
-
-#~ msgid ""
-#~ "missing floating point number in\n"
-#~ "file: <%s>\n"
-#~ "line: %d\n"
-#~ "offset: %d"
-#~ msgstr ""
-#~ "brak liczby typu float w\n"
-#~ "pliku: <%s>\n"
-#~ "linia: %d\n"
-#~ "przesunięcie: %d"
-
-#~ msgid "Layer '%s' in file '%s' at line %d, is not in fixed layer hash"
-#~ msgstr ""
-#~ "Warstwa '%s' w pliku '%s' w linii %d, nie występuje w stałym kluczu warstw"
-
-#~ msgid ""
-#~ "Layer '%s' in file\n"
-#~ "'%s'\n"
-#~ "at line %d, position %d\n"
-#~ "was not defined in the layers section"
-#~ msgstr ""
-#~ "Warstwa '%s' w pliku\n"
-#~ "'%s'\n"
-#~ "w linii %d, pozycja %d\n"
-#~ "nie została zdefiniowana w sekcji warstw"
-
-#~ msgid "duplicate NETCLASS name '%s' in file <%s> at line %d, offset %d"
-#~ msgstr ""
-#~ "zduplikowana nazwa Klasy Sieci '%s' w pliku <%s> w linii %d, przesunięcie "
-#~ "%d"
-
-#~ msgid ""
-#~ "invalid net ID in\n"
-#~ "file: <%s>\n"
-#~ "line: %d\n"
-#~ "offset: %d"
-#~ msgstr ""
-#~ "niepoprawny ID w:\n"
-#~ "plik: <%s>\n"
-#~ "linia: %d:\n"
-#~ "przesunięcie: %d"
-
-#~ msgid "The auto save file '%s' could not be removed!"
-#~ msgstr "Plik automatycznej kopii zapasowej '%s' nie może zostac usunięty!"
-
-#~ msgid ""
-#~ "You have run Pcbnew for the first time using the new footprint library "
-#~ "table method for finding footprints.\n"
-#~ "Pcbnew has either copied the default table or created an empty table in "
-#~ "the kicad configuration folder.\n"
-#~ "You must first configure the library table to include all footprint "
-#~ "libraries you want to use.\n"
-#~ "See the \"Footprint Library  Table\" section of the CvPcb or Pcbnew "
-#~ "documentation for more information."
-#~ msgstr ""
-#~ "Pcbnew został uruchomiony pierwszy raz z użyciem nowej metody "
-#~ "wyszukiwania fooptrintów w Tabeli Bibliotek. Pcbnew skopiuje teraz "
-#~ "domyślną tabelę bądź utworzy pustą tabele w katalogu domowym użytkownika. "
-#~ "Konfigurację tabeli bibliotek należy uzupełnić o pozostałe biblioteki "
-#~ "footprintów nie będące składnikami programu. Zobacz rozdział \"Tabele "
-#~ "bibliotek\" w dokumentacji programu Pcbnew by uzyskać więcej informacji."
-
-#~ msgid "Hide Microwave Toolbar"
-#~ msgstr "Schowaj pasek narzędzi mikrofalowych"
-
-#~ msgid "Save Macros File"
-#~ msgstr "Zapisz plik makr"
-
-#~ msgid "Read Macros File"
-#~ msgstr "Odczytaj plik makr"
-
-#~ msgid "Increase spacing"
-#~ msgstr "Zwiększ prześwit"
-
-#~ msgid "Decrease spacing"
-#~ msgstr "Zmniejsz prześwit"
-
-#~ msgid "Increase amplitude"
-#~ msgstr "Zwiększ amplitudę"
-
-#~ msgid "Decrease amplitude"
-#~ msgstr "Zmniejsz amplitudę"
-
-#~ msgid "Drags a track or a via."
-#~ msgstr "Przeciąga ścieżkę lub przelotkę."
-
-#~ msgid "Switches posture of the currenly routed track."
-#~ msgstr "Zmienia sposób załamania bieżąco prowadzonej ścieżki."
-
-#~ msgid "Custom size"
-#~ msgstr "Rozmiar użytkownika"
-
-#~ msgid "Use the starting track width"
-#~ msgstr "Użyj początkowej szerokości ścieżki"
-
-#~ msgid "Use net class values"
-#~ msgstr "Użyj wartości z klas sieci"
-
-#~ msgid "Unable to export, please fix and try again."
-#~ msgstr "Nie mogę eksportować. Napraw błędy i spróbuj ponownie."
-
-#~ msgid ""
-#~ "Unable to find the next boundary segment with an endpoint of (%s mm, %s "
-#~ "mm).\n"
-#~ "Edit Edge.Cuts perimeter graphics, making them contiguous polygons each."
-#~ msgstr ""
-#~ "Nie mogę odnaleźć następnego segmentu z punktem końcowym (%s mm, %s mm).\n"
-#~ "Popraw obrys na warstwie Edge.Cuts, tworząc z niego zamknięty wielokąt."
-
-#~ msgid ""
-#~ "Unable to find the next keepout segment with an endpoint of (%s mm, %s "
-#~ "mm).\n"
-#~ "Edit Edge.Cuts interior graphics, making them contiguous polygons each."
-#~ msgstr ""
-#~ "Nie mogę odnaleźć następnego segmentu z punktem końcowym (%s mm, %s mm).\n"
-#~ "Popraw wewnętrzny obrys na warstwie Edge.Cuts, tworząc z niego zamknięty "
-#~ "wielokąt."
-
-#~ msgid "Component with value of '%s' has empty reference id."
-#~ msgstr "Komponent z wartością '%s' nie posiada oznaczenia."
-
-#~ msgid "Multiple components have identical reference IDs of '%s'."
-#~ msgstr "Wiele komponentów ma to samo oznaczenie \"%s\"."
-
-#~ msgid "BOARD may be corrupted, do not save it."
-#~ msgstr "Płytka może być uszkodzona. Nie zapisuj jej."
-
-#~ msgid "Fix problem and try again."
-#~ msgstr "Napraw problem i sprobój ponownie."
-
-#~ msgid "Session file has 'reference' to non-existent component \"%s\""
-#~ msgstr ""
-#~ "Plik sesji zawiera 'odniesienie' do nieistniejącego komponentu \"%s\""
-
-#~ msgid "Update footprint in current board"
-#~ msgstr "Uaktualnij footprint na bieżącej płytce"
-
-#~ msgid "Place the footprint reference anchor"
-#~ msgstr "Ustaw punkt zakotwiczenia footprintu"
-
-#~ msgid "Show footprint ratsnest when moving"
-#~ msgstr "Pokaż połączenia wspomagające footprintów w trakcie przesuwania"
-
-#~ msgid "Disable design rule checking"
-#~ msgstr "Wyłącz kontrolę reguł projektowania"
-
-#~ msgid "Hide footprint ratsnest"
-#~ msgstr "Ukryj połączenia wspomagające footprintu"
-
-#~ msgid "Show footprint ratsnest"
-#~ msgstr "Pokaż połączenia wspomagające footprintu"
-
-#~ msgid "trivial connection"
-#~ msgstr "Od węzła do węzła"
-
-#~ msgid "copper connection"
-#~ msgstr "Połączenia na war. miedzi"
-
-#~ msgid "whole net"
-#~ msgstr "Cała sieć"
-
-#~ msgid "Find an item"
-#~ msgstr "Znajdź element"
-
-#~ msgid "Copy pad settings to Current Settings"
-#~ msgstr "Kopiuj ustawienia tego pola do bieżących ustawień pola"
-
-#~ msgid ""
-#~ "Copies the properties of selected pad to the current template pad "
-#~ "settings."
-#~ msgstr ""
-#~ "Kopiuje ustawienia wybranego pola lutowniczego do obecnych ustawień pola."
-
-#~ msgid "Copy Current Settings to pads"
-#~ msgstr "Kopiuj bieżące ustawienia pola do tego pola"
-
-#~ msgid "Copies the current template pad settings to the selected pad(s)."
-#~ msgstr "Kopiuje obecne ustawienia pola lutowniczego do wybranego pola/pól."
-
-#~ msgid "Global Pad Edition"
-#~ msgstr "Globalna edycja pól lutowniczych"
-
-#~ msgid "Changes pad properties globally."
-#~ msgstr "Zmienia globalne ustawienia pól lutowniczych."
-
-#~ msgid "Rotates selected item(s)"
-#~ msgstr "Obraca wybrany(e) element(y)"
-
-#~ msgid "Fill all"
-#~ msgstr "Wypełnij wszystkie"
-
-#~ msgid "Unfill all"
-#~ msgstr "Usuń wszystkie wypełnienia"
-
-#~ msgid "Enumerate pads"
-#~ msgstr "Ponumeruj pola lutownicze"
-
-#~ msgid "Copy items"
-#~ msgstr "Kopiuj elementy"
-
-#~ msgid "Create corner"
-#~ msgstr "Utwórz narożnik"
-
-#~ msgid "Align items to the top"
-#~ msgstr "Wyrównaj elementy do górnej linii"
-
-#~ msgid "Align items to the bottom"
-#~ msgstr "Wyrównaj elementy do dolnej linii"
-
-#~ msgid "Align items to the left"
-#~ msgstr "Wyrównaj elementy do lewej linii"
-
-#~ msgid "Align items to the right"
-#~ msgstr "Wyrównaj elementy do prawej linii"
-
-#~ msgid "Cannot delete component reference."
-#~ msgstr "Nie można usunąć oznaczenia komponentu."
-
-#~ msgid "Cannot delete component value."
-#~ msgstr "Nie można usunąć wartości komponentu."
-
-#~ msgid "Hold left mouse button and move cursor over pads to enumerate them"
-#~ msgstr ""
-#~ "Przytrzymaj lewy przycisk myszy i przesuń kursor nad polami lutowniczymi "
-#~ "by je ponumerować"
-
-#~ msgid "Select reference point"
-#~ msgstr "Wybierz punkt referencyjny"
-
-#~ msgid "Copied %d item(s)"
-#~ msgstr "Skopiowano pozycji: %d"
-
-#~ msgid "Align/distribute"
-#~ msgstr "Wyrównywanie/rozkładanie"
-
-#~ msgid "Select..."
-#~ msgstr "Wybierz..."
-
-#~ msgid "Change footprint of '%s'"
-#~ msgstr "Zamień footprint '%s'"
-
-#~ msgid "Change footprints '%s'"
-#~ msgstr "Zamienić footprinty '%s'"
-
-#~ msgid "File '%s' created\n"
-#~ msgstr "Plik '%s' został utworzony\n"
-
-#~ msgid "** Could not create file '%s' ***\n"
-#~ msgstr "*** Nie mogę utworzyć pliku '%s' ***\n"
-
-#~ msgid "Change footprint %s -> %s (for value = %s)?"
-#~ msgstr "Zamienić footprinty %s -> %s (o wartości = %s)?"
-
-#~ msgid "Change footprint %s -> %s ?"
-#~ msgstr "Zamienić footprint %s -> %s?"
-
-#~ msgid "Are you sure you want to change all footprints?"
-#~ msgstr "Czy chcesz zamienić wszystkie footprinty?"
-
-#~ msgid "Change footprint '%s' (from '%s') to '%s'"
-#~ msgstr "Zamień footprint '%s' (z '%s') na '%s'"
-
-#~ msgid "Could not create file '%s'"
-#~ msgstr "Nie mogę utworzyć pliku '%s'"
-
-#~ msgid ""
-#~ "The duplicated zone is on the same layer as the initial zone, which has "
-#~ "no sense.\n"
-#~ "Please, choose an other layer for the new zone"
-#~ msgstr ""
-#~ "Powielona strefa znajduje się na tej samej warstwie jak strefa "
-#~ "kopiowana.\n"
-#~ "Proszę wybrać inną warstwę docelową dla nowej strefy."
-
-#~ msgid "The outline of the duplicated zone fails DRC check!"
-#~ msgstr ""
-#~ "Obrys powielonej strefy powoduje niepowodzenie przy sprawdzaniu DRC!"
-
-#~ msgid "Filling zone %d out of %d (net %s)..."
-#~ msgstr "Wypełnianie strefy %d, obecnie %d (sieć %s)..."
-
-#~ msgid "Updating ratsnest..."
-#~ msgstr "Aktualizacja połączeń wspomagających..."
-
-#~ msgid "About..."
-#~ msgstr "&O programie..."
-
-#~ msgid "Path Configuration"
-#~ msgstr "Konfiguracja ścieżek dostępu"
-
-#~ msgid "Save footprint association in schematic component footprint fields"
-#~ msgstr "Zapisuje przypisania footprintów w polach symboli na schemacie"
-
-#~ msgid "EESchema Colors"
-#~ msgstr "Kolory Eeschema"
-
-#~ msgid "Component Properties"
-#~ msgstr "Właściwości symbolu"
-
-#~ msgid "Plot Schematic"
-#~ msgstr "Rysuj schemat (na ploterze)"
-
-#~ msgid "Find components and text"
-#~ msgstr "Znajdź symbole i teksty"
-
-#~ msgid "Place component"
-#~ msgstr "Dodaj symbol"
-
-#~ msgid "Place not-connected flag"
-#~ msgstr "Dodaj flagę \"Niepołączone\""
-
-#~ msgid "Place net name - local label"
-#~ msgstr "Dodaj nazwę sieci (lokalna)"
-
-#~ msgid ""
-#~ "Place a hierarchical label. Label will be seen as a hierarchical pin in "
-#~ "the sheet symbol"
-#~ msgstr ""
-#~ "Dodaj etykietę hierarchiczną. Etykieta ta będzie widoczna jako pin w "
-#~ "symbolu arkusza"
-
-#~ msgid "Annotate schematic components"
-#~ msgstr "Numeruje elementy na schemcie"
-
-#~ msgid "Library Editor - Create/edit components"
-#~ msgstr "Edytor bibliotek - Tworzenie i modyfikacja symboli"
-
-#~ msgid "Library Browser - Browse components"
-#~ msgstr "Przeglądarka bibliotek - Przeglądanie symboli z bibliotek"
-
-#~ msgid "Generate bill of materials and/or cross references"
-#~ msgstr "Generuje listę materiałów i/lub referencje"
-
-#~ msgid "Back-import component footprint fields via CvPcb .cmp file"
-#~ msgstr ""
-#~ "Importuje nazwy footprintów do schematu z pliku .CMP tworzonego przez "
-#~ "CvPcb"
-
-#~ msgid "Add pins to component"
-#~ msgstr "Dodaj wyprowadzenia do symbolu"
-
-#~ msgid "Add text to component body"
-#~ msgstr "Dodaj tekst (grafika) do ciała symbolu"
-
-#~ msgid "Add graphic rectangle to component body"
-#~ msgstr "Dodaj prostokąt (grafika) do ciała symbolu"
-
-#~ msgid "Add circles to component body"
-#~ msgstr "Dodaj okrąg (grafika) do ciała symbolu"
-
-#~ msgid "Add arcs to component body"
-#~ msgstr "Dodaj łuk (grafika) do ciała symbolu"
-
-#~ msgid "Add lines and polygons to component body"
-#~ msgstr "Dodaj linie i wielokąty (grafika) do ciała symbolu"
-
-#~ msgid "Export SVG file"
-#~ msgstr "Eksportuj plik SVG"
-
-#~ msgid "Pad enumeration settings"
-#~ msgstr "Ustawienia wyliczania pól lutowniczych"
-
-#~ msgid "Generate Component Position Files"
-#~ msgstr "Generowanie plików położeń footprintów"
-
-#~ msgid "Drill Files Generation"
-#~ msgstr "Generuj pliki wierceń"
-
-#~ msgid "Global Pads Edition"
-#~ msgstr "Globalna edycja pól lutowniczych"
-
-#~ msgid "Footprints Orientation"
-#~ msgstr "Orientacja footprintów"
-
-#~ msgid "Trace length tuning"
-#~ msgstr "Dostrajanie długości ścieżki"
-
-#~ msgid "Grid Properties"
-#~ msgstr "Właściwości siatki"
-
-#~ msgid "Track width and via size"
-#~ msgstr "Szerokości ścieżek i rozmiar przelotek"
-
-#~ msgid "Zoom to fit the board on the screen"
-#~ msgstr "Dopasuj powiększenie do rozmiarów płytki"
-
-#~ msgid "Redraw the current screen"
-#~ msgstr "Przerysuj ekran"
-
-#~ msgid ""
-#~ "Show/hide the microwave toolbar\n"
-#~ "This is a experimental feature (under development)"
-#~ msgstr ""
-#~ "Pokazuje/ukrywa pasek narzędzi mikrofalowych\n"
-#~ "Jest to funkcja eksperymentalna (w ciągłym rozwoju)"
+msgstr "Sprawdzanie stref"


### PR DESCRIPTION
This updated translation fixes problem with wrong file filters in file open dialogs. KiCad now use string concatenation to manage file extensions filters. Previous translation uses fixed extensions, so internal code create wrong (doubled, for ex. ".liblib") extensions.

Fix for https://bugs.launchpad.net/kicad/+bug/1783508