### PR TITLE
DE: center and warp on zoom text was inverted to its actual meaning

### DIFF
--- a/de/kicad.po
+++ b/de/kicad.po
@@ -2336,7 +2336,7 @@ msgstr "Bildschwenk und Zoom"
 
 #: common/dialogs/panel_common_settings_base.cpp:175
 msgid "Ce&nter and warp cursor on zoom"
-msgstr "Curs&or beim Zoomen nicht zentrieren und umpositionieren"
+msgstr "Curs&or beim Zoomen zentrieren und umpositionieren"
 
 #: common/dialogs/panel_common_settings_base.cpp:176
 msgid "Center the cursor on screen when zooming."


### PR DESCRIPTION
The meaning of this sentence should actually be the other way round